### PR TITLE
Log bogus package name

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -158,7 +158,8 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		managerContext.Source, err = bundle.FindSource(pkgName, targetVersion)
 		managerContext.Package.Status.TargetVersion = printableTargetVersion(managerContext.Source, targetVersion)
 		if err != nil {
-			managerContext.Package.Status.Detail = fmt.Sprintf("Package %s@%s is not in the active bundle (%s). Did you forget to activate the new bundle?", pkgName, targetVersion, bundle.ObjectMeta.Name)
+			managerContext.Package.Status.Detail = fmt.Sprintf("Package %s@%s is not in the active bundle (%s).", pkgName, targetVersion, bundle.ObjectMeta.Name)
+			r.Log.Info(managerContext.Package.Status.Detail)
 			if err = r.Status().Update(ctx, &managerContext.Package); err != nil {
 				return ctrl.Result{RequeueAfter: managerContext.RequeueAfter}, err
 			}

--- a/controllers/package_controller_test.go
+++ b/controllers/package_controller_test.go
@@ -191,7 +191,7 @@ func TestReconcile(t *testing.T) {
 
 		pkg.Spec.PackageVersion = "2.0.0"
 		pkg.Status.TargetVersion = "2.0.0"
-		pkg.Status.Detail = fmt.Sprintf("Package %s@%s is not in the active bundle (%s). Did you forget to activate the new bundle?", pkg.Spec.PackageName, pkg.Spec.PackageVersion, "fake bundle")
+		pkg.Status.Detail = fmt.Sprintf("Package %s@%s is not in the active bundle (%s).", pkg.Spec.PackageName, pkg.Spec.PackageVersion, "fake bundle")
 		status.EXPECT().
 			Update(ctx, pkg).
 			Return(testErr)


### PR DESCRIPTION
I was very confused why my package wasn't installing and I was just looking at the logs instead of the status.
```
1.656686978400248e+09	INFO	Package.Package	Package bogus-hello-eks-anywhere@latest is not in the active bundle (v1-21-32)
```

I also reduced the status to just the facts, leave the rest for a troubleshooting document
