### PR TITLE
Update install workflow to support Go v1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ kubetest2: ## Download kubetest2 locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 MOCKGEN = $(shell pwd)/bin/mockgen
 mockgen: ## Download mockgen locally if necessary.
@@ -153,7 +153,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 $(GO) mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin $(GO) get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin $(GO) install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Command `go get` can no longer be used to build packages starting `Go v1.18` (see [deprecation notice](https://go.dev/doc/go-get-install-deprecation)). Kustomize version also needs to be updated since `go install` doesn't support exclude directives (see [issue](https://github.com/kubernetes-sigs/kustomize/issues/3618)). The change has been tested on both `Go v1.17` and `Go v1.18` to ensure the Makefile works properly.

*Issue #, if available:* N/A

*Description of changes:* Update `go get` to `go install`, and Kustomize version to `v4.5`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
