### PR TITLE
Ignore all packages outside of namespace

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -127,6 +127,10 @@ func (r *PackageReconciler) mapBundleChangesToPackageUpdate(_ client.Object) (re
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.Namespace != api.PackageNamespace {
+		r.Log.V(6).Info("Ignoring:", "NamespacedName", req.NamespacedName)
+		return ctrl.Result{Requeue: false}, nil
+	}
 	r.Log.V(6).Info("Reconcile:", "NamespacedName", req.NamespacedName)
 
 	// Get the CRD object from the k8s API.
@@ -141,9 +145,8 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		if req.Namespace == api.PackageNamespace {
-			managerContext.SetUninstalling(req.Name)
-		}
+
+		managerContext.SetUninstalling(req.Name)
 	} else {
 		bundle, err := r.bundleClient.GetActiveBundle(ctx)
 		if err != nil {

--- a/controllers/package_controller_test.go
+++ b/controllers/package_controller_test.go
@@ -266,7 +266,7 @@ func TestReconcile(t *testing.T) {
 
 const (
 	name      string = "Yoda"
-	namespace string = "Jedi"
+	namespace string = "eksa-packages"
 )
 
 type testFixtures struct {


### PR DESCRIPTION
I noticed a problem deleting a package outside of our namespace caused it to requeue forever. It is just easier to completely ignore forever resources out of our namespace.
