### PR TITLE
Add KubeVersion check to PackageBundle State

### DIFF
--- a/api/v1alpha1/export_test.go
+++ b/api/v1alpha1/export_test.go
@@ -1,0 +1,5 @@
+// Export private functions and methods for testing
+package v1alpha1
+
+var GetMajorMinorBuild = (*PackageBundle).getMajorMinorBuild
+var GetMajorMinorFromString = getMajorMinorFromString

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -70,7 +70,7 @@ func (config *PackageBundle) getMajorMinorBuild() (major int, minor int, build i
 }
 
 // getMajorMinorFromString returns the Kubernetes major and minor version.
-
+//
 // It returns 0, 0 for empty string.
 func getMajorMinorFromString(kubeVersion string) (major int, minor int) {
 	s := strings.Split(kubeVersion, "-")

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -57,8 +57,8 @@ func (config *PackageBundle) LessThan(rhsBundle *PackageBundle) bool {
 	return lhsMajor < rhsMajor || lhsMinor < rhsMinor || lhsBuild < rhsBuild
 }
 
-// getMajorMinorBuild parses PackageBundle name, and return the Kubernetes major
-// version, Kubernetes minor version, and bundle build version.
+// getMajorMinorBuild returns the Kubernetes major version, Kubernetes minor
+// version, and bundle build version.
 func (config *PackageBundle) getMajorMinorBuild() (major int, minor int, build int) {
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
@@ -69,8 +69,7 @@ func (config *PackageBundle) getMajorMinorBuild() (major int, minor int, build i
 	return major, minor, build
 }
 
-// getMajorMinorFromString parses the kubeVersion (in string format), and
-// return the Kubernetes major version and Kubernetes minor version.
+// getMajorMinorFromString returns the Kubernetes major and minor version.
 
 // It returns 0, 0 for empty string.
 func getMajorMinorFromString(kubeVersion string) (major int, minor int) {
@@ -84,7 +83,7 @@ func getMajorMinorFromString(kubeVersion string) (major int, minor int) {
 
 // KubeVersionMatches returns true if the target Kubernetes matches the
 // current bundle's Kubernetes version.
-
+//
 // Note the method only compares the major and minor versions of Kubernetes, and
 // ignore the patch numbers.
 func (config *PackageBundle) KubeVersionMatches(targetKubeVersion string) bool {

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -85,7 +85,6 @@ func GetMajorMinorFromString(kubeVersion string) (major int, minor int) {
 // current bundle's Kubernetes version. Note the method only compares the major
 // and minor versions of Kubernetes, and ignore the patch numbers.
 func (config *PackageBundle) KubeVersionMatches(targetKubeVersion string) bool {
-
 	currKubeMajor, currKubeMinor, _ := config.GetMajorMinorBuild()
 	targetKubeMajor, targetKubeMinor := GetMajorMinorFromString(targetKubeVersion)
 

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -57,8 +57,8 @@ func (config *PackageBundle) LessThan(rhsBundle *PackageBundle) bool {
 	return lhsMajor < rhsMajor || lhsMinor < rhsMinor || lhsBuild < rhsBuild
 }
 
-// GetMajorMinorBuild parses PackageBundle name, and return the Kubenetes major
-// version, Kubenetes minor version, and bundle build version.
+// GetMajorMinorBuild parses PackageBundle name, and return the Kubernetes major
+// version, Kubernetes minor version, and bundle build version.
 func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build int) {
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
@@ -70,7 +70,7 @@ func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build i
 }
 
 // GetMajorMinorFromString parses the kubeVersion (in string format), and
-// return the Kubenetes major version and Kubenetes minor version. It returns
+// return the Kubernetes major version and Kubernetes minor version. It returns
 // 0, 0 for empty string.
 func GetMajorMinorFromString(kubeVersion string) (major int, minor int) {
 	s := strings.Split(kubeVersion, "-")

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -52,14 +52,14 @@ func (config *PackageBundle) FindSource(pkgName, pkgVersion string) (retSource P
 // method returns true. If it is newer (greater) it returns false. If they are
 // the same it returns false.
 func (config *PackageBundle) LessThan(rhsBundle *PackageBundle) bool {
-	lhsMajor, lhsMinor, lhsBuild := config.GetMajorMinorBuild()
-	rhsMajor, rhsMinor, rhsBuild := rhsBundle.GetMajorMinorBuild()
+	lhsMajor, lhsMinor, lhsBuild := config.getMajorMinorBuild()
+	rhsMajor, rhsMinor, rhsBuild := rhsBundle.getMajorMinorBuild()
 	return lhsMajor < rhsMajor || lhsMinor < rhsMinor || lhsBuild < rhsBuild
 }
 
-// GetMajorMinorBuild parses PackageBundle name, and return the Kubernetes major
+// getMajorMinorBuild parses PackageBundle name, and return the Kubernetes major
 // version, Kubernetes minor version, and bundle build version.
-func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build int) {
+func (config *PackageBundle) getMajorMinorBuild() (major int, minor int, build int) {
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
 	s[0] = strings.TrimPrefix(s[0], "v")
@@ -69,10 +69,11 @@ func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build i
 	return major, minor, build
 }
 
-// GetMajorMinorFromString parses the kubeVersion (in string format), and
-// return the Kubernetes major version and Kubernetes minor version. It returns
-// 0, 0 for empty string.
-func GetMajorMinorFromString(kubeVersion string) (major int, minor int) {
+// getMajorMinorFromString parses the kubeVersion (in string format), and
+// return the Kubernetes major version and Kubernetes minor version.
+
+// It returns 0, 0 for empty string.
+func getMajorMinorFromString(kubeVersion string) (major int, minor int) {
 	s := strings.Split(kubeVersion, "-")
 	s = append(s, "", "", "")
 	s[0] = strings.TrimPrefix(s[0], "v")
@@ -82,11 +83,13 @@ func GetMajorMinorFromString(kubeVersion string) (major int, minor int) {
 }
 
 // KubeVersionMatches returns true if the target Kubernetes matches the
-// current bundle's Kubernetes version. Note the method only compares the major
-// and minor versions of Kubernetes, and ignore the patch numbers.
+// current bundle's Kubernetes version.
+
+// Note the method only compares the major and minor versions of Kubernetes, and
+// ignore the patch numbers.
 func (config *PackageBundle) KubeVersionMatches(targetKubeVersion string) bool {
-	currKubeMajor, currKubeMinor, _ := config.GetMajorMinorBuild()
-	targetKubeMajor, targetKubeMinor := GetMajorMinorFromString(targetKubeVersion)
+	currKubeMajor, currKubeMinor, _ := config.getMajorMinorBuild()
+	targetKubeMajor, targetKubeMinor := getMajorMinorFromString(targetKubeVersion)
 
 	return currKubeMajor == targetKubeMajor && currKubeMinor == targetKubeMinor
 }

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -71,8 +71,8 @@ func (s PackageOCISource) AsRepoURI() string {
 	return path.Join(s.Registry, s.Repository)
 }
 
-// Matches returns true if the given source locations match one another.
-func (s BundlePackageSource) Matches(other BundlePackageSource) bool {
+// PackageMatches returns true if the given source locations match one another.
+func (s BundlePackageSource) PackageMatches(other BundlePackageSource) bool {
 	if s.Registry != other.Registry {
 		return false
 	}

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -57,6 +57,8 @@ func (config *PackageBundle) LessThan(rhsBundle *PackageBundle) bool {
 	return lhsMajor < rhsMajor || lhsMinor < rhsMinor || lhsBuild < rhsBuild
 }
 
+// GetMajorMinorBuild parses PackageBundle name, and return the Kubenetes major
+// version, Kubenetes minor version, and bundle build version.
 func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build int) {
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
@@ -65,6 +67,29 @@ func (config *PackageBundle) GetMajorMinorBuild() (major int, minor int, build i
 	minor, _ = strconv.Atoi(s[1])
 	build, _ = strconv.Atoi(s[2])
 	return major, minor, build
+}
+
+// GetMajorMinorFromString parses the kubeVersion (in string format), and
+// return the Kubenetes major version and Kubenetes minor version. It returns
+// 0, 0 for empty string.
+func GetMajorMinorFromString(kubeVersion string) (major int, minor int) {
+	s := strings.Split(kubeVersion, "-")
+	s = append(s, "", "", "")
+	s[0] = strings.TrimPrefix(s[0], "v")
+	major, _ = strconv.Atoi(s[0])
+	minor, _ = strconv.Atoi(s[1])
+	return major, minor
+}
+
+// KubeVersionMatches returns true if the target Kubernetes matches the
+// current bundle's Kubernetes version. Note the method only compares the major
+// and minor versions of Kubernetes, and ignore the patch numbers.
+func (config *PackageBundle) KubeVersionMatches(targetKubeVersion string) bool {
+
+	currKubeMajor, currKubeMinor, _ := config.GetMajorMinorBuild()
+	targetKubeMajor, targetKubeMinor := GetMajorMinorFromString(targetKubeVersion)
+
+	return currKubeMajor == targetKubeMajor && currKubeMinor == targetKubeMinor
 }
 
 func (s PackageOCISource) AsRepoURI() string {

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -106,7 +106,7 @@ func TestPackageBundle_Find(t *testing.T) {
 	})
 }
 
-func TestMatches(t *testing.T) {
+func TestPackageMatches(t *testing.T) {
 	orig := api.BundlePackageSource{
 		Registry:   "registry",
 		Repository: "repository",
@@ -116,7 +116,7 @@ func TestMatches(t *testing.T) {
 		},
 	}
 
-	t.Run("matches", func(t *testing.T) {
+	t.Run("package matches", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry",
 			Repository: "repository",
@@ -125,13 +125,13 @@ func TestMatches(t *testing.T) {
 				{Name: "v2", Digest: "sha256:cafebabe"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if !result {
 			t.Errorf("expected <%t> got <%t>", true, result)
 		}
 	})
 
-	t.Run("registries must match", func(t *testing.T) {
+	t.Run("package registries must match", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry2",
 			Repository: "repository",
@@ -140,13 +140,13 @@ func TestMatches(t *testing.T) {
 				{Name: "v2", Digest: "sha256:cafebabe"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
 		}
 	})
 
-	t.Run("repositories must match", func(t *testing.T) {
+	t.Run("package repositories must match", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry",
 			Repository: "repository2",
@@ -155,13 +155,13 @@ func TestMatches(t *testing.T) {
 				{Name: "v2", Digest: "sha256:cafebabe"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
 		}
 	})
 
-	t.Run("added versions cause mismatch", func(t *testing.T) {
+	t.Run("package added versions cause mismatch", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry",
 			Repository: "repository",
@@ -171,13 +171,13 @@ func TestMatches(t *testing.T) {
 				{Name: "v3", Digest: "sha256:deadf00d"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
 		}
 	})
 
-	t.Run("removed versions cause mismatch", func(t *testing.T) {
+	t.Run("package removed versions cause mismatch", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry",
 			Repository: "repository",
@@ -185,13 +185,13 @@ func TestMatches(t *testing.T) {
 				{Name: "v2", Digest: "sha256:cafebabe"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
 		}
 	})
 
-	t.Run("changed tags cause mismatch", func(t *testing.T) {
+	t.Run("package changed tags cause mismatch", func(t *testing.T) {
 		other := api.BundlePackageSource{
 			Registry:   "registry",
 			Repository: "repository",
@@ -200,7 +200,7 @@ func TestMatches(t *testing.T) {
 				{Name: "v2", Digest: "sha256:cafebabe"},
 			},
 		}
-		result := orig.Matches(other)
+		result := orig.PackageMatches(other)
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
 		}

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -110,8 +110,8 @@ func TestGetMajorMinorFromString(t *testing.T) {
 
 	t.Run("Parse from default Kubernetes version name", func(t *testing.T) {
 
-		target_version := "v1-21-1"
-		major, minor := api.GetMajorMinorFromString(target_version)
+		targetVersion := "v1-21-1"
+		major, minor := api.GetMajorMinorFromString(targetVersion)
 
 		assert.Equal(t, 1, major)
 		assert.Equal(t, 21, minor)
@@ -120,8 +120,8 @@ func TestGetMajorMinorFromString(t *testing.T) {
 	t.Run("Parse from Kubernetes version name without patch number", func(
 		t *testing.T) {
 
-		target_version := "v1-21"
-		major, minor := api.GetMajorMinorFromString(target_version)
+		targetVersion := "v1-21"
+		major, minor := api.GetMajorMinorFromString(targetVersion)
 
 		assert.Equal(t, 1, major)
 		assert.Equal(t, 21, minor)
@@ -130,8 +130,8 @@ func TestGetMajorMinorFromString(t *testing.T) {
 	t.Run("Parse from Kubernetes version name without v perfix", func(
 		t *testing.T) {
 
-		target_version := "1-21-1"
-		major, minor := api.GetMajorMinorFromString(target_version)
+		targetVersion := "1-21-1"
+		major, minor := api.GetMajorMinorFromString(targetVersion)
 
 		assert.Equal(t, 1, major)
 		assert.Equal(t, 21, minor)
@@ -139,8 +139,8 @@ func TestGetMajorMinorFromString(t *testing.T) {
 
 	t.Run("Parse from empty Kubernetes version name", func(t *testing.T) {
 
-		target_version := ""
-		major, minor := api.GetMajorMinorFromString(target_version)
+		targetVersion := ""
+		major, minor := api.GetMajorMinorFromString(targetVersion)
 
 		assert.Equal(t, 0, major)
 		assert.Equal(t, 0, minor)
@@ -154,9 +154,9 @@ func TestKubeVersionMatches(t *testing.T) {
 
 	t.Run("Kubernetes version matches", func(t *testing.T) {
 
-		target_version := "v1-21-1"
+		targetVersion := "v1-21-1"
 
-		result := bundle.KubeVersionMatches(target_version)
+		result := bundle.KubeVersionMatches(targetVersion)
 
 		if !result {
 			t.Errorf("expected <%t> got <%t>", true, result)
@@ -165,9 +165,9 @@ func TestKubeVersionMatches(t *testing.T) {
 
 	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
 
-		target_version := "v2-21-1"
+		targetVersion := "v2-21-1"
 
-		result := bundle.KubeVersionMatches(target_version)
+		result := bundle.KubeVersionMatches(targetVersion)
 
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)
@@ -176,9 +176,9 @@ func TestKubeVersionMatches(t *testing.T) {
 
 	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
 
-		target_version := "v1-22-1"
+		targetVersion := "v1-22-1"
 
-		result := bundle.KubeVersionMatches(target_version)
+		result := bundle.KubeVersionMatches(targetVersion)
 
 		if result {
 			t.Errorf("expected <%t> got <%t>", false, result)

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -106,6 +106,86 @@ func TestPackageBundle_Find(t *testing.T) {
 	})
 }
 
+func TestGetMajorMinorFromString(t *testing.T) {
+
+	t.Run("Parse from default Kubernetes version name", func(t *testing.T) {
+
+		target_version := "v1-21-1"
+		major, minor := api.GetMajorMinorFromString(target_version)
+
+		assert.Equal(t, 1, major)
+		assert.Equal(t, 21, minor)
+	})
+
+	t.Run("Parse from Kubernetes version name without patch number", func(
+		t *testing.T) {
+
+		target_version := "v1-21"
+		major, minor := api.GetMajorMinorFromString(target_version)
+
+		assert.Equal(t, 1, major)
+		assert.Equal(t, 21, minor)
+	})
+
+	t.Run("Parse from Kubernetes version name without v perfix", func(
+		t *testing.T) {
+
+		target_version := "1-21-1"
+		major, minor := api.GetMajorMinorFromString(target_version)
+
+		assert.Equal(t, 1, major)
+		assert.Equal(t, 21, minor)
+	})
+
+	t.Run("Parse from empty Kubernetes version name", func(t *testing.T) {
+
+		target_version := ""
+		major, minor := api.GetMajorMinorFromString(target_version)
+
+		assert.Equal(t, 0, major)
+		assert.Equal(t, 0, minor)
+	})
+}
+
+func TestKubeVersionMatches(t *testing.T) {
+
+	bundle := api.PackageBundle{ObjectMeta: metav1.ObjectMeta{
+		Name: "v1-21-1001"}}
+
+	t.Run("Kubernetes version matches", func(t *testing.T) {
+
+		target_version := "v1-21-1"
+
+		result := bundle.KubeVersionMatches(target_version)
+
+		if !result {
+			t.Errorf("expected <%t> got <%t>", true, result)
+		}
+	})
+
+	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
+
+		target_version := "v2-21-1"
+
+		result := bundle.KubeVersionMatches(target_version)
+
+		if result {
+			t.Errorf("expected <%t> got <%t>", false, result)
+		}
+	})
+
+	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
+
+		target_version := "v1-22-1"
+
+		result := bundle.KubeVersionMatches(target_version)
+
+		if result {
+			t.Errorf("expected <%t> got <%t>", false, result)
+		}
+	})
+}
+
 func TestPackageMatches(t *testing.T) {
 	orig := api.BundlePackageSource{
 		Registry:   "registry",

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -124,7 +124,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
-		// Downlod the bundle using name tag.
+		// Download the bundle using name tag.
 		bundle, err := r.bundleManager.DownloadBundle(ctx, req.Name)
 		if err != nil {
 			r.Log.Error(err, "Active bundle deleted and failed to download",

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -65,7 +65,14 @@ func (m bundleManager) Update(ctx context.Context, newBundle *api.PackageBundle,
 		return false, err
 	}
 
-	if newBundle.Namespace != api.PackageNamespace {
+	kubeVersion, err := m.apiVersion()
+	if err != nil {
+		return false, fmt.Errorf("retrieving k8s API version: %w", err)
+	}
+
+	kubeMatches := newBundle.KubeVersionMatches(kubeVersion)
+
+	if newBundle.Namespace != api.PackageNamespace || !kubeMatches {
 		if newBundle.Status.State != api.PackageBundleStateIgnored {
 			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 			newBundle.Status.State = api.PackageBundleStateIgnored

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -208,6 +208,22 @@ func TestUpdate(t *testing.T) {
 		puller := testutil.NewMockPuller()
 		bundle := givenPackageBundle(api.PackageBundleStateInactive)
 		bundle.Namespace = "billy"
+		bundle.Name = "v1-21"
+		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
+		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(true, nil)
+		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)
+
+		update, err := bm.Update(ctx, bundle, noBundles)
+		assert.True(t, update)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, api.PackageBundleStateIgnored, bundle.Status.State)
+	})
+
+	t.Run("ignore incompatible Kubernetes version", func(t *testing.T) {
+		discovery := testutil.NewFakeDiscoveryWithDefaults()
+		puller := testutil.NewMockPuller()
+		bundle := givenPackageBundle(api.PackageBundleStateInactive)
+		bundle.Name = "v1-01"
 		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(true, nil)
 		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)
@@ -237,6 +253,7 @@ func TestUpdate(t *testing.T) {
 		discovery := testutil.NewFakeDiscoveryWithDefaults()
 		puller := testutil.NewMockPuller()
 		bundle := givenPackageBundle(api.PackageBundleStateInactive)
+		bundle.Name = "v1-21"
 		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(true, nil)
 		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)
@@ -251,6 +268,7 @@ func TestUpdate(t *testing.T) {
 		discovery := testutil.NewFakeDiscoveryWithDefaults()
 		puller := testutil.NewMockPuller()
 		bundle := givenPackageBundle(api.PackageBundleStateActive)
+		bundle.Name = "v1-21"
 		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(false, nil)
 		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)
@@ -265,6 +283,7 @@ func TestUpdate(t *testing.T) {
 		discovery := testutil.NewFakeDiscoveryWithDefaults()
 		puller := testutil.NewMockPuller()
 		bundle := givenPackageBundle(api.PackageBundleStateInactive)
+		bundle.Name = "v1-21"
 		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(false, nil)
 		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)
@@ -279,6 +298,7 @@ func TestUpdate(t *testing.T) {
 		discovery := testutil.NewFakeDiscoveryWithDefaults()
 		puller := testutil.NewMockPuller()
 		bundle := givenPackageBundle(api.PackageBundleStateActive)
+		bundle.Name = "v1-21"
 		mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 		mockBundleClient.EXPECT().IsActive(ctx, bundle).Return(true, nil)
 		bm := NewBundleManager(logr.Discard(), discovery, puller, mockBundleClient)


### PR DESCRIPTION
If the version of the bundle doesn't match the specified Kubernetes version, the PackageBundle state will be marked as `PackageBundleStateIgnored`.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/138

*Description of changes:* Add `KubeVersionMatches` method, helper function `GetMajorMinorFromString`; and update `Update` in manager.go


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
