### PR TITLE
Fix chart webhooks

### DIFF
--- a/charts/eks-anywhere-packages/templates/service.yaml
+++ b/charts/eks-anywhere-packages/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "eks-anywhere-packages.fullname" . }}-webhook-service
+  name: {{ .Release.Name }}-eks-anywhere-packages-webhook-service
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "eks-anywhere-packages.labels" . | nindent 4 }}


### PR DESCRIPTION
The webhooks service name did not match the certificate and admission control configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
