### PR TITLE
Update examples with latest from dev build

### DIFF
--- a/api/testdata/bundle_one.yaml
+++ b/api/testdata/bundle_one.yaml
@@ -6,21 +6,21 @@ metadata:
   annotations: {}
 spec:
   packages:
-    - name: Test
+    - name: test
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
           - name: 0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d
             digest: sha256:b2f1efe2f2bf126992ddcba03c353dc1106113c924c49553a9da7366f1653d2a
-    - name: Flux
+    - name: flux
       source:
         registry: public.ecr.aws/j0a1m4z9
         repository: fluxcd/flux2
         versions:
           - name: v0.23.0-0b585d5986a1cfcee67b7a956eeef687f00ae468-helm
             digest: sha256:5fb61d0b650483851ce3892e30f1d2c4c1372aafd51be24f37bbb0056db04012
-    - name: Harbor
+    - name: harbor
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: harbor/harbor-helm

--- a/api/testdata/bundle_one.yaml
+++ b/api/testdata/bundle_one.yaml
@@ -11,8 +11,8 @@ spec:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
-          - name: 0.1.1_b41df7249b38548e535531d2e971ba85bb374434
-            digest: sha256:64ea03b119d2421f9206252ff4af4bf7cdc2823c343420763e0e6fc20bf03b68
+          - name: 0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d
+            digest: sha256:b2f1efe2f2bf126992ddcba03c353dc1106113c924c49553a9da7366f1653d2a
     - name: Flux
       source:
         registry: public.ecr.aws/j0a1m4z9
@@ -22,8 +22,8 @@ spec:
             digest: sha256:5fb61d0b650483851ce3892e30f1d2c4c1372aafd51be24f37bbb0056db04012
     - name: Harbor
       source:
-        registry: public.ecr.aws/y8n6a2y0
+        registry: public.ecr.aws/l0g8r8j6
         repository: harbor/harbor-helm
         versions:
-          - name: v2.4.1-f47374093e8a9c48aca8c7a7f06ae185eb7506f3-helm
-            digest: sha256:423eb28b0586376f4d1d30b492370a4e215f2b0210a587fff6f358efc41dda4c
+          - name: 2.5.0-f78bf0f83fc6986478cab1336de8c411647c2096
+            digest: sha256:0fe93a79c75e9d81cfc1141e20bb7d2d17fa1d516a2f001e229d01245ede1519

--- a/api/testdata/bundle_one.yaml.digest
+++ b/api/testdata/bundle_one.yaml.digest
@@ -1,1 +1,1 @@
-ZYvrsjGV6c14Ux1VRDoku+IhfuPhm5PKgcFD21RtJAM=
+Jdz/QLNrigZuo3KuT09V3Dyo4fbVW6JTtW2rmQJKzuA=

--- a/api/testdata/bundle_one.yaml.digest
+++ b/api/testdata/bundle_one.yaml.digest
@@ -1,1 +1,1 @@
-Jdz/QLNrigZuo3KuT09V3Dyo4fbVW6JTtW2rmQJKzuA=
+z3bqIbXMuMGwDAqIjCLcCRBujXnByeoyJLe2CCbl0cc=

--- a/api/testdata/bundle_one.yaml.signed
+++ b/api/testdata/bundle_one.yaml.signed
@@ -3,7 +3,7 @@ kind: PackageBundle
 metadata:
   name: v1-21-1001
   namespace: eksa-packages
-  annotations: {eksa.aws.com/signature: MEYCIQCf0PEXc2ceOu7bb1EovaSNM9BjvdT4vexn1uwW67FzjQIhALg+sW0Vqgt6wc/FEWWXOrwM93coY1BXkRkivr7hwz+d}
+  annotations: {eksa.aws.com/signature: MEQCICsPkClx2iduW5iYSxZaE74HhCQdsvpRsQapP1gHRU7YAiAsl04YtOOzIQkYfNy9yxX0TTNq8tVqACX43I5kYmqoAQ==}
 spec:
   packages:
     - name: Test
@@ -11,8 +11,8 @@ spec:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
-          - name: v0.1.1-8b3810e1514b7432e032794842425accc837757a-helm
-            digest: sha256:64ea03b119d2421f9206252ff4af4bf7cdc2823c343420763e0e6fc20bf03b68
+          - name: 0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d
+            digest: sha256:b2f1efe2f2bf126992ddcba03c353dc1106113c924c49553a9da7366f1653d2a
     - name: Flux
       source:
         registry: public.ecr.aws/j0a1m4z9
@@ -22,8 +22,8 @@ spec:
             digest: sha256:5fb61d0b650483851ce3892e30f1d2c4c1372aafd51be24f37bbb0056db04012
     - name: Harbor
       source:
-        registry: public.ecr.aws/y8n6a2y0
+        registry: public.ecr.aws/l0g8r8j6
         repository: harbor/harbor-helm
         versions:
-          - name: v2.4.1-f47374093e8a9c48aca8c7a7f06ae185eb7506f3-helm
-            digest: sha256:423eb28b0586376f4d1d30b492370a4e215f2b0210a587fff6f358efc41dda4c
+          - name: 2.5.0-f78bf0f83fc6986478cab1336de8c411647c2096
+            digest: sha256:0fe93a79c75e9d81cfc1141e20bb7d2d17fa1d516a2f001e229d01245ede1519

--- a/api/testdata/bundle_one.yaml.signed
+++ b/api/testdata/bundle_one.yaml.signed
@@ -3,24 +3,24 @@ kind: PackageBundle
 metadata:
   name: v1-21-1001
   namespace: eksa-packages
-  annotations: {eksa.aws.com/signature: MEQCICsPkClx2iduW5iYSxZaE74HhCQdsvpRsQapP1gHRU7YAiAsl04YtOOzIQkYfNy9yxX0TTNq8tVqACX43I5kYmqoAQ==}
+  annotations: {eksa.aws.com/signature: MEUCIBLTDl8yEBKpi4+tvW8Dnyww06yRie1c8acy5hpFWCkBAiEAkhMosU5KH9GMGpbO/L1e5P+BhB9g4CH8pDjDVw4WnQg=}
 spec:
   packages:
-    - name: Test
+    - name: test
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
           - name: 0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d
             digest: sha256:b2f1efe2f2bf126992ddcba03c353dc1106113c924c49553a9da7366f1653d2a
-    - name: Flux
+    - name: flux
       source:
         registry: public.ecr.aws/j0a1m4z9
         repository: fluxcd/flux2
         versions:
           - name: v0.23.0-0b585d5986a1cfcee67b7a956eeef687f00ae468-helm
             digest: sha256:5fb61d0b650483851ce3892e30f1d2c4c1372aafd51be24f37bbb0056db04012
-    - name: Harbor
+    - name: harbor
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: harbor/harbor-helm

--- a/api/testdata/bundle_two.yaml
+++ b/api/testdata/bundle_two.yaml
@@ -6,21 +6,21 @@ metadata:
   annotations: {}
 spec:
   packages:
-    - name: Test
+    - name: test
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
           - name: v0.1.1
             digest: sha256:64ea03b119d2421f9206252ff4af4bf7cdc2823c343420763e0e6fc20bf03b68
-    - name: Flux
+    - name: flux
       source:
         registry: public.ecr.aws/j0a1m4z9
         repository: fluxcd/flux2
         versions:
           - name: v0.25.1-7fb396bd0be3769162a408aa4d22a48fd74a9db7-helm
             digest: sha256:ab067969310f3f237c716d6f348dab9cfdce8cc2c188dfdd6b5cfa0e2cd63939
-    - name: Harbor
+    - name: harbor
       source:
         registry: public.ecr.aws/y8n6a2y0
         repository: harbor/harbor-helm

--- a/api/testdata/bundle_two.yaml.digest
+++ b/api/testdata/bundle_two.yaml.digest
@@ -1,1 +1,1 @@
-zWa+2Led+4aMxXdMBZmbv3i08cZH2PcwNl+sPVUMLyY=
+BBoUqGcFqfXAxKSVMn7925HuUo88f5gRU2OUijbha7Q=

--- a/api/testdata/bundle_two.yaml.signed
+++ b/api/testdata/bundle_two.yaml.signed
@@ -3,24 +3,24 @@ kind: PackageBundle
 metadata:
   name: v1-21-1002
   namespace: eksa-packages
-  annotations: {eksa.aws.com/signature: MEQCIGgSyzwTBqPuFj8yCu4agaasqGOvAvFAiP+eJLLOD7jBAiB4tKIy7LS8FQIyft86NhirLPwSJZZAIjk5LzUYFma15A==}
+  annotations: {eksa.aws.com/signature: MEUCIQDvYu8Sk2bfN+JQJcdYUVvi+ccT7OT+tV+KMDQ9WbZPxAIgcXy0+8/FMb1F/tqfcu1m4h9IyBaRdcHc5pUy8zUsBug=}
 spec:
   packages:
-    - name: Test
+    - name: test
       source:
         registry: public.ecr.aws/l0g8r8j6
         repository: hello-eks-anywhere
         versions:
           - name: v0.1.1
             digest: sha256:64ea03b119d2421f9206252ff4af4bf7cdc2823c343420763e0e6fc20bf03b68
-    - name: Flux
+    - name: flux
       source:
         registry: public.ecr.aws/j0a1m4z9
         repository: fluxcd/flux2
         versions:
           - name: v0.25.1-7fb396bd0be3769162a408aa4d22a48fd74a9db7-helm
             digest: sha256:ab067969310f3f237c716d6f348dab9cfdce8cc2c188dfdd6b5cfa0e2cd63939
-    - name: Harbor
+    - name: harbor
       source:
         registry: public.ecr.aws/y8n6a2y0
         repository: harbor/harbor-helm

--- a/api/testdata/harbor.yaml
+++ b/api/testdata/harbor.yaml
@@ -4,5 +4,5 @@ metadata:
   name: my-harbor
   namespace: eksa-packages
 spec:
-  packageName: Harbor
+  packageName: harbor
   packageVersion: v2.4.1-f47374093e8a9c48aca8c7a7f06ae185eb7506f3-helm

--- a/api/testdata/test.yaml
+++ b/api/testdata/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-test
   namespace: eksa-packages
 spec:
-  packageName: Test
+  packageName: test
   config: |
     config:
       foo: windom

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -49,16 +49,16 @@ func TestDownloadBundle(t *testing.T) {
 			t.Errorf("expected three packages to be defined, found %d",
 				len(bundle.Spec.Packages))
 		}
-		if bundle.Spec.Packages[0].Name != "Test" {
-			t.Errorf("expected first package name to be \"Test\", got: %q",
+		if bundle.Spec.Packages[0].Name != "test" {
+			t.Errorf("expected first package name to be \"test\", got: %q",
 				bundle.Spec.Packages[0].Name)
 		}
-		if bundle.Spec.Packages[1].Name != "Flux" {
-			t.Errorf("expected second package name to be \"Flux\", got: %q",
+		if bundle.Spec.Packages[1].Name != "flux" {
+			t.Errorf("expected second package name to be \"flux\", got: %q",
 				bundle.Spec.Packages[1].Name)
 		}
-		if bundle.Spec.Packages[2].Name != "Harbor" {
-			t.Errorf("expected third package name to be \"Harbor\", got: %q",
+		if bundle.Spec.Packages[2].Name != "harbor" {
+			t.Errorf("expected third package name to be \"harbor\", got: %q",
 				bundle.Spec.Packages[2].Name)
 		}
 	})


### PR DESCRIPTION
With these updated examples, the installs are working for me

```
% k get packages,packagebundles,packagebundlecontrollers -A
NAMESPACE       NAME                                         PACKAGE   AGE   STATE       CURRENTVERSION                                   TARGETVERSION                                             DETAIL
eksa-packages   package.packages.eks.amazonaws.com/my-test   test      8s    installed   0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d   0.1.1-6d0e566362d03a00f41d75524d21de5ddb95fd1d (latest)   

NAMESPACE       NAME                                                  STATE
eksa-packages   packagebundle.packages.eks.amazonaws.com/v1-21-1001   active

NAMESPACE       NAME                                                                                 STATE          DETAIL
eksa-packages   packagebundlecontroller.packages.eks.amazonaws.com/eksa-packages-bundle-controller   disconnected  
```
