### PR TITLE
Add "TargetVersion" to package status and rename "version"

### DIFF
--- a/api/v1alpha1/package_types.go
+++ b/api/v1alpha1/package_types.go
@@ -23,7 +23,8 @@ import (
 // +kubebuilder:printcolumn:name="Package",type=string,JSONPath=`.spec.packageName`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
-// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="CurrentVersion",type=string,JSONPath=`.status.currentVersion`
+// +kubebuilder:printcolumn:name="TargetVersion",type=string,JSONPath=`.status.targetVersion`
 // +kubebuilder:printcolumn:name="Detail",type=string,JSONPath=`.status.detail`
 // Package is the Schema for the package API
 type Package struct {
@@ -70,7 +71,11 @@ type PackageStatus struct {
 
 	// +kubebuilder:validation:Required
 	// Version currently installed
-	Version string `json:"version"`
+	CurrentVersion string `json:"currentVersion"`
+
+	// +kubebuilder:validation:Required
+	// Version to be installed
+	TargetVersion string `json:"targetVersion"`
 
 	// State of the installation
 	State StateEnum `json:"state,omitempty"`

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -6,6 +6,7 @@ import (
 )
 
 type PackageOCISource struct {
+    Version    string `json:"version"`
 	Registry   string `json:"registry"`
 	Repository string `json:"repository"`
 	Digest     string `json:"digest"`
@@ -32,7 +33,7 @@ func (config *PackageBundle) FindSource(pkgName, pkgVersion string) (retSource P
 				//We do not sort before getting `latest` because there will be only a single version per release in normal cases. For edge cases which may require multiple
 				//versions, the order in the file will be ordered according to what we want `latest` to point to
 				if version.Name == pkgVersion || version.Digest == pkgVersion || pkgVersion == Latest {
-					retSource = PackageOCISource{Registry: source.Registry, Repository: source.Repository, Digest: version.Digest}
+                    retSource = PackageOCISource{Registry: source.Registry, Repository: source.Repository, Digest: version.Digest, Version: version.Name}
 					return retSource, nil
 				}
 			}

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -23,20 +23,20 @@ func (config *PackageBundle) ExpectedKind() string {
 	return PackageBundleKind
 }
 
-func (config *PackageBundle) FindSource(pkgName, pkgVersion string) (retSource PackageOCISource, version string, err error) {
+func (config *PackageBundle) FindSource(pkgName, pkgVersion string) (retSource PackageOCISource, err error) {
 	for _, pkg := range config.Spec.Packages {
 		if pkg.Name == pkgName {
 			source := pkg.Source
 			for _, version := range source.Versions {
 				if version.Name == pkgVersion || version.Digest == pkgVersion {
 					retSource = PackageOCISource{Registry: source.Registry, Repository: source.Repository, Digest: version.Digest}
-					return retSource, version.Name, nil
+					return retSource, nil
 				}
 			}
 		}
 	}
 
-	return retSource, "", fmt.Errorf("package not found: %s @ %s", pkgName, pkgVersion)
+	return retSource, fmt.Errorf("package not found in current active bundle: %s @ %s", pkgName, pkgVersion)
 }
 
 func (s PackageOCISource) AsRepoURI() string {

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -13,6 +13,7 @@ type PackageOCISource struct {
 
 const (
 	PackageBundleKind = "PackageBundle"
+	Latest            = "latest"
 )
 
 func (config *PackageBundle) MetaKind() string {
@@ -28,7 +29,9 @@ func (config *PackageBundle) FindSource(pkgName, pkgVersion string) (retSource P
 		if pkg.Name == pkgName {
 			source := pkg.Source
 			for _, version := range source.Versions {
-				if version.Name == pkgVersion || version.Digest == pkgVersion {
+				//We do not sort before getting `latest` because there will be only a single version per release in normal cases. For edge cases which may require multiple
+				//versions, the order in the file will be ordered according to what we want `latest` to point to
+				if version.Name == pkgVersion || version.Digest == pkgVersion || pkgVersion == Latest {
 					retSource = PackageOCISource{Registry: source.Registry, Repository: source.Repository, Digest: version.Digest}
 					return retSource, nil
 				}

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -36,19 +36,17 @@ func TestPackageBundle_Find(t *testing.T) {
 		Repository: "eks-anywhere-test",
 		Digest:     "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7",
 	}
-	expectedVersion := "v0.1.0"
-	actual, version, err := sut.FindSource("eks-anywhere-test", "v0.1.0")
+
+	actual, err := sut.FindSource("eks-anywhere-test", "v0.1.0")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
-	assert.Equal(t, expectedVersion, version)
 
-	actual, version, err = sut.FindSource("eks-anywhere-test", "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7")
+	actual, err = sut.FindSource("eks-anywhere-test", "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
-	assert.Equal(t, expectedVersion, version)
 
-	expectedErr := "package not found: Bogus @ bar"
-	_, _, err = sut.FindSource("Bogus", "bar")
+	expectedErr := "package not found in current active bundle: Bogus @ bar"
+	_, err = sut.FindSource("Bogus", "bar")
 	assert.EqualError(t, err, expectedErr)
 }
 

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -39,6 +39,7 @@ func TestPackageBundle_Find(t *testing.T) {
 		Registry:   "public.ecr.aws/l0g8r8j6",
 		Repository: "eks-anywhere-test",
 		Digest:     "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7",
+		Version:    "0.1.0",
 	}
 
 	actual, err := sut.FindSource("eks-anywhere-test", "0.1.0")
@@ -66,30 +67,36 @@ func TestPackageBundle_Find(t *testing.T) {
 				},
 			},
 		)
-	expected := api.PackageOCISource{
-		Registry:   "public.ecr.aws/l0g8r8j6",
-		Repository: "eks-anywhere-test",
-		Digest:     "sha256:deadbeef",
-        Version: "0.1.1",
-	}
+		expected := api.PackageOCISource{
+			Registry:   "public.ecr.aws/l0g8r8j6",
+			Repository: "eks-anywhere-test",
+			Digest:     "sha256:deadbeef",
+			Version:    "0.1.1",
+		}
 		actual, err = latest.FindSource("eks-anywhere-test", api.Latest)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("Get latest version", func(t *testing.T) {
+	t.Run("Get latest version returns the first item even if the name describes a later version", func(t *testing.T) {
 		latest := givenBundle(
 			[]api.SourceVersion{
-				{
-					Name:   "0.1.1",
-					Digest: "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7",
-				},
 				{
 					Name:   "0.1.0",
 					Digest: "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7",
 				},
+				{
+					Name:   "0.1.1",
+					Digest: "sha256:deadbeef",
+				},
 			},
 		)
+		expected := api.PackageOCISource{
+			Registry:   "public.ecr.aws/l0g8r8j6",
+			Repository: "eks-anywhere-test",
+			Digest:     "sha256:eaa07ae1c06ffb563fe3c16cdb317f7ac31c8f829d5f1f32442f0e5ab982c3e7",
+			Version:    "0.1.0",
+		}
 		actual, err = latest.FindSource("eks-anywhere-test", api.Latest)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)

--- a/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
@@ -26,8 +26,11 @@ spec:
     - jsonPath: .status.state
       name: State
       type: string
-    - jsonPath: .status.version
-      name: Version
+    - jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - jsonPath: .status.targetVersion
+      name: TargetVersion
       type: string
     - jsonPath: .status.detail
       name: Detail
@@ -74,6 +77,9 @@ spec:
           status:
             description: PackageStatus defines the observed state of Package
             properties:
+              currentVersion:
+                description: Version currently installed
+                type: string
               detail:
                 description: Detail of the state
                 type: string
@@ -100,6 +106,9 @@ spec:
                 - updating
                 - uninstalling
                 type: string
+              targetVersion:
+                description: Version to be installed
+                type: string
               upgradesAvailable:
                 description: UpgradesAvailable indicates upgraded versions in the
                   bundle.
@@ -120,12 +129,10 @@ spec:
                   - version
                   type: object
                 type: array
-              version:
-                description: Version currently installed
-                type: string
             required:
+            - currentVersion
             - source
-            - version
+            - targetVersion
             type: object
         type: object
     served: true

--- a/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
@@ -92,10 +92,13 @@ spec:
                     type: string
                   repository:
                     type: string
+                  version:
+                    type: string
                 required:
                 - digest
                 - registry
                 - repository
+                - version
                 type: object
               state:
                 description: State of the installation

--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -176,7 +176,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func printableTargetVersion(source api.PackageOCISource, targetVersion string) string {
     ret := targetVersion
     if targetVersion == api.Latest {
-        ret = fmt.Sprintf("%s (%s)", ret, targetVersion)
+        ret = fmt.Sprintf("%s (%s)", source.Version, targetVersion)
     }
     return ret
 }

--- a/controllers/package_controller_test.go
+++ b/controllers/package_controller_test.go
@@ -18,6 +18,7 @@ import (
 	ctrlmocks "github.com/aws/eks-anywhere-packages/controllers/mocks"
 	bundlefake "github.com/aws/eks-anywhere-packages/pkg/bundle/fake"
 	drivermocks "github.com/aws/eks-anywhere-packages/pkg/driver/mocks"
+	"github.com/aws/eks-anywhere-packages/pkg/packages"
 	packageMocks "github.com/aws/eks-anywhere-packages/pkg/packages/mocks"
 )
 
@@ -37,7 +38,7 @@ func TestReconcile(t *testing.T) {
 			Return(true)
 
 		status := tf.mockStatusWriter()
-		pkg.Status.TargetVersion = "v0.1.1"
+		pkg.Status.TargetVersion = "0.1.1"
 		status.EXPECT().
 			Update(ctx, pkg).
 			Return(nil)
@@ -148,7 +149,7 @@ func TestReconcile(t *testing.T) {
 
 		testErr := errors.New("status update test error")
 		status := tf.mockStatusWriter()
-		pkg.Status.TargetVersion = "v0.1.1"
+		pkg.Status.TargetVersion = "0.1.1"
 		status.EXPECT().
 			Update(ctx, pkg).
 			Return(testErr)
@@ -183,8 +184,8 @@ func TestReconcile(t *testing.T) {
 		testErr := errors.New("status update test error")
 		status := tf.mockStatusWriter()
 
-		pkg.Spec.PackageVersion = "v2.0.0"
-		pkg.Status.TargetVersion = "v2.0.0"
+		pkg.Spec.PackageVersion = "2.0.0"
+		pkg.Status.TargetVersion = "2.0.0"
 		pkg.Status.Detail = fmt.Sprintf("Package %s@%s is not in the current active bundle. Did you forget to activate the new bundle?", pkg.Spec.PackageName, pkg.Spec.PackageVersion)
 		status.EXPECT().
 			Update(ctx, pkg).
@@ -200,6 +201,55 @@ func TestReconcile(t *testing.T) {
 
 		assert.Error(t, err, testErr)
 		expected := time.Duration(0)
+		assert.Equal(t, expected, got.RequeueAfter)
+
+	})
+
+	t.Run("Packages without version hold upgrade to latest", func(t *testing.T) {
+		tf, ctx := newTestFixtures(t)
+
+		fn, pkg := tf.mockGetFnPkg()
+		tf.ctrlClient.EXPECT().
+			Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pkg)).
+			DoAndReturn(fn).Times(2)
+
+		pkg.Spec.PackageVersion = ""
+
+		tf.bundleManager.FakeActiveBundle = tf.mockBundle()
+
+		newBundle := tf.mockBundle()
+		newBundle.Spec.Packages[0].Source.Versions = []api.SourceVersion{{
+			Name:   "0.2.0",
+			Digest: "sha256:deadbeef020",
+		}}
+
+		tf.packageManager.EXPECT().
+			Process(gomock.Any()).
+			Return(false).Do(func(mctx *packages.ManagerContext) {
+			assert.Equal(t,
+				api.PackageOCISource(api.PackageOCISource{Version: "0.1.1", Registry: "public.ecr.aws/l0g8r8j6", Repository: "eks-anywhere-test", Digest: "sha256:deadbeef"}),
+				mctx.Source)
+		})
+
+		sut := tf.newReconciler()
+		req := tf.mockRequest()
+		got, err := sut.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		expected := time.Duration(0)
+		assert.Equal(t, expected, got.RequeueAfter)
+
+		tf.bundleManager.FakeActiveBundle = newBundle
+		tf.packageManager.EXPECT().
+			Process(gomock.Any()).
+			Return(false).Do(func(mctx *packages.ManagerContext) {
+			assert.Equal(t,
+				api.PackageOCISource(api.PackageOCISource{Version: "0.2.0", Registry: "public.ecr.aws/l0g8r8j6", Repository: "eks-anywhere-test", Digest: "sha256:deadbeef020"}),
+				mctx.Source)
+		})
+
+		got, err = sut.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		expected = time.Duration(0)
 		assert.Equal(t, expected, got.RequeueAfter)
 
 	})
@@ -243,7 +293,7 @@ func newTestFixtures(t *testing.T) (*testFixtures, context.Context) {
 func (tf *testFixtures) mockSpec() api.PackageSpec {
 	return api.PackageSpec{
 		PackageName:    "eks-anywhere-test",
-		PackageVersion: "v0.1.1",
+		PackageVersion: "0.1.1",
 		Config: map[string]string{
 			"config.foo": configValue,
 			"secret.bar": secretValue,
@@ -268,8 +318,8 @@ func (tf *testFixtures) mockBundle() *api.PackageBundle {
 						Registry:   "public.ecr.aws/l0g8r8j6",
 						Repository: "eks-anywhere-test",
 						Versions: []api.SourceVersion{
-							{Name: "v0.1.1", Digest: "sha256:deadbeef"},
-							{Name: "v0.1.0", Digest: "sha256:cafebabe"},
+							{Name: "0.1.1", Digest: "sha256:deadbeef"},
+							{Name: "0.1.0", Digest: "sha256:cafebabe"},
 						},
 					},
 				},

--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -56,6 +56,7 @@ func (d *helmDriver) Install(ctx context.Context,
 	install := action.NewInstall(d.cfg)
 	fullName := d.prefixName(name)
 
+    install.Version = source.Version
 	install.ReleaseName = fullName
 	install.Namespace = namespace
 

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -59,7 +59,7 @@ func processInstalling(mc *ManagerContext) bool {
 	}
 	mc.Log.Info("Installed", "name", mc.Package.Name, "chart", mc.Package.Status.Source)
 	mc.Package.Status.State = api.StateInstalled
-	mc.Package.Status.CurrentVersion = mc.Package.Spec.PackageVersion
+	mc.Package.Status.CurrentVersion = mc.Source.Version
 	mc.Package.Status.Detail = ""
 	return true
 }

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -59,7 +59,7 @@ func processInstalling(mc *ManagerContext) bool {
 	}
 	mc.Log.Info("Installed", "name", mc.Package.Name, "chart", mc.Package.Status.Source)
 	mc.Package.Status.State = api.StateInstalled
-	mc.Package.Status.Version = mc.Version
+	mc.Package.Status.CurrentVersion = mc.Package.Spec.PackageVersion
 	mc.Package.Status.Detail = ""
 	return true
 }


### PR DESCRIPTION
"Version" becomes "CurrentVersion" and represents what's currently
installed. "TargetVersion" represents what the controler is targetting
to install.

An example output:
```
$ kubectl get packages -A -w
NAMESPACE       NAME       PACKAGE   AGE     STATE       CURRENTVERSION   TARGETVERSION   DETAIL
eksa-packages   my-redis   redis     4m37s   installed   16.3.0           16.3.0
eksa-packages   my-redis   redis     17m     installed   16.3.0           16.3.0
eksa-packages   my-redis   redis     18m     installed   16.3.0           16.3.0          Package redis@16.3.0 is not in the current active bundle. Did you forget to activate the new bundle?
eksa-packages   my-redis   redis     18m     installed   16.3.0           16.3.0          Package redis@16.3.0 is not in the current active bundle. Did you forget to activate the new bundle?
eksa-packages   my-redis   redis     18m     updating    16.3.0           16.4.0          Package redis@16.3.0 is not in the current active bundle. Did you forget to activate the new bundle?
eksa-packages   my-redis   redis     18m     installed   16.4.0           16.4.0
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
