### PR TITLE
Fix chart deployment ENABLE_WEBHOOK env var

### DIFF
--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: ENABLE_WEBHOOKS
-              value: {{ .Values.controller.enableWebhooks }}
+              value: {{ .Values.controller.enableWebhooks | quote}}
             {{- if .Values.controller.env }}
             {{- with .Values.controller.env }}
               {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The env var is defined as plain `true` in the rendered chart, making the deployment fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
