### PR TITLE
Add helm-build to default make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ kubetest-plugins: kubetest2
 	$(MAKE) -C kubetest-plugins build
 
 .PHONY: presubmit
-presubmit: vet generate manifests build test # lint is run via github action
+presubmit: vet generate manifests build helm-build test # lint is run via github action
 
 %.yaml.signed: %.yaml
 	pkg/signature/testdata/sign_file.sh $?


### PR DESCRIPTION
If the helm-build was called on default from the make file, maybe the chart would be kept up to date.