### PR TITLE
Rename abc vars to pbc for client.go

### DIFF
--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -70,14 +70,14 @@ func (bc *bundleClient) GetActiveBundle(ctx context.Context) (activeBundle *api.
 // GetActiveBundleNamespacedName retrieves the namespace and name of the
 // currently active bundle from the PackageBundleController.
 func (bc *bundleClient) GetActiveBundleNamespacedName(ctx context.Context) (types.NamespacedName, error) {
-	abc, err := bc.getPackageBundleController(ctx)
+	pbc, err := bc.getPackageBundleController(ctx)
 	if err != nil {
 		return types.NamespacedName{}, err
 	}
 
 	nn := types.NamespacedName{
 		Namespace: api.PackageNamespace,
-		Name:      abc.Spec.ActiveBundle,
+		Name:      pbc.Spec.ActiveBundle,
 	}
 
 	return nn, nil


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updated `client.go` file. There are more abc references in the repo, but I'm keeping the PR small to avoid conflict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
