### PR TITLE
Ensure that the output directory exists.

### DIFF
--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -78,5 +78,6 @@ endif
 
 .PHONY: oras-install
 oras-install:
+	mkdir -p $(REPO_ROOT)/bin
 	curl -L -s https://github.com/oras-project/oras/releases/download/v$(ORAS_VERSION)/oras_$(ORAS_VERSION)_$(ORAS_OSARCH).tar.gz \
 		| tar zx -C $(REPO_ROOT)/bin oras

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -31,7 +31,6 @@ ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
     --input ${BASE_DIRECTORY}/generatebundlefile/data/input_121.yaml \
     --key alias/${KMS_KEY}
 
-mkdir -p ${BASE_DIRECTORY}/bin
 make oras-install
 
 ECR_PASSWORD=$(aws ecr-public get-login-password --region us-east-1)

--- a/generatebundlefile/hack/release.sh
+++ b/generatebundlefile/hack/release.sh
@@ -50,7 +50,6 @@ ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
     --input ${BASE_DIRECTORY}/generatebundlefile/data/input_121_prod.yaml \
     --key alias/${KMS_KEY}
 
-mkdir -p ${BASE_DIRECTORY}/bin
 make oras-install
 
 ECR_PASSWORD=$(aws ecr-public get-login-password --region us-east-1 --profile ${PROFILE})


### PR DESCRIPTION
The creation of the directory is being performed in scripts, but they
shouldn't need to worry about things like this. Move it to the
Makefile where it belongs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
