### PR TITLE
New command: sign-object

### DIFF
--- a/cmd/sign-object/main.go
+++ b/cmd/sign-object/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/yaml"
+
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	"github.com/aws/eks-anywhere-packages/pkg/signable"
+)
+
+const (
+	defaultKey    = "private.ec.key"
+	defaultOutput = "-"
+)
+
+func main() {
+	var keyFile string
+	var outputFile string
+
+	rootCmd := &cobra.Command{
+		Use:   "sign-object -s filename [-o object.signed.yaml] [object.yaml]",
+		Short: "Sign a kubernetes object file",
+		Long: `Sign a kubernetes object YAML file.
+
+The signing key is expected to be PEM-encoded.
+
+If no bundle file is supplied, reads from stdin.
+
+If no output file is specified, writes to stdout.
+`,
+		Args: cobra.MaximumNArgs(1), // a kubernetes object file for input
+		RunE: sign,
+	}
+	rootCmd.Flags().StringVarP(&keyFile, "signing-key", "s", defaultKey,
+		"private key filename for signing the package bundle")
+	rootCmd.Flags().StringVarP(&outputFile, "output", "o", defaultOutput,
+		"output bundle filename")
+	if err := rootCmd.MarkFlagRequired("signing-key"); err != nil {
+		log.Fatal(err)
+	}
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var DefaultGroup = api.GroupVersion.Group
+var DefaultVersion = api.GroupVersion.Version
+
+func sign(cmd *cobra.Command, args []string) error {
+	var err error
+
+	objectFile := os.Stdin
+	if len(args) > 0 && args[0] != "-" {
+		objectFile, err = os.Open(args[0])
+		if err != nil {
+			return fmt.Errorf("opening object file %q: %w", args[0], err)
+		}
+		defer objectFile.Close()
+	}
+
+	gvk := schema.GroupVersionKind{}
+	scheme := runtime.NewScheme()
+	utilruntime.Must(api.AddToScheme(scheme))
+	buf := &bytes.Buffer{}
+	_, err = io.Copy(buf, objectFile)
+	if err != nil {
+		return fmt.Errorf("reading object: %w", err)
+	}
+
+	err = yaml.Unmarshal(buf.Bytes(), &gvk)
+	if err != nil {
+		return fmt.Errorf("unmarshaling object's gvk: %w", err)
+	}
+	if gvk.Group == "" {
+		gvk.Group = DefaultGroup
+	}
+	if gvk.Version == "" {
+		gvk.Version = DefaultVersion
+	}
+	object, err := scheme.New(gvk)
+	if err != nil {
+		return fmt.Errorf("finding gvk in schema: %w", err)
+	}
+
+	err = yaml.Unmarshal(buf.Bytes(), object)
+	if err != nil {
+		return fmt.Errorf("unmarshaling object: %w", err)
+	}
+
+	pemKeyFilename := cmd.Flag("signing-key").Value.String()
+	pemPrivKey, err := os.ReadFile(pemKeyFilename)
+	if err != nil {
+		return fmt.Errorf("reading signing key file %q: %w", pemKeyFilename, err)
+	}
+
+	s := signable.New(object.(signable.Object))
+	objectSigned, err := s.SignedYAML(pemPrivKey)
+	if err != nil {
+		return err
+	}
+
+	signedObjectFile := os.Stdout
+	outputFilename := cmd.Flag("output").Value.String()
+	if outputFilename != "" && outputFilename != "-" {
+		if signedObjectFile, err = os.Open(outputFilename); err != nil {
+			return fmt.Errorf("opening object file %q: %w",
+				outputFilename, err)
+		}
+		defer signedObjectFile.Close()
+	}
+
+	fmt.Fprintln(signedObjectFile, string(objectSigned))
+
+	return nil
+}

--- a/cmd/testjson/main.go
+++ b/cmd/testjson/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+)
+
+func main() {
+
+	p := api.Package{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: api.PackageSpec{
+			PackageName: "bar",
+		},
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	err := encoder.Encode(NewDisplayPackage(p))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
+
+// DisplayPackage wraps Package to omit undesired members (like Status).
+//
+// This is necessary in part because of https://github.com/golang/go/issues/11939
+// but also because we just don't want to generate a Status section when we're
+// emitting templates for a user to modify.
+type DisplayPackage struct {
+	*api.Package
+	Status *struct{} `json:"status,omitempty"`
+}
+
+func NewDisplayPackage(p api.Package) DisplayPackage {
+	return DisplayPackage{Package: &p}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/aws/eks-anywhere-packages
 go 1.17
 
 require (
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-logr/logr v1.2.2
 	github.com/golang/mock v1.6.0
 	github.com/itchyny/gojq v0.12.6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
+	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.8.1
@@ -115,7 +117,6 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMi
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
+github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=

--- a/pkg/signable/signable.go
+++ b/pkg/signable/signable.go
@@ -1,0 +1,243 @@
+package signable
+
+import (
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	goyaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere-packages/pkg/signature"
+)
+
+const (
+	DefaultHash = signature.DefaultHash
+	ExcludesSep = signature.ExcludesSep
+)
+
+// Signable knows how to sign and output Kubernetes objects for EKS Anywhere
+// Packages.
+//
+// This means knowing how to prepare the object for signing, how to sign it, and
+// how to then output a signed version.
+type Signable interface {
+	// SignedYAML annotates the object's metadata with a signature.
+	//
+	// It obeys EKS Anywhere-specific annotations such as eksa.aws.com/exclude.
+	SignedYAML(pemPrivateKey []byte) ([]byte, error)
+
+	// SignedYAMLWithHash works like SignedYAML, but allows the caller to specify
+	// the hash used for the signed digest.
+	SignedYAMLWithHash(pemPrivateKey []byte, hash crypto.Hash) ([]byte, error)
+}
+
+// signable implements Signable.
+type signable struct {
+	Object
+	// sigs.k8s.io/yaml doesn't re-export these, but they're needed.
+	goyaml.Marshaler
+	goyaml.Unmarshaler
+}
+
+var _ Signable = (*signable)(nil)
+
+func New(object Object) *signable {
+	return &signable{Object: object}
+}
+
+type Object interface {
+	GetAnnotations() map[string]string
+	SetAnnotations(map[string]string)
+}
+
+func (s signable) SignedYAML(pemPrivateKey []byte) ([]byte, error) {
+	return s.SignedYAMLWithHash(pemPrivateKey, DefaultHash)
+}
+
+func (s signable) SignedYAMLWithHash(pemPrivateKey []byte, hash crypto.Hash) (
+	[]byte, error) {
+
+	yamlObject, err := s.patchedYAML(s.signingPatch)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := SignDigestBase64(pemPrivateKey, yamlObject, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	as := s.GetAnnotations()
+	if as == nil {
+		as = make(map[string]string)
+		s.SetAnnotations(as)
+	}
+	as[signature.FullSignatureAnnotation] = sig
+
+	return s.patchedYAML(s.exportPatch)
+}
+
+// patchedYAML applies a patch to itself, returning the resulting YAML.
+//
+// This is done by marshaling to JSON, applying the patch, then converting the
+// JSON to YAML, which is similar to what Kustomize does. The primary difference
+// is in the flags passed when applying the patch.
+func (s signable) patchedYAML(fn patchFunction) ([]byte, error) {
+	jsonObject, err := json.Marshal(s.Object)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling signable to JSON: %w", err)
+	}
+
+	patch, err := fn()
+	if err != nil {
+		return nil, err
+	}
+
+	patchedJSONObject, err := patch.Apply(jsonObject)
+	if err != nil {
+		return nil, fmt.Errorf("patching signable for digestion: %w", err)
+	}
+
+	patchedYAMLObject, err := yaml.JSONToYAML(patchedJSONObject)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling patched signable to YAML: %w", err)
+	}
+
+	return patchedYAMLObject, nil
+}
+
+func (s signable) excludes() ([]jsonPointer, error) {
+	excludesKey := signature.DomainName + "/" + signature.ExcludesAnnotation
+	b64Excludes := s.GetAnnotations()[excludesKey]
+	excludes, err := base64.StdEncoding.DecodeString(b64Excludes)
+	if err != nil {
+		return nil, fmt.Errorf("decoding excludes annotations: %w", err)
+	}
+
+	// The excludes within the object are in JSON path format, so stick with that
+	// for now, escape them when they're converted to JSON pointers.
+	prefix := ".metadata.annotations."
+	var pointers []jsonPointer
+	for _, exclude := range strings.Split(string(excludes), ExcludesSep) {
+		pointers = append(pointers, fromJSONPath(prefix+exclude))
+	}
+
+	return pointers, nil
+}
+
+// exportPatch builds a JSON patch that removes fields that shouldn't be
+// exported.
+func (s signable) exportPatch() (customPatch, error) {
+	patch := customPatch{}
+	for _, exclude := range signature.AlwaysExcluded {
+		patch = append(patch, genRemovePathOp(fromJSONPath(exclude)))
+	}
+
+	return patch, nil
+}
+
+// signingPatch builds a JSON patch that removes fields that shouldn't be
+// considered when generating a digest.
+//
+// It would be convenient to use Kustomize to manipulate the YAML k8s
+// objects. However, Kustomize doesn't handle applying patches where the key to
+// be removed doesn't exist. This follows the JSON Patch spec, but it's
+// annoying. Fortunately, the underlying library used by Kustomize (json-patch),
+// _does_ support that ability via an optional flag (a flag that Kustomize
+// doesn't expose). So in order to apply patches without a ton of headache when
+// they fail due to a missing key, use json-patch directly.
+func (s signable) signingPatch() (customPatch, error) {
+	var patch jsonpatch.Patch
+
+	excludes, err := s.excludes()
+	if err != nil {
+		return nil, err
+	}
+	for _, exclude := range excludes {
+		patch = append(patch, genRemovePathOp(exclude))
+	}
+
+	// ...plus the signature (go) package excludes...
+	for _, alwaysExclude := range signature.AlwaysExcluded {
+		patch = append(patch, genRemovePathOp(fromJSONPath(alwaysExclude)))
+	}
+
+	return customPatch(patch), nil
+}
+
+// genRemovePathOp returns an operation that removes a path.
+func genRemovePathOp(ptr jsonPointer) jsonpatch.Operation {
+	return jsonpatch.Operation{
+		"op":   rawMsgPointer("remove"),
+		"path": rawMsgPointer(ptr.String()),
+	}
+}
+
+// customPatch wraps jsonpatch.Patch to set options for EKS-Anywhere Packages
+// use.
+//
+// Because patchWithAllowMissingPathOnRemove is too long of a name.
+type customPatch jsonpatch.Patch
+
+// patchFunction returns a JSON patch (jsonpatch.Patch).
+type patchFunction func() (customPatch, error)
+
+// Apply applies custom options when applying.
+func (p customPatch) Apply(doc []byte) ([]byte, error) {
+	options := jsonpatch.NewApplyOptions()
+	options.AllowMissingPathOnRemove = true
+	return jsonpatch.Patch(p).ApplyWithOptions(doc, options)
+}
+
+// ApplyIndent applies custom options when applying (with indent).
+func (p customPatch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
+	options := jsonpatch.NewApplyOptions()
+	options.AllowMissingPathOnRemove = true
+	return jsonpatch.Patch(p).ApplyIndentWithOptions(doc, indent, options)
+}
+
+// jsonPointer helps keep straight the format of a path (JSON path vs JSON pointer).
+type jsonPointer string
+
+func (p jsonPointer) String() string {
+	return string(p)
+}
+
+// fromJSONPath converts from a JSON path to a JSON pointer.
+//
+// It will escape the individual path segments in the process.
+func fromJSONPath(jsonPath string) jsonPointer {
+	segments := strings.Split(jsonPath, ".")
+	escaped := ""
+	if strings.HasPrefix(jsonPath, ".") {
+		escaped = "/"
+	}
+	for _, segment := range segments {
+		escaped = path.Join(escaped, escapeStringForJSONPointer(segment))
+	}
+
+	return jsonPointer(escaped)
+}
+
+// escapeStringForJSONPointer escapes a string for use as a segment in a JSON
+// pointer.
+//
+// https://datatracker.ietf.org/doc/html/rfc6901
+func escapeStringForJSONPointer(str string) string {
+	tmp := strings.ReplaceAll(str, "~", "~0")
+	return strings.ReplaceAll(tmp, "/", "~1")
+}
+
+// rawMsgPointer makes it a little less painful to generate jsonpatch.Operations.
+//
+// Why not use jsonpatch.DecodePatch? Because it can fail. This can't fail. Which
+// makes it much handier, since errors don't need to be checked.
+func rawMsgPointer(s string) *json.RawMessage {
+	var x json.RawMessage = json.RawMessage(fmt.Sprintf("%q", s))
+	return &x
+}

--- a/pkg/signable/util.go
+++ b/pkg/signable/util.go
@@ -1,0 +1,61 @@
+package signable
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+// Sign data with a private key.
+//
+// Key should be a SEC1 / ASN.1 / DER / PEM-encoded private key.
+func Sign(pemKey []byte, data []byte, hash crypto.Hash) ([]byte, error) {
+	blk, _ := pem.Decode(pemKey)
+	var key crypto.PrivateKey
+	var err error
+
+	key, err = x509.ParseECPrivateKey(blk.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing signing key: %w", err)
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("key isn't valid for signing")
+	}
+
+	sig, err := signer.Sign(rand.Reader, data, hash)
+	if err != nil {
+		return nil, fmt.Errorf("signing: %w", err)
+	}
+
+	return sig, nil
+}
+
+// SignDigest wraps sign to digest the data before signing.
+//
+// Key should be a SEC1 / ASN.1 / DER / PEM-encoded private key.
+func SignDigest(pemKey []byte, data []byte, hash crypto.Hash) ([]byte, error) {
+	h := hash.New()
+	_, err := h.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("digesting: %w", err)
+	}
+
+	return Sign(pemKey, h.Sum(nil), hash)
+}
+
+// SignDigestBase64 wraps signDigest to base64 encode the signature.
+func SignDigestBase64(pemKey []byte, data []byte, hash crypto.Hash) (
+	string, error) {
+
+	sigBytes, err := SignDigest(pemKey, data, hash)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(sigBytes), nil
+}

--- a/pkg/signature/manifest_test.go
+++ b/pkg/signature/manifest_test.go
@@ -42,8 +42,8 @@ func TestValidateSignature(t *testing.T) {
 		}
 		valid, _, _, err := ValidateSignature(bundle, EksaDomain)
 
-		assert.True(t, valid, "Signature should be valid for the EKS-A domain")
 		assert.Nilf(t, err, "An error occured validating the signature: %v", err)
+		assert.True(t, valid, "Signature should be valid for the EKS-A domain")
 	})
 
 	t.Run("invalid signature on valid manifest", func(t *testing.T) {
@@ -90,7 +90,8 @@ func TestValidateSignature(t *testing.T) {
 		digest, _, err := GetDigest(bundle, EksaDomain)
 
 		// An empty object serializes to "{}" in yaml.
-		assert.Equal(t, sha256.Sum256([]byte("{}\n")), digest, "This tests validates the behavior of an affectively empty document signature made empty via excludes")
+		expected := sha256.Sum256([]byte("{}\n"))
+		assert.Equalf(t, expected[:], digest, "This tests validates the behavior of an affectively empty document signature made empty via excludes")
 		assert.Nil(t, err)
 		valid, _, _, err := ValidateSignature(bundle, EksaDomain)
 		assert.False(t, valid, "Signature should be invalid as it's signing actual content")
@@ -214,6 +215,6 @@ func TestDigest(t *testing.T) {
 		digest, _, err := GetDigest(bundle, EksaDomain)
 		var b64error base64.CorruptInputError = 0
 		assert.ErrorIs(t, err, b64error)
-		assert.Equal(t, digest, [32]byte{})
+		assert.Nil(t, digest)
 	})
 }


### PR DESCRIPTION
    go run ./cmd/sign-object --help

It has a different take on how to generate the signature from what we
currently have.

The current solution uses github.com/itchyny/gojq (a Go-library that
implements jq). I've found that operations like we're performing are
very difficult with jq. The queries are brittle and hard to read (even
harder to modify).

I started looking to see if we could use Kustomize to patch in a
signature. However, Kustomize isn't flexible enough (this is a long
story).

So for this new bit of functionality, I've gone to the library that
underlies Kustomize, jsonpatch (github.com/evanphx/json-patch). I feel
like this is more resilient, though it's definitely more lines of
code. I think this will be more maintainable and composable in the long
run. Those familiar with Kustomize should have an easier time wrapping
their heads around how this code works. Also, if, in the future, the
limitations that prevent us from using Kustomize directly are removed,
we might be able to simply do that, which would simplify a chunk of
this.

I've not functionally modified the existing signature package, though I
did perform a few tweaks that were either sanitary (extracting
constants, etc) or just made the existing code a little easier to
read/use (moving from [32]byte to []byte).

If this approach is deemed worthwhile, I would like to expand to using
its approach in the signature package. I'd also be writing a bunch of
tests of course.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
