### PR TITLE
Removing go compat now we're on GO 1.17

### DIFF
--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -44,7 +44,7 @@ clean: ## Clean output directory, and the built binary
 
 build: ## Build release binary.
 	mkdir -p $(REPO_ROOT)/generatebundlefile/bin
-	$(GO) mod tidy -compat=1.17
+	$(GO) mod tidy
 	$(GO) build -o $(REPO_ROOT)/generatebundlefile/bin/generatebundlefile *.go
 
 build-linux:


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
