### PR TITLE
Use kustomize's output to generate CRDs for helm

### DIFF
--- a/charts/eks-anywhere-packages/crds/crd.yaml
+++ b/charts/eks-anywhere-packages/crds/crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -23,28 +21,21 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PackageBundleController is the Schema for the packagebundlecontrollers
-          API
+        description: PackageBundleController is the Schema for the packagebundlecontrollers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: PackageBundleControllerSpec defines the desired state of
-              PackageBundleController
+            description: PackageBundleControllerSpec defines the desired state of PackageBundleController
             properties:
               activeBundle:
-                description: ActiveBundle is name of the bundle from which packages
-                  should be sourced.
+                description: ActiveBundle is name of the bundle from which packages should be sourced.
                 type: string
               logLevel:
                 description: LogLevel controls the verbosity of logging in the controller.
@@ -57,23 +48,20 @@ spec:
                     description: Registry is the OCR address hosting the bundle.
                     type: string
                   repository:
-                    description: Repository is the location of the bundle within the
-                      OCR registry.
+                    description: Repository is the location of the bundle within the OCR registry.
                     type: string
                 required:
                 - registry
                 - repository
                 type: object
               upgradeCheckInterval:
-                description: "UpgradeCheckInterval is the time between upgrade checks.
-                  \n The format is that of time's ParseDuration."
+                description: "UpgradeCheckInterval is the time between upgrade checks. \n The format is that of time's ParseDuration."
                 type: string
             required:
             - source
             type: object
           status:
-            description: PackageBundleControllerStatus defines the observed state
-              of PackageBundleController
+            description: PackageBundleControllerStatus defines the observed state of PackageBundleController
             properties:
               state:
                 description: State of the bundle controller
@@ -93,16 +81,25 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: packagebundles.packages.eks.amazonaws.com
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: packages.eks.amazonaws.com
   names:
     kind: PackageBundle
@@ -124,14 +121,10 @@ spec:
         description: PackageBundle is the Schema for the packagebundles API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -139,8 +132,7 @@ spec:
             description: PackageBundleSpec defines the desired state of PackageBundle
             properties:
               kubeVersion:
-                description: KubeVersion is the Kubernetes version to which this bundle
-                  is compatible.
+                description: KubeVersion is the Kubernetes version to which this bundle is compatible.
                 type: string
               packages:
                 description: Packages supported by this bundle.
@@ -151,40 +143,32 @@ spec:
                       description: Name of the package
                       type: string
                     source:
-                      description: Source location for the package (probably a helm
-                        chart).
+                      description: Source location for the package (probably a helm chart).
                       properties:
                         registry:
                           description: Registry in which the package is found.
                           type: string
                         repository:
-                          description: Repository within the Registry where the package
-                            is found.
+                          description: Repository within the Registry where the package is found.
                           type: string
                         versions:
                           description: Versions of the package supported by this bundle.
                           items:
-                            description: SourceVersion describes a version of a package
-                              within a repository.
+                            description: SourceVersion describes a version of a package within a repository.
                             properties:
                               digest:
-                                description: Digest is a checksum value identifying
-                                  the version of the package and its contents.
+                                description: Digest is a checksum value identifying the version of the package and its contents.
                                 type: string
                               images:
-                                description: Images is a list of images used by this
-                                  version of the package
+                                description: Images is a list of images used by this version of the package
                                 items:
-                                  description: VersionImages is an image used by a
-                                    version of a package.
+                                  description: VersionImages is an image used by a version of a package.
                                   properties:
                                     digest:
-                                      description: Digest is a checksum value identifying
-                                        the version of the package and its contents.
+                                      description: Digest is a checksum value identifying the version of the package and its contents.
                                       type: string
                                     repository:
-                                      description: Repository is source in the registry
-                                        for the image
+                                      description: Repository is source in the registry for the image
                                       type: string
                                   required:
                                   - digest
@@ -192,8 +176,7 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: Name is a human-friendly description
-                                  of the version, e.g. "v1.0".
+                                description: Name is a human-friendly description of the version, e.g. "v1.0".
                                 type: string
                             required:
                             - digest
@@ -220,8 +203,7 @@ spec:
                 description: PackageBundleSpec defines the desired state of PackageBundle
                 properties:
                   kubeVersion:
-                    description: KubeVersion is the Kubernetes version to which this
-                      bundle is compatible.
+                    description: KubeVersion is the Kubernetes version to which this bundle is compatible.
                     type: string
                   packages:
                     description: Packages supported by this bundle.
@@ -232,42 +214,32 @@ spec:
                           description: Name of the package
                           type: string
                         source:
-                          description: Source location for the package (probably a
-                            helm chart).
+                          description: Source location for the package (probably a helm chart).
                           properties:
                             registry:
                               description: Registry in which the package is found.
                               type: string
                             repository:
-                              description: Repository within the Registry where the
-                                package is found.
+                              description: Repository within the Registry where the package is found.
                               type: string
                             versions:
-                              description: Versions of the package supported by this
-                                bundle.
+                              description: Versions of the package supported by this bundle.
                               items:
-                                description: SourceVersion describes a version of
-                                  a package within a repository.
+                                description: SourceVersion describes a version of a package within a repository.
                                 properties:
                                   digest:
-                                    description: Digest is a checksum value identifying
-                                      the version of the package and its contents.
+                                    description: Digest is a checksum value identifying the version of the package and its contents.
                                     type: string
                                   images:
-                                    description: Images is a list of images used by
-                                      this version of the package
+                                    description: Images is a list of images used by this version of the package
                                     items:
-                                      description: VersionImages is an image used
-                                        by a version of a package.
+                                      description: VersionImages is an image used by a version of a package.
                                       properties:
                                         digest:
-                                          description: Digest is a checksum value
-                                            identifying the version of the package
-                                            and its contents.
+                                          description: Digest is a checksum value identifying the version of the package and its contents.
                                           type: string
                                         repository:
-                                          description: Repository is source in the
-                                            registry for the image
+                                          description: Repository is source in the registry for the image
                                           type: string
                                       required:
                                       - digest
@@ -275,8 +247,7 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: Name is a human-friendly description
-                                      of the version, e.g. "v1.0".
+                                    description: Name is a human-friendly description of the version, e.g. "v1.0".
                                     type: string
                                 required:
                                 - digest
@@ -316,7 +287,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -340,14 +310,10 @@ spec:
         description: PackageController is the Schema for the packagecontrollers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -359,8 +325,7 @@ spec:
                 format: int32
                 type: integer
               upgradeCheckInterval:
-                description: "UpgradeCheckInterval is the time between upgrade checks.
-                  \n The format is that of time's ParseDuration."
+                description: "UpgradeCheckInterval is the time between upgrade checks. \n The format is that of time's ParseDuration."
                 type: string
             type: object
           status:
@@ -377,7 +342,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -405,8 +369,11 @@ spec:
     - jsonPath: .status.state
       name: State
       type: string
-    - jsonPath: .status.version
-      name: Version
+    - jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - jsonPath: .status.targetVersion
+      name: TargetVersion
       type: string
     - jsonPath: .status.detail
       name: Detail
@@ -417,14 +384,10 @@ spec:
         description: Package is the Schema for the package API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -437,12 +400,10 @@ spec:
                 description: Config for the package
                 type: object
               packageName:
-                description: PackageName is the name of the package as specified in
-                  the bundle.
+                description: PackageName is the name of the package as specified in the bundle.
                 type: string
               packageVersion:
-                description: PackageVersion is a human-friendly version name or sha256
-                  checksum for the package, as specified in the bundle.
+                description: PackageVersion is a human-friendly version name or sha256 checksum for the package, as specified in the bundle.
                 type: string
               targetNamespace:
                 description: TargetNamespace where package resources will be deployed.
@@ -453,6 +414,9 @@ spec:
           status:
             description: PackageStatus defines the observed state of Package
             properties:
+              currentVersion:
+                description: Version currently installed
+                type: string
               detail:
                 description: Detail of the state
                 type: string
@@ -465,10 +429,13 @@ spec:
                     type: string
                   repository:
                     type: string
+                  version:
+                    type: string
                 required:
                 - digest
                 - registry
                 - repository
+                - version
                 type: object
               state:
                 description: State of the installation
@@ -479,32 +446,29 @@ spec:
                 - updating
                 - uninstalling
                 type: string
+              targetVersion:
+                description: Version to be installed
+                type: string
               upgradesAvailable:
-                description: UpgradesAvailable indicates upgraded versions in the
-                  bundle.
+                description: UpgradesAvailable indicates upgraded versions in the bundle.
                 items:
-                  description: PackageAvailableUpgrade details the package's available
-                    upgrades' versions.
+                  description: PackageAvailableUpgrade details the package's available upgrades' versions.
                   properties:
                     tag:
-                      description: Tag is a specific version number or sha256 checksum
-                        for the package upgrade.
+                      description: Tag is a specific version number or sha256 checksum for the package upgrade.
                       type: string
                     version:
-                      description: Version is a human-friendly version name for the
-                        package upgrade.
+                      description: Version is a human-friendly version name for the package upgrade.
                       type: string
                   required:
                   - tag
                   - version
                   type: object
                 type: array
-              version:
-                description: Version currently installed
-                type: string
             required:
+            - currentVersion
             - source
-            - version
+            - targetVersion
             type: object
         type: object
     served: true

--- a/hack/helm.sh
+++ b/hack/helm.sh
@@ -18,10 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-cd ${SCRIPT_ROOT}/..
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-cat config/crd/bases/packages.eks.amazonaws.com_package* >charts/eks-anywhere-packages/crds/crd.yaml
+cd ${ROOT_DIR}
+./bin/kustomize build config/crd > charts/eks-anywhere-packages/crds/crd.yaml
+
 cp api/testdata/packagebundlecontroller.yaml api/testdata/packagecontroller.yaml charts/eks-anywhere-packages/templates
 cd charts
 helm lint eks-anywhere-packages


### PR DESCRIPTION
Ideally, we'd want all chart resources to be generate from the kustomize output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
