### PR TITLE
Ignore other namespaces

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -66,6 +66,7 @@ func (m bundleManager) Update(newBundle *api.PackageBundle, active bool,
 
 	if newBundle.Namespace != api.PackageNamespace {
 		if newBundle.Status.State != api.PackageBundleStateIgnored {
+			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 			newBundle.Status.State = api.PackageBundleStateIgnored
 			return true
 		}
@@ -73,6 +74,7 @@ func (m bundleManager) Update(newBundle *api.PackageBundle, active bool,
 	}
 	if !active {
 		if newBundle.Status.State == api.PackageBundleStateActive {
+			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 			newBundle.Status.State = api.PackageBundleStateInactive
 			return true
 		}

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -64,6 +64,13 @@ var _ Manager = (*bundleManager)(nil)
 func (m bundleManager) Update(newBundle *api.PackageBundle, active bool,
 	allBundles []api.PackageBundle) bool {
 
+	if newBundle.Namespace != api.PackageNamespace {
+		if newBundle.Status.State != api.PackageBundleStateIgnored {
+			newBundle.Status.State = api.PackageBundleStateIgnored
+			return true
+		}
+		return false
+	}
 	if !active {
 		if newBundle.Status.State == api.PackageBundleStateActive {
 			newBundle.Status.State = api.PackageBundleStateInactive


### PR DESCRIPTION
```
% k get packages,packagebundles,packagebundlecontrollers,packagecontrollers -A
NAMESPACE       NAME                                                  STATE
default         packagebundle.packages.eks.amazonaws.com/v1-21-1003   ignored
eksa-packages   packagebundle.packages.eks.amazonaws.com/v1-21-1001   active (upgrade available)
eksa-packages   packagebundle.packages.eks.amazonaws.com/v1-21-1002   inactive

NAMESPACE       NAME                                                                                 STATE     DETAIL
default         packagebundlecontroller.packages.eks.amazonaws.com/bob                               ignored   
default         packagebundlecontroller.packages.eks.amazonaws.com/eksa-packages-bundle-controller   ignored   
eksa-packages   packagebundlecontroller.packages.eks.amazonaws.com/billy                             ignored   
eksa-packages   packagebundlecontroller.packages.eks.amazonaws.com/eksa-packages-bundle-controller   active    
```