### PR TITLE
Restore signature webhook config

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -26,3 +26,23 @@ webhooks:
     resources:
     - packagebundlecontrollers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-packages-eks-amazonaws-com-v1alpha1-packagebundle
+  failurePolicy: Fail
+  name: vpackagebundle.kb.io
+  rules:
+  - apiGroups:
+    - packages.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - packagebundles
+  sideEffects: None


### PR DESCRIPTION
This config was thought not to be used, but it is at least used during
the webhook envtests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
