### PR TITLE
Increase resources limit on controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 50Mi


### PR DESCRIPTION
We've had reports of the controller getting `OOMKilled`, increasing the limit will prevent that.

I've profiled the controller and I see total usage of the container go up to 101MiB, the controller itself doesn't report much heap usage however. More profiling will be done in the future.

