### PR TITLE
Remove ActiveBundle method

### DIFF
--- a/pkg/bundle/fake/manager.go
+++ b/pkg/bundle/fake/manager.go
@@ -26,15 +26,6 @@ func NewBundleManager() *FakeBundleManager {
 	return &FakeBundleManager{}
 }
 
-func (bm *FakeBundleManager) ActiveBundle(ctx context.Context,
-	client client.Client) (*api.PackageBundle, error) {
-
-	if bm.FakeActiveBundleError != nil {
-		return nil, bm.FakeActiveBundleError
-	}
-	return bm.FakeActiveBundle, nil
-}
-
 func (bm *FakeBundleManager) DownloadBundle(ctx context.Context, ref string) (
 	*api.PackageBundle, error) {
 

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -25,10 +25,6 @@ type Manager interface {
 	IsActive(ctx context.Context, client client.Client,
 		namespacedName types.NamespacedName) (bool, error)
 
-	// ActiveBundle retrieves the currently active bundle.
-	ActiveBundle(ctx context.Context, client client.Client) (
-		*api.PackageBundle, error)
-
 	// GetActiveBundleNamespacedName retrieves the namespace and name of the
 	// currently active bundle.
 	GetActiveBundleNamespacedName(ctx context.Context, client client.Client) (
@@ -207,30 +203,6 @@ func (m *bundleManager) apiVersion() (string, error) {
 	version = strings.ReplaceAll(version, "+", "")
 
 	return version, nil
-}
-
-// ActiveBundle retrieves the bundle from which package are installed.
-//
-// It retrieves the name of the active bundle from the PackageBundleController,
-// then uses the K8s API to retrieve and return the CRD for the active bundle
-// itself.
-func (m bundleManager) ActiveBundle(ctx context.Context, client client.Client) (*api.PackageBundle, error) {
-	abc, err := m.getPackageBundleController(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-
-	nn := types.NamespacedName{
-		Namespace: api.PackageNamespace,
-		Name:      abc.Spec.ActiveBundle,
-	}
-	bundle := &api.PackageBundle{}
-	err = client.Get(ctx, nn, bundle)
-	if err != nil {
-		return nil, err
-	}
-
-	return bundle, nil
 }
 
 // GetActiveBundleNamespacedName retrieves the namespace and name of the


### PR DESCRIPTION
This method was replaced by GetActiveBundle in the client
