### PR TITLE
Sort bundles numerically

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 	DownloadBundle(ctx context.Context, ref string) (
 		*api.PackageBundle, error)
 
-	SortBundlesNewestFirst(bundles []api.PackageBundle)
+	SortBundlesDescending(bundles []api.PackageBundle)
 }
 
 type bundleManager struct {
@@ -87,7 +87,7 @@ func (m bundleManager) Update(newBundle *api.PackageBundle, active bool,
 	// allBundles should never be nil or empty in production, but for testing
 	// it's much easier to handle a nil case.
 	if active && allBundles != nil && len(allBundles) > 0 {
-		m.SortBundlesNewestFirst(allBundles)
+		m.SortBundlesDescending(allBundles)
 		if allBundles[0].Name != newBundle.Name {
 			newBundle.Status.State = api.PackageBundleStateUpgradeAvailable
 		}
@@ -97,8 +97,9 @@ func (m bundleManager) Update(newBundle *api.PackageBundle, active bool,
 	return true
 }
 
-// SortBundlesNewestFirst will sort a slice of bundles so that the newest is first.
-func (m bundleManager) SortBundlesNewestFirst(bundles []api.PackageBundle) {
+// SortBundlesDescending will sort a slice of bundles in descending order so
+// that the newest (greatest) bundle will be displayed first.
+func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 	sortFn := func(i, j int) bool {
 		return bundles[j].LessThan(&bundles[i])
 	}

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -305,7 +305,7 @@ func TestSortBundleNewestFirst(t *testing.T) {
 		}
 
 		bm := NewBundleManager(logr.Discard(), discovery, puller)
-		bm.SortBundlesNewestFirst(allBundles)
+		bm.SortBundlesDescending(allBundles)
 		if assert.Greater(t, len(allBundles), 1) {
 			assert.Equal(t, "v1-21-1002", allBundles[0].Name)
 			assert.Equal(t, "v1-21-1001", allBundles[1].Name)
@@ -329,7 +329,7 @@ func TestSortBundleNewestFirst(t *testing.T) {
 		}
 
 		bm := NewBundleManager(logr.Discard(), discovery, puller)
-		bm.SortBundlesNewestFirst(allBundles)
+		bm.SortBundlesDescending(allBundles)
 		if assert.Greater(t, len(allBundles), 2) {
 			assert.Equal(t, "v1-21-1002", allBundles[0].Name)
 			assert.Equal(t, "v1-21-1001", allBundles[1].Name)


### PR DESCRIPTION
Rename the `SortBundlesNewestFirst` method to `SortBundlesDescending`. Though the current sorting logic does represent "NewestFirst", this sorting logic needs to be further tuned (and may be subject to changes). Before we re-tune the logic, we want to rename the method to a more generic name "SortBundlesDescending" to avoid confusion for users.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/166

*Description of changes:* Rename method `SortBundlesNewestFirst`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
