### PR TITLE
prod tag fix

### DIFF
--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -437,9 +437,9 @@ func copyImagePrivPubSameAcct(log logr.Logger, authFile, version string, stsClie
 }
 
 // copyImagePubPubDifferentAcct will copy an OCI artifact from ECR Public to ECR Public to another account.
-func (c *SDKClients) copyImagePubPubDifferentAcct(log logr.Logger, authFile string, image Image) error {
-	source := fmt.Sprintf("docker://%s/%s:%s", c.ecrPublicClient.SourceRegistry, image.Repository, image.Tag)
-	destination := fmt.Sprintf("docker://%s/%s:%s", c.ecrPublicClientRelease.SourceRegistry, image.Repository, image.Tag)
+func (c *SDKClients) copyImagePubPubDifferentAcct(log logr.Logger, authFile, version string, image Image) error {
+	source := fmt.Sprintf("docker://%s/%s:%s", c.ecrPublicClient.SourceRegistry, image.Repository, version)
+	destination := fmt.Sprintf("docker://%s/%s:%s", c.ecrPublicClientRelease.SourceRegistry, image.Repository, version)
 	log.Info("Promoting...", source, destination)
 	cmd := exec.Command("skopeo", "copy", "--authfile", authFile, source, destination, "-f", "oci", "--all")
 	_, err := ExecCommand(cmd)

--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -139,7 +139,7 @@ func (c *SDKClients) PromoteHelmChart(repository, authFile string, crossAccount 
 			// If using a profile we just copy from source account to destination account
 			if crossAccount {
 				fmt.Printf("Image Digest, and Tag dont exist in destination location......copying to %s/%s:%s %s\n", c.ecrPublicClientRelease.SourceRegistry, images.Repository, version, images.Digest)
-				err := c.copyImagePubPubDifferentAcct(BundleLog, authFile, images)
+				err := c.copyImagePubPubDifferentAcct(BundleLog, authFile, version, images)
 				if err != nil {
 					return fmt.Errorf("Unable to copy image from source to destination repo %s", err)
 				}


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Tags not sync'd when copying over to Prod, trying a fix which doesn't require a new build. Otherwise we need to revert the bundle in the helm chart to `v1-22-4` since `v1-22-5` is showing newer sha sums which are not in Prod yet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
