### PR TITLE
Fixing pipeline removing registry from bundle output

### DIFF
--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -86,6 +86,7 @@ func (c *ecrPublicClient) NewPackageFromInput(project Project) (*api.BundlePacka
 		Name: project.Name,
 		Source: api.BundlePackageSource{
 			Repository: project.Repository,
+			Registry:   project.Registry,
 			Versions:   versionList,
 		},
 	}

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -168,11 +168,11 @@ func main() {
 		}
 
 		// Pull Helm charts for all the populated helm fields of the bundles.
-		for _, charts := range addOnBundleSpec.Packages {
+		for i, charts := range addOnBundleSpec.Packages {
 			fullURI := fmt.Sprintf("%s/%s", charts.Source.Registry, charts.Source.Repository)
 			chartPath, err := driver.PullHelmChart(fullURI, charts.Source.Versions[0].Name)
 			if err != nil {
-				BundleLog.Error(err, "Unable to pull Helm Chart %s", charts.Source.Repository)
+				BundleLog.Error(err, "Unable to pull Helm Chart")
 				os.Exit(1)
 			}
 			chartName, helmname, err := splitECRName(fullURI)
@@ -218,6 +218,9 @@ func main() {
 				})
 			}
 			charts.Source.Versions[0].Configurations = helmConfiguration
+
+			// Set the registry to empty string since we pull it from the PackageBundleController instead now.
+			addOnBundleSpec.Packages[i].Source.Registry = ""
 		}
 
 		// Write list of bundle structs into Bundle CRD files


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

We keep the registry in the PackageBundleSpec until after the lookups are complete, then set it to empty string before doing the signature, and writing to yaml.