### PR TITLE
Extract awsAuth function and use it in more places

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common functions used by various build scripts. To use these
+# functions, source this file, e.g.:
+#    . <path-to-this-file>/common.sh
+
+# awsAuth calls a command and pipes credentials to it.
+#
+# It will pipe its output into any command, though it was built to
+# work with oras sub-commands that support the --password-stdin flag
+# (e.g. pull and push). If the function detects that a public ECR is
+# in use, it will adjust accordingly.
+#
+# An AWS profile can be selected via the PROFILE env var (defaults to
+# "default").
+function awsAuth () {
+    declare -a cmd=( ecr )
+
+    for arg in "$@"; do
+	if [[ "$arg" =~ public\.ecr\.aws ]]; then
+	    cmd=( ecr-public --region us-east-1 )
+	    break
+	fi
+    done
+    # shellcheck disable=SC2086
+    aws ${cmd[*]} get-login-password --profile ${PROFILE:-default} \
+	| "$@"
+}

--- a/generatebundlefile/hack/release.sh
+++ b/generatebundlefile/hack/release.sh
@@ -52,29 +52,14 @@ ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
 
 make oras-install
 
-# orasAuth wraps calls to oras and sends credentials on stdin.
-#
-# Use it with any oras sub-command that supports the --password-stdin
-# flag. The function will detect if pushing to public and adjust
-# accordingly. Note that the caller is still responsible for all flags
-# sent to oras (including --password-stdin!)
-function orasAuth () {
-    declare -a cmd=( ecr )
-
-    for arg in "$@"; do
-	if [[ "$arg" =~ public\.ecr\.aws ]]; then
-	    cmd=( ecr-public --region us-east-1 )
-	    break
-	fi
-    done
-
-    aws ${cmd[*]} get-login-password --profile ${PROFILE:-default} \
-	| ${BASE_DIRECTORY}/bin/oras "$*"
-}
-
+. "${BASE_DIRECTORY}/common.sh"
 cd ${BASE_DIRECTORY}/generatebundlefile/output
-orasAuth push --username AWS --password-stdin "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-21-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-orasAuth push --username AWS --password-stdin "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-21-latest" bundle.yaml
+awsAuth ${BASE_DIRECTORY}/bin/oras push --username AWS --password-stdin \
+    "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-21-${CODEBUILD_BUILD_NUMBER}" \
+    bundle.yaml
+awsAuth ${BASE_DIRECTORY}/bin/oras push --username AWS --password-stdin \
+    "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-21-latest" \
+    bundle.yaml
 
 # 1.22 Bundle Build
 cd ${BASE_DIRECTORY}/generatebundlefile
@@ -84,5 +69,9 @@ ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
     --key alias/${KMS_KEY}
 
 cd ${BASE_DIRECTORY}/generatebundlefile/output
-orasAuth push --username AWS --password-stdin "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-22-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-orasAuth push --username AWS --password-stdin "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-22-latest" bundle.yaml
+awsAuth ${BASE_DIRECTORY}/bin/oras push --username AWS --password-stdin \
+    "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-22-${CODEBUILD_BUILD_NUMBER}" \
+    bundle.yaml
+awsAuth ${BASE_DIRECTORY}/bin/oras push --username AWS --password-stdin \
+    "${IMAGE_REGISTRY}/eks-anywhere-packages-bundles:v1-22-latest" \
+    bundle.yaml


### PR DESCRIPTION
This extends the work performed in
https://github.com/aws/eks-anywhere-packages/pull/210 to use the
orasAuth function in more places. The calling convention has changed a
little, as the new awsAuth function no longer wraps the oras call, but
rather it calls whatever command is passed to it. This eliminates the
need for the awsAuth function to know anything about the paths where
binaries can be found.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
