### PR TITLE
Add a recreate bundle functionality to Controller

### DIFF
--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -108,7 +108,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		// If the bundle controller detects that the active bundle is deleted,
 		// the bundle controller will validate the active bundle by namespace
-		// and name, and re-download the bundle.
+		// and name, redownload and recreate the bundle.
 		nn, err := r.bundleManager.GetActiveBundleNamespacedName(ctx, r.Client)
 		if err != nil {
 			r.Log.Info("Unable to get active bundle namespace and name",
@@ -116,20 +116,32 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
+		// Verify the namespace and name of the active bundle.
 		if nn.Namespace != req.Namespace || nn.Name != req.Name {
 			r.Log.Info("Bundle deleted", "bundle", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 
-		_, err = r.bundleManager.DownloadBundle(ctx, req.Name)
-
+		// Downlod the bundle using name tag.
+		bundle, err := r.bundleManager.DownloadBundle(ctx, req.Name)
 		if err != nil {
-			r.Log.Error(err, "Active bundle deleted and failed to download", "bundle",
-				req.NamespacedName)
+			r.Log.Error(err, "Active bundle deleted and failed to download",
+				"bundle", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 
 		r.Log.Info("Bundle downloaded", "bundle", req.NamespacedName)
+
+		// Use the client interface to recreate the bundle.
+		err = r.Client.Create(ctx, bundle)
+		if err != nil {
+			r.Log.Error(err, "Unable to recreate package bundle",
+				"bundle", req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+
+		r.Log.Info("Bundle created", "bundle", req.NamespacedName)
+
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
 Use the k8s client interface to recreate the bundle.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/136

*Description of changes:* Add the recreate bundle logic and update format for `Reconcile`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
