### PR TITLE
Only delete packages for CRs in the namespace

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -137,7 +137,9 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		managerContext.SetUninstalling(req.Name)
+		if req.Namespace == bundle.ActiveBundleNamespace {
+			managerContext.SetUninstalling(req.Name)
+		}
 	} else {
 		bundle, err := r.bundleManager.ActiveBundle(ctx, r.Client)
 		if err != nil {


### PR DESCRIPTION
I haven't tried it, but this change should stop someone from being able to uninstall your package
