### PR TITLE
Adding config, and images to bundle creation

### DIFF
--- a/generatebundlefile/bundle_types.go
+++ b/generatebundlefile/bundle_types.go
@@ -91,8 +91,14 @@ type Requires struct {
 }
 
 type RequiresSpec struct {
-	Images         []Image `json:"images,omitempty"`
-	Configurations []Tag   `json:"configurations,omitempty"`
+	Images         []Image         `json:"images,omitempty"`
+	Configurations []Configuration `json:"configurations,omitempty"`
+}
+
+type Configuration struct {
+	Name     string `json:"name,omitempty"`
+	Required bool   `json:"required,omitempty"`
+	Default  string `json:"default,omitempty"`
 }
 
 type Image struct {

--- a/generatebundlefile/helm.go
+++ b/generatebundlefile/helm.go
@@ -81,6 +81,10 @@ func UnTarHelmChart(chartRef, chartPath, dest string) error {
 		} else {
 			return errors.Errorf("failed to untar: a file or directory with the name %s already exists", dest)
 		}
+	} else {
+		if err != nil { // Checks directory check errors such as permission issues to read
+			return errors.Errorf("failed UnTarHelmChart: %w", err)
+		}
 	}
 	// Untar the files, and create the directory structure
 	return chartutil.ExpandFile(dest, chartRef)

--- a/generatebundlefile/helm.go
+++ b/generatebundlefile/helm.go
@@ -73,9 +73,6 @@ func UnTarHelmChart(chartRef, chartPath, dest string) error {
 		return fmt.Errorf("Empty input value given for UnTarHelmChart")
 	}
 	_, err := os.Stat(dest)
-	if err != nil {
-		return fmt.Errorf("Not valid File %w", err)
-	}
 	if os.IsNotExist(err) {
 		if _, err := os.Stat(chartPath); err != nil {
 			if err := os.MkdirAll(chartPath, 0755); err != nil {

--- a/generatebundlefile/input.go
+++ b/generatebundlefile/input.go
@@ -151,7 +151,6 @@ func (c *ecrPublicClient) NewBundleFromInput(Input *Input) (api.PackageBundleSpe
 		name = fmt.Sprintf("v1-%s-%s", version[1], name)
 	}
 	for _, org := range Input.Packages {
-		fmt.Printf("org=%v\n", org)
 		for _, project := range org.Projects {
 			bundlePkg, err := c.NewPackageFromInput(project)
 			if err != nil {

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -59,12 +59,15 @@ func main() {
 				"public.ecr.aws": DockerAuthRegistry{clients.ecrPublicClient.AuthConfig},
 			},
 		}
-		authFile, err := NewAuthFile(dockerStruct)
-		if err != nil || authFile == "" {
+		dockerAuth, err := NewAuthFile(dockerStruct)
+		if err != nil || dockerAuth.Authfile == "" {
 			BundleLog.Error(err, "Unable create AuthFile")
 		}
-		defer os.Remove(authFile)
-		err = clients.PromoteHelmChart(o.promote, authFile, false)
+		err = dockerAuth.Remove()
+		if err != nil {
+			BundleLog.Error(err, "Unable remove AuthFile")
+		}
+		err = clients.PromoteHelmChart(o.promote, dockerAuth.Authfile, false)
 		if err != nil {
 			BundleLog.Error(err, "Unable to promote Helm Chart")
 		}
@@ -142,12 +145,16 @@ func main() {
 				fmt.Sprintf("public.ecr.aws/%s", clients.ecrPublicClient.SourceRegistry): DockerAuthRegistry{clients.ecrPublicClient.AuthConfig},
 			},
 		}
-		authFile, err := NewAuthFile(dockerReleaseStruct)
-		if err != nil || authFile == "" {
+
+		dockerAuth, err := NewAuthFile(dockerReleaseStruct)
+		if err != nil || dockerAuth.Authfile == "" {
 			BundleLog.Error(err, "Unable create AuthFile")
 		}
-		defer os.Remove(authFile)
-		driver, err := NewHelm(BundleLog, authFile)
+		err = dockerAuth.Remove()
+		if err != nil {
+			BundleLog.Error(err, "Unable remove AuthFile")
+		}
+		driver, err := NewHelm(BundleLog, dockerAuth.Authfile)
 		if err != nil {
 			BundleLog.Error(err, "Unable to create Helm driver")
 			os.Exit(1)
@@ -238,12 +245,16 @@ func main() {
 					"public.ecr.aws": DockerAuthRegistry{clients.ecrPublicClientRelease.AuthConfig},
 				},
 			}
-			authFile, err = NewAuthFile(dockerReleaseStruct)
-			if err != nil || authFile == "" {
+			dockerAuth, err = NewAuthFile(dockerReleaseStruct)
+			if err != nil || dockerAuth.Authfile == "" {
 				BundleLog.Error(err, "Unable create AuthFile")
 			}
+			err = dockerAuth.Remove()
+			if err != nil {
+				BundleLog.Error(err, "Unable remove AuthFile")
+			}
 			for _, charts := range addOnBundleSpec.Packages {
-				err = clients.PromoteHelmChart(charts.Source.Repository, authFile, true)
+				err = clients.PromoteHelmChart(charts.Source.Repository, dockerAuth.Authfile, true)
 			}
 			return
 		}

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	sig "github.com/aws/eks-anywhere-packages/pkg/signature"
 )
 
@@ -134,12 +135,84 @@ func main() {
 			BundleLog.Error(err, "Unable to validate input file")
 			os.Exit(1)
 		}
+
+		// Create Authfile for Helm Driver
+		dockerReleaseStruct := &DockerAuth{
+			Auths: map[string]DockerAuthRegistry{
+				fmt.Sprintf("public.ecr.aws/%s", clients.ecrPublicClient.SourceRegistry): DockerAuthRegistry{clients.ecrPublicClient.AuthConfig},
+			},
+		}
+		authFile, err := NewAuthFile(dockerReleaseStruct)
+		if err != nil || authFile == "" {
+			BundleLog.Error(err, "Unable create AuthFile")
+		}
+		defer os.Remove(authFile)
+		driver, err := NewHelm(BundleLog, authFile)
+		if err != nil {
+			BundleLog.Error(err, "Unable to create Helm driver")
+			os.Exit(1)
+		}
+
 		BundleLog.Info("In Progress: Populating Bundles and looking up Sha256 tags")
 		addOnBundleSpec, name, err := clients.ecrPublicClient.NewBundleFromInput(Inputs)
 		if err != nil {
 			BundleLog.Error(err, "Unable to create CRD skaffolding of AddoOBundle from input file")
 			os.Exit(1)
 		}
+
+		// Pull Helm charts for all the populated helm fields of the bundles.
+		for _, charts := range addOnBundleSpec.Packages {
+			fullURI := fmt.Sprintf("%s/%s", charts.Source.Registry, charts.Source.Repository)
+			chartPath, err := driver.PullHelmChart(fullURI, charts.Source.Versions[0].Name)
+			if err != nil {
+				BundleLog.Error(err, "Unable to pull Helm Chart %s", charts.Source.Repository)
+				os.Exit(1)
+			}
+			chartName, helmname, err := splitECRName(fullURI)
+			if err != nil {
+				BundleLog.Error(err, "Unable to split helm hame, invalid format")
+				os.Exit(1)
+			}
+			dest := filepath.Join(pwd, chartName)
+			err = UnTarHelmChart(chartPath, chartName, dest)
+			if err != nil {
+				BundleLog.Error(err, "Unable to untar Helm Chart")
+				os.Exit(1)
+			}
+			// Check for requires.yaml in the unpacked helm chart
+			helmDest := filepath.Join(pwd, chartName, helmname)
+			f, err := hasRequires(helmDest)
+			if err != nil {
+				BundleLog.Error(err, "Helm chart doesn't have requires.yaml inside")
+				os.Exit(1)
+			}
+			// Unpack requires.yaml into a GO struct
+			helmRequires, err := validateHelmRequires(f)
+			if err != nil {
+				BundleLog.Error(err, "Unable to parse requires.yaml file to Go Struct")
+				os.Exit(1)
+			}
+			// Populate Images to bundle spec from Requires.yaml
+			helmImage := []api.VersionImages{}
+			for _, image := range helmRequires.Spec.Images {
+				helmImage = append(helmImage, api.VersionImages{
+					Repository: image.Repository,
+					Digest:     image.Digest,
+				})
+			}
+			charts.Source.Versions[0].Images = helmImage
+			// Populate Configurations to bundle spec from Requires.yaml
+			helmConfiguration := []api.VersionConfiguration{}
+			for _, config := range helmRequires.Spec.Configurations {
+				helmConfiguration = append(helmConfiguration, api.VersionConfiguration{
+					Name:     config.Name,
+					Required: config.Required,
+					Default:  config.Default,
+				})
+			}
+			charts.Source.Versions[0].Configurations = helmConfiguration
+		}
+
 		// Write list of bundle structs into Bundle CRD files
 		BundleLog.Info("In Progress: Writing bundle to output")
 		bundle := AddMetadata(addOnBundleSpec, name)
@@ -159,17 +232,16 @@ func main() {
 			if err != nil {
 				BundleLog.Error(err, "Unable create find Public ECR URI for destination account")
 			}
-			dockerReleaseStruct := &DockerAuth{
+			dockerReleaseStruct = &DockerAuth{
 				Auths: map[string]DockerAuthRegistry{
 					fmt.Sprintf("public.ecr.aws/%s", clients.ecrPublicClient.SourceRegistry): DockerAuthRegistry{clients.ecrPublicClient.AuthConfig},
 					"public.ecr.aws": DockerAuthRegistry{clients.ecrPublicClientRelease.AuthConfig},
 				},
 			}
-			authFile, err := NewAuthFile(dockerReleaseStruct)
+			authFile, err = NewAuthFile(dockerReleaseStruct)
 			if err != nil || authFile == "" {
 				BundleLog.Error(err, "Unable create AuthFile")
 			}
-			defer os.Remove(authFile)
 			for _, charts := range addOnBundleSpec.Packages {
 				err = clients.PromoteHelmChart(charts.Source.Repository, authFile, true)
 			}


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Adding in the Config/Images to bundle creation, requires using the helm driver during bundle creation, so moved around the authfile creation a bit so it wouldn't be duplicated on releases too. 

Everything is tested in dev account pipeline, although my dev harbor build is older so it doesn't have all the config values.

```
apiVersion: packages.eks.amazonaws.com/v1alpha1
kind: PackageBundle
metadata:
  annotations:
    eksa.aws.com/excludes: LnNwZWMucGFja2FnZXNbXS5zb3VyY2UucmVnaXN0cnkKLnNwZWMucGFja2FnZXNbXS5zb3VyY2UucmVwb3NpdG9yeQo=
    eksa.aws.com/signature: MEQCIGXNYvwgo38cwuXl7H1ybG9uDfpmXp68hbkVn+/LXG5qAiBpziFMbIOdmiIvLIjcCc9D7gg30cNxfDA9Eg/u8YALMw==
  name: v1-21-30
  namespace: eksa-packages
spec:
  packages:
  - name: hello-eks-anywhere
    source:
      registry: public.ecr.aws/f5b7k4z5
      repository: hello-eks-anywhere
      versions:
      - configurations:
        - default: ""
          name: sourceRegistry
          required: false
        - default: Amazon EKS Anywhere
          name: title
          required: false
        - default: Run EKS in your datacenter
          name: subtitle
          required: false
        digest: sha256:ded8e6e3be2cabe38d08b14b09250992127906c466a4483b14e6254978d2e5f6
        images:
        - digest: sha256:219a8e6d877bcef52126946f76b70c589525dd8b188a7551dc06a1898c415900
          repository: hello-eks-anywhere
        name: 0.1.1-d03bf631cfddbad84cf12f5041da12ad3c50d899
  - name: harbor
    source:
      registry: public.ecr.aws/f5b7k4z5
      repository: harbor/harbor-helm
      versions:
      - configurations:
        - default: ""
          name: sourceRegistry
          required: false
        - default: ""
          name: secretKey
          required: false
        digest: sha256:ed582b64cca5db373b9d50b33001adfcd8dcd42bd5256e75608fbff906651b1e
        images:
        - digest: sha256:578aa02a58d33aea44c3340f66c81547cd369bb76652224d6e5dfbf2a879232f
          repository: harbor/harbor-core
        - digest: sha256:77b4a1fcb1097977da1e5ee5e372d81a88f9ac823cad05ebff547b118147b88f
          repository: harbor/harbor-db
        - digest: sha256:b4550a5358003fed41a089168c9a2834b817ec449e737e69e640944bf298bf3f
          repository: harbor/harbor-exporter
        - digest: sha256:cab7ad27df9921baa9a871e66cc2340fca56a6e8bbe70fac7af762e5db8fc339
          repository: harbor/harbor-jobservice
        - digest: sha256:8162f66122c9abc7e6b0c27df6e69fc805b1479aadf5f5dbf2d3a058eae222d6
          repository: harbor/harbor-nginx
        - digest: sha256:675c1ba6403b7f8d9b87dd300b492ef471fc42132854c0794b8aad5f56703001
          repository: harbor/harbor-portal
        - digest: sha256:9b1eeb6b171aa379d26ecdc0273c55e61af5e5a1ad4f3bbcebb3d173b20981ae
          repository: harbor/harbor-redis
        - digest: sha256:0a7b3bcf7b779ba829d3f87d1187be2450a43c49c2774799d3d98581feb843f0
          repository: harbor/harbor-registry
        - digest: sha256:867941e44363f67ccf3d87031530d4fe8879bf6cbbf7da8a127c87a6070341e3
          repository: harbor/harbor-registryctl
        name: 2.5.0-76bee84aeb63dee2507413dae39fea7c7c4ffef3
```


