### PR TITLE
Updating helm driver to be compatible with helm3.8

### DIFF
--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -33,7 +33,7 @@ func NewHelm(log logr.Logger) (*helmDriver, error) {
 	//see: https://github.com/aws/eks-anywhere-packages/issues/20
 	client, err := registry.NewClient()
 	if err != nil {
-		return nil, fmt.Errorf("Error creating registry client while initializing helm driver: %w", err)
+		return nil, fmt.Errorf("creating registry client while initializing helm driver: %w", err)
 	}
 	cfg := &action.Configuration{RegistryClient: client}
 	err = cfg.Init(settings.RESTClientGetter(), settings.Namespace(),


### PR DESCRIPTION
Helm was upgraded to 3.8 but our helm driver required changes in order to be
compatible. This commit instantiates a `registry.Client` to be placed in the
configuration object and used by Install actions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
