### PR TITLE
Replace Tag with Digest

### DIFF
--- a/generatebundlefile/README.md
+++ b/generatebundlefile/README.md
@@ -47,9 +47,9 @@ spec:
       repository: jetstack/cert-manager-controller
       versions:
       - name: v1.1.0-eks-a-4
-        tag: sha256:273fe866f82e7278a16ef4d32c5a4cb31b688aae48290080dd8f2f7f44485c5c
+        digest: sha256:273fe866f82e7278a16ef4d32c5a4cb31b688aae48290080dd8f2f7f44485c5c
       - name: v1.1.0-eks-a-3
-        tag: sha256:c3516d93fa52bdb459f46839d708c113d127895468ef6d6a86ec44003cc85c4d
+        digest: sha256:c3516d93fa52bdb459f46839d708c113d127895468ef6d6a86ec44003cc85c4d
   kubernetesVersion: "1.21"
 status:
   upgradesavailable: []
@@ -109,6 +109,6 @@ spec:
       repository: sample-Repository
       versions:
       - name: v0.0
-        tag: sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66
+        digest: sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66
   kubeVersion: "1.21"
 ```

--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -47,8 +47,8 @@ func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *api.Packag
 						Repository: "sample-Repository",
 						Versions: []api.SourceVersion{
 							{
-								Name: "v0.0",
-								Tag:  "sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66",
+								Name:   "v0.0",
+								Digest: "sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66",
 							},
 						},
 					},

--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -58,7 +58,7 @@ func (c *ecrClient) GetShaForTags(project Project) ([]api.SourceVersion, error) 
 			matchingTags := project.Matches(tag)
 			switch {
 			case len(matchingTags) == 1:
-				v := &api.SourceVersion{Name: matchingTags[0], Tag: *images.ImageDigest}
+				v := &api.SourceVersion{Name: matchingTags[0], Digest: *images.ImageDigest}
 				sourceVersion = append(sourceVersion, *v)
 			// If we get more than 1 tag match, we lookup whichever was the most recent push ex: two images are labeled with v1.1 we used the most recent one.
 			case len(matchingTags) > 1:
@@ -84,7 +84,7 @@ func removeDuplicates(s []api.SourceVersion) []api.SourceVersion {
 	for _, i := range s {
 		if _, j := k[i.Name]; !j {
 			k[i.Name] = true
-			l = append(l, api.SourceVersion{Name: i.Name, Tag: i.Tag})
+			l = append(l, api.SourceVersion{Name: i.Name, Digest: i.Digest})
 		}
 	}
 	return l
@@ -111,5 +111,5 @@ func getLastestImageSha(details []types.ImageDetail) (*api.SourceVersion, error)
 	if reflect.ValueOf(latest).Interface() == reflect.ValueOf(types.ImageDetail{}).Interface() {
 		return nil, fmt.Errorf("error no images found")
 	}
-	return &api.SourceVersion{Name: latest.ImageTags[0], Tag: *latest.ImageDigest}, nil
+	return &api.SourceVersion{Name: latest.ImageTags[0], Digest: *latest.ImageDigest}, nil
 }


### PR DESCRIPTION
Tag has been replaced with Digest. Updating some of the classes to reflect the change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
