### PR TITLE
Rename ABC related vars to PBC for controller_test.go

### DIFF
--- a/controllers/packagebundlecontroller_controller_test.go
+++ b/controllers/packagebundlecontroller_controller_test.go
@@ -35,7 +35,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 		NamespacedName: controllerNN,
 	}
 
-	setMockABC := func(src *api.PackageBundleController) func(ctx context.Context,
+	setMockPBC := func(src *api.PackageBundleController) func(ctx context.Context,
 		name types.NamespacedName, pbc *api.PackageBundleController) error {
 		return func(ctx context.Context, name types.NamespacedName,
 			target *api.PackageBundleController) error {
@@ -58,7 +58,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 
 		ctx := context.Background()
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		mockABC := &api.PackageBundleController{
+		mockPBC := &api.PackageBundleController{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      api.PackageBundleControllerName,
 				Namespace: "blah",
@@ -76,7 +76,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 			Namespace: api.PackageNamespace,
 		}
 		mockClient.EXPECT().Get(ctx, inactiveController, gomock.Any()).
-			DoAndReturn(setMockABC(mockABC))
+			DoAndReturn(setMockPBC(mockPBC))
 		mockStatusClient := mocks.NewMockStatusWriter(gomock.NewController(t))
 		mockClient.EXPECT().Status().Return(mockStatusClient)
 		mockStatusClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).
@@ -105,7 +105,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 
 		ctx := context.Background()
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		mockABC := &api.PackageBundleController{
+		mockPBC := &api.PackageBundleController{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      api.PackageBundleControllerName,
 				Namespace: api.PackageNamespace,
@@ -124,7 +124,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 		}
 
 		mockClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).
-			DoAndReturn(setMockABC(mockABC))
+			DoAndReturn(setMockPBC(mockPBC))
 		mockStatusClient := mocks.NewMockStatusWriter(gomock.NewController(t))
 		mockClient.EXPECT().Status().Return(mockStatusClient)
 		mockStatusClient.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updated `packagebundlecontroller_controller_test.go` file. `PBC` stands for `PackageBundleController`, which ensures better readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
