### PR TITLE
Make bundle print more reasonable

### DIFF
--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -146,7 +146,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	r.Log.Info("Add/Update:", "bundle", pkgBundle)
+	r.Log.Info("Add/Update:", "bundle", req.NamespacedName)
 	change, err := r.bundleManager.Update(ctx, pkgBundle)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("package bundle update: %s", err)


### PR DESCRIPTION
Bundle is too big to print out

Closes: https://github.com/aws/eks-anywhere-packages/issues/275

