### PR TITLE
Fix signing script

### DIFF
--- a/pkg/signature/testdata/sign_file.sh
+++ b/pkg/signature/testdata/sign_file.sh
@@ -6,6 +6,7 @@ yq () {
   docker run --rm -i --entrypoint yq linuxserver/yq ${params} -rc "${query}" <${file}
 }
 file=$1 
+tmpfile=$(mktemp ${file}.digest.XXXXXX)
 alwaysexcludes='.metadata.annotations."eksa.aws.com/signature"'
 has_excludes=$(yq "${file}" '.metadata.annotations."eksa.aws.com/excludes"')
 
@@ -13,9 +14,8 @@ excludes=""
 if [ "${has_excludes}" != "null" ]; then
     excludes=$(yq "${file}" '.metadata.annotations."eksa.aws.com/excludes"' | base64 -d | cat <(echo ${alwaysexcludes}) - | paste -sd "," -) 
 fi
-fixed=$(yq ${file} \
-    "del(${alwaysexcludes}$([ ! -z ${excludes} ] && echo , ${excludes})) | walk( if type == \"object\" then with_entries(select(.value != \"\" and .value != null and .value != [])) else . end)" "--indentless-lists -Y -S")
-digest=$(openssl dgst -sha256 -binary <<<"${fixed}")
-signature=$(openssl pkeyutl -inkey pkg/signature/testdata/private.ec.key -sign -in <(echo "${digest}") | base64 | tr -d '\n')
+yq ${file} "del(${alwaysexcludes}$([ ! -z ${excludes} ] && echo , ${excludes})) | walk( if type == \"object\" then with_entries(select(.value != \"\" and .value != null and .value != [])) else . end)" "--indentless-lists -Y -S" | openssl dgst -sha256 -binary >${tmpfile}
+signature=$(openssl pkeyutl -inkey pkg/signature/testdata/private.ec.key -sign -in ${tmpfile} | base64 | tr -d '\n')
 yq "${file}" ".metadata.annotations.\"eksa.aws.com/signature\" = \"${signature}\"" -Y > "${file}.signed"
-echo -n "${digest}" | base64 | tr -d '\n' > ${file}.digest
+cat ${tmpfile} | base64 | tr -d '\n' > ${file}.digest
+rm -f ${tmpfile}


### PR DESCRIPTION
Signing script fails sometimes because of bash handling of binary data in variables.
