### PR TITLE
Make registry optional in bundle

### DIFF
--- a/api/v1alpha1/packagebundle_types.go
+++ b/api/v1alpha1/packagebundle_types.go
@@ -53,9 +53,9 @@ type BundlePackage struct {
 
 // BundlePackageSource identifies the location of a package.
 type BundlePackageSource struct {
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Registry in which the package is found.
-	Registry string `json:"registry"`
+	Registry string `json:"registry,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Repository within the Registry where the package is found.

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundles.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundles.yaml
@@ -125,7 +125,6 @@ spec:
                           minItems: 1
                           type: array
                       required:
-                      - registry
                       - repository
                       - versions
                       type: object
@@ -230,7 +229,6 @@ spec:
                               minItems: 1
                               type: array
                           required:
-                          - registry
                           - repository
                           - versions
                           type: object

--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -59,7 +59,6 @@ func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *api.Packag
 				{
 					Name: "sample-package",
 					Source: api.BundlePackageSource{
-						Registry:   "sample-Registry",
 						Repository: "sample-Repository",
 						Versions: []api.SourceVersion{
 							{
@@ -86,7 +85,6 @@ func (c *ecrPublicClient) NewPackageFromInput(project Project) (*api.BundlePacka
 	bundlePkg := &api.BundlePackage{
 		Name: project.Name,
 		Source: api.BundlePackageSource{
-			Registry:   project.Registry,
 			Repository: project.Repository,
 			Versions:   versionList,
 		},

--- a/generatebundlefile/bundle_test.go
+++ b/generatebundlefile/bundle_test.go
@@ -39,7 +39,6 @@ func TestNewBundleGenerate(t *testing.T) {
 						{
 							Name: "sample-package",
 							Source: api.BundlePackageSource{
-								Registry:   "sample-Registry",
 								Repository: "sample-Repository",
 								Versions: []api.SourceVersion{
 									{
@@ -81,7 +80,6 @@ func TestNewPackageFromInput(t *testing.T) {
 			testname: "Test no tags",
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
-				Registry:   "public.ecr.aws/f5b7k4z5",
 				Repository: "hello-eks-anywhere",
 				Versions:   []Tag{},
 			},
@@ -91,7 +89,6 @@ func TestNewPackageFromInput(t *testing.T) {
 			testname: "Test named tag",
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
-				Registry:   "public.ecr.aws/f5b7k4z5",
 				Repository: "hello-eks-anywhere",
 				Versions: []Tag{
 					{Name: testTagBundle},
@@ -101,7 +98,6 @@ func TestNewPackageFromInput(t *testing.T) {
 			wantBundle: &api.BundlePackage{
 				Name: "hello-eks-anywhere",
 				Source: api.BundlePackageSource{
-					Registry:   "public.ecr.aws/f5b7k4z5",
 					Repository: "hello-eks-anywhere",
 					Versions: []api.SourceVersion{
 						{
@@ -116,7 +112,6 @@ func TestNewPackageFromInput(t *testing.T) {
 			testname: "Test 'latest' tag",
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
-				Registry:   "public.ecr.aws/f5b7k4z5",
 				Repository: "hello-eks-anywhere",
 				Versions: []Tag{
 					{Name: "latest"},
@@ -126,7 +121,6 @@ func TestNewPackageFromInput(t *testing.T) {
 			wantBundle: &api.BundlePackage{
 				Name: "hello-eks-anywhere",
 				Source: api.BundlePackageSource{
-					Registry:   "public.ecr.aws/f5b7k4z5",
 					Repository: "hello-eks-anywhere",
 					Versions: []api.SourceVersion{
 						{


### PR DESCRIPTION
The registry in the bundle should not be provided unless we want to override it. This change is to support private registries.
