### PR TITLE
Temp-fix for config types in marshaling

### DIFF
--- a/api/v1alpha1/packagebundle_types.go
+++ b/api/v1alpha1/packagebundle_types.go
@@ -104,7 +104,7 @@ type VersionConfiguration struct {
 	Required bool `json:"required"`
 
 	// Default is the name of the configuration
-	Default string `json:"default"`
+	Default interface{} `json:"default"`
 }
 
 // PackageBundleStatus defines the observed state of PackageBundle

--- a/generatebundlefile/bundle_types.go
+++ b/generatebundlefile/bundle_types.go
@@ -96,9 +96,9 @@ type RequiresSpec struct {
 }
 
 type Configuration struct {
-	Name     string `json:"name,omitempty"`
-	Required bool   `json:"required,omitempty"`
-	Default  string `json:"default,omitempty"`
+	Name     string      `json:"name,omitempty"`
+	Required bool        `json:"required,omitempty"`
+	Default  interface{} `json:"default,omitempty"`
 }
 
 type Image struct {


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Config Values for Helm charts come in multiple different types, and it's breaking the marshaling trying since things are currently only done as strings. This is a temp fix until we figure out a better long term solution for config checking.

https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/goharbor/harbor/helm/requires-config.yaml#L26


Created an issue for follow-up on this with a better long term solution. https://github.com/aws/eks-anywhere-packages/issues/270