### PR TITLE
Use get bundle list in manager

### DIFF
--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -147,14 +147,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	r.Log.Info("Add/Update:", "bundle", pkgBundle)
-
-	allBundles := &api.PackageBundleList{}
-	err := r.List(ctx, allBundles)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("listing package bundles: %s", err)
-	}
-
-	change, err := r.bundleManager.Update(ctx, pkgBundle, allBundles.Items)
+	change, err := r.bundleManager.Update(ctx, pkgBundle)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("package bundle update: %s", err)
 	}

--- a/controllers/packagebundle_controller_test.go
+++ b/controllers/packagebundle_controller_test.go
@@ -36,7 +36,6 @@ func TestPackageBundleReconciler_ReconcileAddUpdate(t *testing.T) {
 	mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 	mockClient.EXPECT().Get(ctx, request.NamespacedName, gomock.Any()).Return(nil)
 	mockClient.EXPECT().Status().Return(statusWriter)
-	mockClient.EXPECT().List(ctx, gomock.Any()).Return(nil)
 	statusWriter.EXPECT().Update(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	bm := bundlefake.NewBundleManager()
 	bm.FakeUpdate = true
@@ -74,7 +73,6 @@ func TestPackageBundleReconciler_ReconcileIgnored(t *testing.T) {
 	mockClient := mocks.NewMockClient(gomock.NewController(t))
 	mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
 	mockClient.EXPECT().Get(ctx, request.NamespacedName, gomock.Any()).Return(nil)
-	mockClient.EXPECT().List(ctx, gomock.Any()).Return(nil)
 	bm := bundlefake.NewBundleManager()
 	bm.FakeUpdate = false
 	sut := controllers.NewPackageBundleReconciler(mockClient, nil, mockBundleClient, bm, logr.Discard())

--- a/pkg/bundle/fake/manager.go
+++ b/pkg/bundle/fake/manager.go
@@ -33,7 +33,6 @@ func (bm *FakeBundleManager) DownloadBundle(ctx context.Context, ref string) (
 	return bm.FakeDownloadBundle, nil
 }
 
-func (bm *FakeBundleManager) Update(ctx context.Context, bundle *api.PackageBundle,
-	allBundles []api.PackageBundle) (bool, error) {
+func (bm *FakeBundleManager) Update(ctx context.Context, bundle *api.PackageBundle) (bool, error) {
 	return bm.FakeUpdate, nil
 }

--- a/pkg/bundle/mocks/manager.go
+++ b/pkg/bundle/mocks/manager.go
@@ -78,18 +78,18 @@ func (mr *MockManagerMockRecorder) SortBundlesDescending(bundles interface{}) *g
 }
 
 // Update mocks base method.
-func (m *MockManager) Update(ctx context.Context, newBundle *v1alpha1.PackageBundle, allBundles []v1alpha1.PackageBundle) (bool, error) {
+func (m *MockManager) Update(ctx context.Context, newBundle *v1alpha1.PackageBundle) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, newBundle, allBundles)
+	ret := m.ctrl.Call(m, "Update", ctx, newBundle)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockManagerMockRecorder) Update(ctx, newBundle, allBundles interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Update(ctx, newBundle interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), ctx, newBundle, allBundles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), ctx, newBundle)
 }
 
 // UpdateLatestBundle mocks base method.


### PR DESCRIPTION
Use of bundle list in controller was not filtering by namespace and this change uses a common method to get the list.

Slight added benefit that we don't get the bundle list unless we need to.

Closes: #237 