### PR TITLE
Add error if there is no active bundle

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -150,7 +150,12 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else {
 		bundle, err := r.bundleClient.GetActiveBundle(ctx)
 		if err != nil {
-			return ctrl.Result{RequeueAfter: retryLong}, err
+			r.Log.Error(err, "Getting active bundle")
+			managerContext.Package.Status.Detail = err.Error()
+			if err = r.Status().Update(ctx, &managerContext.Package); err != nil {
+				return ctrl.Result{RequeueAfter: retryLong}, err
+			}
+			return ctrl.Result{RequeueAfter: retryLong}, nil
 		}
 
 		targetVersion := managerContext.Package.Spec.PackageVersion

--- a/controllers/package_controller_test.go
+++ b/controllers/package_controller_test.go
@@ -118,6 +118,9 @@ func TestReconcile(t *testing.T) {
 
 		testErr := errors.New("active bundle test error")
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(nil, testErr)
+		status := tf.mockStatusWriter()
+		status.EXPECT().Update(ctx, gomock.Any()).Return(nil)
+		tf.ctrlClient.EXPECT().Status().Return(status)
 
 		fn, pkg := tf.mockGetFnPkg()
 		tf.ctrlClient.EXPECT().
@@ -127,8 +130,8 @@ func TestReconcile(t *testing.T) {
 		sut := tf.newReconciler()
 		req := tf.mockRequest()
 		got, err := sut.Reconcile(ctx, req)
-		if err == nil || err.Error() != "active bundle test error" {
-			t.Fatalf("expected test error, got nil")
+		if err != nil {
+			t.Errorf("expected <nil> got <%s>", err)
 		}
 
 		expected := retryLong

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -74,6 +74,10 @@ func (bc *bundleClient) GetActiveBundle(ctx context.Context) (activeBundle *api.
 		return nil, err
 	}
 
+	if pbc.Spec.ActiveBundle == "" {
+		return nil, fmt.Errorf("There is no activeBundle set in PackageBundleController")
+	}
+
 	nn := types.NamespacedName{
 		Namespace: api.PackageNamespace,
 		Name:      pbc.Spec.ActiveBundle,


### PR DESCRIPTION
The error message for no active bundle was very lame and not clear. Previously:
```
"error": "PackageBundle.packages.eks.amazonaws.com \"\" not found"}
```

With this change:
```
{"error": "There is no activeBundle set in PackageBundleController"}
```
