### PR TITLE
Update package bundle image

### DIFF
--- a/api/testdata/bundle_one.yaml
+++ b/api/testdata/bundle_one.yaml
@@ -11,7 +11,7 @@ spec:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
-          - name: v0.1.1-8b3810e1514b7432e032794842425accc837757a-helm
+          - name: 0.1.1_b41df7249b38548e535531d2e971ba85bb374434
             digest: sha256:64ea03b119d2421f9206252ff4af4bf7cdc2823c343420763e0e6fc20bf03b68
     - name: Flux
       source:

--- a/api/testdata/bundle_one.yaml.signed
+++ b/api/testdata/bundle_one.yaml.signed
@@ -3,7 +3,7 @@ kind: PackageBundle
 metadata:
   name: v1-21-1001
   namespace: eksa-packages
-  annotations: {eksa.aws.com/signature: MEYCIQDvH+XuQnC2L2DmxsmzKos5EFRH28F7keZjEG7EAuQNEgIhAJQGe6jPj9cyVsTyCgOggWwFZn31XsvCPGGJkiAki8OZ}
+  annotations: {eksa.aws.com/signature: MEYCIQCf0PEXc2ceOu7bb1EovaSNM9BjvdT4vexn1uwW67FzjQIhALg+sW0Vqgt6wc/FEWWXOrwM93coY1BXkRkivr7hwz+d}
 spec:
   packages:
     - name: Test


### PR DESCRIPTION
Update the name of `hello-eks-anywhere` repository to match an existing version on `public.ecr.aws/l0g8r8j6/hello-eks-anywhere`.

*Issue #, if available:* `v0.1.1-8b3810e1514b7432e032794842425accc837757a-helm` is not a valid name for `hello-eks-anywhere`.

*Description of changes:* Update the name to an existing version on `public.ecr.aws/l0g8r8j6/hello-eks-anywhere`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
