### PR TITLE
Provide a terse error message for latest failure

### DIFF
--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -40,11 +40,19 @@ type PackageBundleControllerSpec struct {
 	// +optional
 	LogLevel *int32 `json:"logLevel,omitempty"`
 
+	// +kubebuilder:default:="1d"
 	// UpgradeCheckInterval is the time between upgrade checks.
 	//
 	// The format is that of time's ParseDuration.
 	// +optional
 	UpgradeCheckInterval metav1.Duration `json:"upgradeCheckInterval,omitempty"`
+
+	// +kubebuilder:default:="1h"
+	// UpgradeCheckShortInterval if there is a problem this is the time between upgrade checks.
+	//
+	// The format is that of time's ParseDuration.
+	// +optional
+	UpgradeCheckShortInterval metav1.Duration `json:"upgradeCheckShortInterval,omitempty"`
 
 	// ActiveBundle is name of the bundle from which packages should be sourced.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -213,6 +213,7 @@ func (in *PackageBundleControllerSpec) DeepCopyInto(out *PackageBundleController
 		**out = **in
 	}
 	out.UpgradeCheckInterval = in.UpgradeCheckInterval
+	out.UpgradeCheckShortInterval = in.UpgradeCheckShortInterval
 	out.Source = in.Source
 }
 

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -65,8 +65,15 @@ spec:
                 - repository
                 type: object
               upgradeCheckInterval:
+                default: 1d
                 description: "UpgradeCheckInterval is the time between upgrade checks.
                   \n The format is that of time's ParseDuration."
+                type: string
+              upgradeCheckShortInterval:
+                default: 1h
+                description: "UpgradeCheckShortInterval if there is a problem this
+                  is the time between upgrade checks. \n The format is that of time's
+                  ParseDuration."
                 type: string
             required:
             - source

--- a/controllers/packagebundlecontroller_controller.go
+++ b/controllers/packagebundlecontroller_controller.go
@@ -123,7 +123,9 @@ func (r *PackageBundleControllerReconciler) Reconcile(ctx context.Context, req c
 
 	latestBundle, err := r.bundleManager.LatestBundle(ctx, abc.Spec.Source.BaseRef())
 	if err != nil {
-		return result, err
+		r.Log.Error(err, "Unable to get latest bundle")
+		result.RequeueAfter = abc.Spec.UpgradeCheckShortInterval.Duration
+		return result, nil
 	}
 
 	bundles := &api.PackageBundleList{}


### PR DESCRIPTION
If the latest bundle download fails, try again in an hour instead of every couple minutes.
