### PR TITLE
Add a re-download functionality to Controller

### DIFF
--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -110,7 +110,6 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// the bundle controller will validate the active bundle by namespace
 		// and name, and re-download the bundle.
 		nn, err := r.bundleManager.GetActiveBundleNamespacedName(ctx, r.Client)
-
 		if err != nil {
 			r.Log.Info("Unable to get active bundle namespace and name",
 				"NamespaceName", nn)

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -122,7 +122,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
-		_, err = r.bundleManager.DownloadBundle(ctx, req.Name))
+		_, err = r.bundleManager.DownloadBundle(ctx, req.Name)
 
 		if err != nil {
 			r.Log.Error(err, "Active bundle deleted and failed to download", "bundle",

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -105,7 +105,32 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
-		r.Log.Info("Bundle deleted (ignoring)", "bundle", req.NamespacedName)
+
+		// If the bundle controller detects that the active bundle is deleted,
+		// the bundle controller will validate the active bundle by namespace
+		// and name, and re-download the bundle.
+		nn, err := r.bundleManager.GetActiveBundleNamespacedName(ctx, r.Client)
+
+		if err != nil {
+			r.Log.Info("Unable to get active bundle namespace and name",
+				"NamespaceName", nn)
+			return ctrl.Result{}, nil
+		}
+
+		if nn.Namespace == req.Namespace && nn.Name == req.Name {
+			r.Log.Info("Bundle deleted", "bundle", req.NamespacedName)
+		}
+
+		ref := fmt.Sprintf("%s:%s", req.Namespace, req.Name)
+		_, err = r.bundleManager.DownloadBundle(ctx, ref)
+
+		if err != nil {
+			r.Log.Info("Unable to download deleted bundle", "bundle",
+				req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+
+		r.Log.Info("Bundle downloaded", "bundle", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -117,15 +117,15 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
-		if nn.Namespace == req.Namespace && nn.Name == req.Name {
+		if nn.Namespace != req.Namespace || nn.Name != req.Name {
 			r.Log.Info("Bundle deleted", "bundle", req.NamespacedName)
+			return ctrl.Result{}, nil
 		}
 
-		ref := fmt.Sprintf("%s:%s", req.Namespace, req.Name)
-		_, err = r.bundleManager.DownloadBundle(ctx, ref)
+		_, err = r.bundleManager.DownloadBundle(ctx, req.Name))
 
 		if err != nil {
-			r.Log.Info("Unable to download deleted bundle", "bundle",
+			r.Log.Error(err, "Active bundle deleted and failed to download", "bundle",
 				req.NamespacedName)
 			return ctrl.Result{}, nil
 		}

--- a/pkg/bundle/fake/manager.go
+++ b/pkg/bundle/fake/manager.go
@@ -12,10 +12,12 @@ import (
 
 type FakeBundleManager struct {
 	bundle.Manager
-	FakeActiveBundleError error
-	FakeActiveBundle      *api.PackageBundle
-	FakeIsActive          bool
-	FakeUpdate            bool
+	FakeActiveBundleError             error
+	FakeActiveBundle                  *api.PackageBundle
+	FakeDownloadBundle                *api.PackageBundle
+	FakeIsActive                      bool
+	FakeUpdate                        bool
+	FakeGetActiveBundleNamespacedName types.NamespacedName
 }
 
 var _ bundle.Manager = (*FakeBundleManager)(nil)
@@ -33,6 +35,15 @@ func (bm *FakeBundleManager) ActiveBundle(ctx context.Context,
 	return bm.FakeActiveBundle, nil
 }
 
+func (bm *FakeBundleManager) DownloadBundle(ctx context.Context, ref string) (
+	*api.PackageBundle, error) {
+
+	if bm.FakeActiveBundleError != nil {
+		return nil, bm.FakeActiveBundleError
+	}
+	return bm.FakeDownloadBundle, nil
+}
+
 func (bm *FakeBundleManager) IsActive(ctx context.Context,
 	client client.Client, name types.NamespacedName) (bool, error) {
 	return bm.FakeIsActive, nil
@@ -41,4 +52,13 @@ func (bm *FakeBundleManager) IsActive(ctx context.Context,
 func (bm *FakeBundleManager) Update(bundle *api.PackageBundle, active bool,
 	allBundles []api.PackageBundle) bool {
 	return bm.FakeUpdate
+}
+
+func (bm *FakeBundleManager) GetActiveBundleNamespacedName(ctx context.Context,
+	client client.Client) (types.NamespacedName, error) {
+
+	if bm.FakeActiveBundleError != nil {
+		return types.NamespacedName{}, bm.FakeActiveBundleError
+	}
+	return bm.FakeGetActiveBundleNamespacedName, nil
 }

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -29,6 +29,11 @@ type Manager interface {
 	ActiveBundle(ctx context.Context, client client.Client) (
 		*api.PackageBundle, error)
 
+	// GetActiveBundleNamespacedName retrieves the namespace and name of the
+	// currently active bundle.
+	GetActiveBundleNamespacedName(ctx context.Context, client client.Client) (
+		types.NamespacedName, error)
+
 	// Update the bundle returns true if there are changes
 	Update(newBundle *api.PackageBundle, isActive bool,
 		allBundles []api.PackageBundle) bool
@@ -226,4 +231,21 @@ func (m bundleManager) ActiveBundle(ctx context.Context, client client.Client) (
 	}
 
 	return bundle, nil
+}
+
+// GetActiveBundleNamespacedName retrieves the namespace and name of the
+// currently active bundle from the PackageBundleController.
+func (m bundleManager) GetActiveBundleNamespacedName(ctx context.Context,
+	client client.Client) (types.NamespacedName, error) {
+	abc, err := m.getPackageBundleController(ctx, client)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+
+	nn := types.NamespacedName{
+		Namespace: api.PackageNamespace,
+		Name:      abc.Spec.ActiveBundle,
+	}
+
+	return nn, nil
 }


### PR DESCRIPTION
Update the `Reconcile` function to support the scenario that if the bundle controller detects that the active bundle is deleted, the bundle controller will validate the active bundle by namespace and name, and re-download the bundle. The changes were tested locally and passed all testing.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/136

*Description of changes:* `Reconcile` function was updated to support the re-download logic. In order to support this logic, I also added a `GetActiveBundleNamespacedName` function in the `manager`, and updated `manager` `fake` functions. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
