### PR TITLE
Private-bundle support

### DIFF
--- a/generatebundlefile/bundle_test.go
+++ b/generatebundlefile/bundle_test.go
@@ -66,6 +66,8 @@ func TestNewBundleGenerate(t *testing.T) {
 var testTagBundle string = "0.1.0_c4e25cb42e9bb88d2b8c2abfbde9f10ade39b214"
 var testShaBundle string = "sha256:d5467083c4d175e7e9bba823e95570d28fff86a2fbccb03f5ec3093db6f039be"
 var testImageMediaType string = "application/vnd.oci.image.manifest.v1+json"
+var testRegistryId string = "public.ecr.aws/eks-anywhere"
+var testRepositoryName string = "hello-eks-anywhere"
 
 func TestNewPackageFromInput(t *testing.T) {
 	client := newMockPublicRegistryClientBundle(nil)
@@ -81,6 +83,7 @@ func TestNewPackageFromInput(t *testing.T) {
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
 				Repository: "hello-eks-anywhere",
+				Registry:   "public.ecr.aws/eks-anywhere",
 				Versions:   []Tag{},
 			},
 			wantErr: true,
@@ -90,6 +93,7 @@ func TestNewPackageFromInput(t *testing.T) {
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
 				Repository: "hello-eks-anywhere",
+				Registry:   "public.ecr.aws/eks-anywhere",
 				Versions: []Tag{
 					{Name: testTagBundle},
 				},
@@ -99,6 +103,7 @@ func TestNewPackageFromInput(t *testing.T) {
 				Name: "hello-eks-anywhere",
 				Source: api.BundlePackageSource{
 					Repository: "hello-eks-anywhere",
+					Registry:   "public.ecr.aws/eks-anywhere",
 					Versions: []api.SourceVersion{
 						{
 							Name:   testTagBundle,
@@ -113,6 +118,7 @@ func TestNewPackageFromInput(t *testing.T) {
 			testproject: Project{
 				Name:       "hello-eks-anywhere",
 				Repository: "hello-eks-anywhere",
+				Registry:   "public.ecr.aws/eks-anywhere",
 				Versions: []Tag{
 					{Name: "latest"},
 				},
@@ -122,6 +128,7 @@ func TestNewPackageFromInput(t *testing.T) {
 				Name: "hello-eks-anywhere",
 				Source: api.BundlePackageSource{
 					Repository: "hello-eks-anywhere",
+					Registry:   "public.ecr.aws/eks-anywhere",
 					Versions: []api.SourceVersion{
 						{
 							Name:   testTagBundle,
@@ -139,9 +146,9 @@ func TestNewPackageFromInput(t *testing.T) {
 					publicRegistryClient: client,
 				},
 			}
-			got, err := clients.ecrPublicClient.NewPackageFromInput(tc.testproject)
+			got, err := clients.NewPackageFromInput(tc.testproject)
 			if (err != nil) != tc.wantErr {
-				tt.Fatalf("NewPackageFromInput() error = %v, wantErr %v", err, tc.wantErr)
+				tt.Fatalf("NewPackageFromInput() error = %v, wantErr %v got %v", err, tc.wantErr, got)
 			}
 			if !reflect.DeepEqual(got, tc.wantBundle) {
 				tt.Fatalf("NewPackageFromInput() = %#v\n\n\n, want %#v", got, tc.wantBundle)
@@ -304,6 +311,8 @@ func (r *mockPublicRegistryClientBundle) DescribeImages(ctx context.Context, par
 				ImageTags:              []string{testTagBundle},
 				ImageManifestMediaType: &testImageMediaType,
 				ImagePushedAt:          &testImagePushedAt,
+				RegistryId:             &testRegistryId,
+				RepositoryName:         &testRepositoryName,
 			},
 		},
 	}, nil

--- a/generatebundlefile/data/input_local.yaml
+++ b/generatebundlefile/data/input_local.yaml
@@ -1,4 +1,3 @@
-# This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
 name: "v1-21-1001"
 kubernetesVersion: "1.21"
 packages:
@@ -6,6 +5,6 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/o2o7p9u3
+        registry: 646717423341.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.1.1-fa2f6f68e65b862a59dcb198a9655037e9ea45c0
+            - name: latest

--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
+	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/pkg/errors"
 )
 
@@ -68,26 +68,77 @@ func (c *ecrClient) Describe(describeInput *ecr.DescribeImagesInput) ([]ecrtypes
 	return images, nil
 }
 
-// getLastestHelmTagandSha Iterates list of ECR Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
-func getLastestHelmTagandSha(details []ecrtypes.ImageDetail) (string, string, error) {
-	if len(details) == 0 {
-		return "", "", fmt.Errorf("no details provided")
-	}
-	var latest ecrtypes.ImageDetail
-	latest.ImagePushedAt = &time.Time{}
-	for _, detail := range details {
-		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 || *detail.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" {
+// GetShaForInputs returns a list of an images version/sha for given inputs to lookup
+func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error) {
+	sourceVersion := []api.SourceVersion{}
+	for _, tag := range project.Versions {
+		if !strings.Contains(tag.Name, "latest") {
+			var imagelookup []ecrtypes.ImageIdentifier
+			imagelookup = append(imagelookup, ecrtypes.ImageIdentifier{ImageTag: &tag.Name})
+			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{
+				RepositoryName: aws.String(project.Repository),
+				ImageIds:       imagelookup,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
+			}
+			for _, images := range ImageDetails {
+				if *images.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" || len(images.ImageTags) == 0 {
+					continue
+				}
+				if len(images.ImageTags) == 1 {
+					v := &api.SourceVersion{Name: tag.Name, Digest: *images.ImageDigest}
+					sourceVersion = append(sourceVersion, *v)
+					continue
+				}
+			}
+		}
+		//
+		if tag.Name == "latest" {
+			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{
+				RepositoryName: aws.String(project.Repository),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
+			}
+			var images []ImageDetailsBothECR
+			for _, image := range ImageDetails {
+				details, _ := createECRImageDetails(ImageDetailsECR{PrivateImageDetails: image})
+				images = append(images, details)
+			}
+			sha, err := getLastestImageSha(images)
+			if err != nil {
+				return nil, err
+			}
+			sourceVersion = append(sourceVersion, *sha)
 			continue
 		}
-		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
-			latest = detail
+		//
+		if strings.Contains(tag.Name, "-latest") {
+			regex := regexp.MustCompile(`-latest`)
+			splitVersion := regex.Split(tag.Name, -1) //extract out the version without the latest
+			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{
+				RepositoryName: aws.String(project.Repository),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
+			}
+			var images []ImageDetailsBothECR
+			for _, image := range ImageDetails {
+				details, _ := createECRImageDetails(ImageDetailsECR{PrivateImageDetails: image})
+				images = append(images, details)
+			}
+			filteredImageDetails := ImageTagFilter(images, splitVersion[0])
+			sha, err := getLastestImageSha(filteredImageDetails)
+			if err != nil {
+				return nil, err
+			}
+			sourceVersion = append(sourceVersion, *sha)
+			continue
 		}
 	}
-	// Check if latest is equal to empty struct, and return error if that's the case.
-	if reflect.DeepEqual(latest, ecrtypes.ImageDetail{}) {
-		return "", "", fmt.Errorf("error no images found")
-	}
-	return latest.ImageTags[0], *latest.ImageDigest, nil
+	sourceVersion = removeDuplicates(sourceVersion)
+	return sourceVersion, nil
 }
 
 // tagFromSha Looks up the Tag of an ECR artifact from a sha
@@ -166,10 +217,15 @@ func (c *SDKClients) getNameAndVersion(s, accountID string) (string, string, str
 		if err != nil {
 			return "", "", "", err
 		}
-		version, sha, err = getLastestHelmTagandSha(ImageDetails)
-		if err != nil {
-			return "", "", "", err
+		var images []ImageDetailsBothECR
+		for _, image := range ImageDetails {
+			details, err := createECRImageDetails(ImageDetailsECR{PrivateImageDetails: image})
+			if err != nil {
+				return "", "", "", err
+			}
+			images = append(images, details)
 		}
+		version, sha, err = getLastestHelmTagandSha(images)
 		ecrname := fmt.Sprintf("%s.dkr.ecr.us-west-2.amazonaws.com/%s", accountID, name)
 		return ecrname, version, sha, err
 	}

--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -127,7 +127,7 @@ func createECRImageDetails(images ImageDetailsECR) (ImageDetailsBothECR, error) 
 	t := &ImageDetailsBothECR{}
 	//Check for empty structs, if non empty copy to new common struct for ECR imagedetails.
 	if reflect.DeepEqual(images.PublicImageDetails, ecrpublictypes.ImageDetail{}) {
-		if images.PrivateImageDetails.ImageDigest != nil && images.PrivateImageDetails.ImagePushedAt != nil && len(images.PrivateImageDetails.ImageTags) > 0 && images.PrivateImageDetails.RegistryId != nil && images.PrivateImageDetails.RepositoryName != nil {
+		if images.PrivateImageDetails.ImageDigest != nil && images.PrivateImageDetails.ImagePushedAt != nil && images.PrivateImageDetails.RegistryId != nil && images.PrivateImageDetails.RepositoryName != nil {
 			copier.Copy(&t, &images.PrivateImageDetails)
 			return *t, nil
 		}

--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -3,8 +3,13 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"reflect"
 	"strings"
+	"time"
 
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	ecrpublictypes "github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	"github.com/jinzhu/copier"
 	"github.com/pkg/errors"
 
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
@@ -75,4 +80,103 @@ func splitECRName(s string) (string, string, error) {
 		return fmt.Sprintf("%s/%s", chartNameList[1], chartNameList[2]), chartNameList[2], nil
 	}
 	return "", "", fmt.Errorf("Error: %s", "Failed parsing chartName, check the input URI is a valid ECR URI")
+}
+
+// imageTagFilter is used when filtering a list of images for a specific tag or tag substring
+func ImageTagFilter(details []ImageDetailsBothECR, version string) []ImageDetailsBothECR {
+	var filteredDetails []ImageDetailsBothECR
+	for _, detail := range details {
+		for _, tag := range detail.ImageTags {
+			if strings.Contains(tag, version) {
+				filteredDetails = append(filteredDetails, detail)
+			}
+		}
+	}
+	return filteredDetails
+}
+
+type ImageDetailsECR struct {
+	PrivateImageDetails ecrtypes.ImageDetail
+	PublicImageDetails  ecrpublictypes.ImageDetail
+}
+
+// ImageDetailsBothECR is used so we can share some functions between private and public ECR bundle creation.
+type ImageDetailsBothECR struct {
+	// The sha256 digest of the image manifest.
+	ImageDigest *string `copier:"ImageDigest"`
+
+	// The media type of the image manifest.
+	ImageManifestMediaType *string `copier:"ImageManifestMediaType"`
+
+	// The date and time, expressed in standard JavaScript date format, at which the
+	// current image was pushed to the repository.
+	ImagePushedAt *time.Time `copier:"ImagePushedAt"`
+
+	// The list of tags associated with this image.
+	ImageTags []string `copier:"ImageTags"`
+
+	// The Amazon Web Services account ID associated with the registry to which this
+	// image belongs.
+	RegistryId *string `copier:"RegistryId"`
+
+	// The name of the repository to which this image belongs.
+	RepositoryName *string `copier:"RepositoryName"`
+}
+
+func createECRImageDetails(images ImageDetailsECR) (ImageDetailsBothECR, error) {
+	t := &ImageDetailsBothECR{}
+	//Check for empty structs, if non empty copy to new common struct for ECR imagedetails.
+	if reflect.DeepEqual(images.PublicImageDetails, ecrpublictypes.ImageDetail{}) {
+		if images.PrivateImageDetails.ImageDigest != nil && images.PrivateImageDetails.ImagePushedAt != nil && len(images.PrivateImageDetails.ImageTags) > 0 && images.PrivateImageDetails.RegistryId != nil && images.PrivateImageDetails.RepositoryName != nil {
+			copier.Copy(&t, &images.PrivateImageDetails)
+			return *t, nil
+		}
+		return ImageDetailsBothECR{}, fmt.Errorf("Error marshalling image details from ECR lookup.")
+	}
+	if reflect.DeepEqual(images.PrivateImageDetails, ecrtypes.ImageDetail{}) {
+		if images.PublicImageDetails.ImageDigest != nil && images.PublicImageDetails.ImagePushedAt != nil && len(images.PublicImageDetails.ImageTags) > 0 && images.PublicImageDetails.RegistryId != nil && images.PublicImageDetails.RepositoryName != nil {
+			copier.Copy(&t, &images.PublicImageDetails)
+			return *t, nil
+		}
+		return ImageDetailsBothECR{}, fmt.Errorf("Error marshalling image details from ECR lookup.")
+	}
+	return ImageDetailsBothECR{}, fmt.Errorf("Error no data passed to createImageDetails")
+}
+
+// getLastestHelmTagandSha Iterates list of ECR Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
+func getLastestHelmTagandSha(details []ImageDetailsBothECR) (string, string, error) {
+	var latest ImageDetailsBothECR
+	latest.ImagePushedAt = &time.Time{}
+	for _, detail := range details {
+		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 || *detail.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" {
+			continue
+		}
+		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
+			latest = detail
+		}
+	}
+	// Check if latest is equal to empty struct, and return error if that's the case.
+	if reflect.DeepEqual(latest, ImageDetailsBothECR{}) {
+		return "", "", fmt.Errorf("error no images found")
+	}
+	return latest.ImageTags[0], *latest.ImageDigest, nil
+}
+
+// getLastestImageSha Iterates list of ECR Public Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
+func getLastestImageSha(details []ImageDetailsBothECR) (*api.SourceVersion, error) {
+	var latest ImageDetailsBothECR
+	latest.ImagePushedAt = &time.Time{}
+	for _, detail := range details {
+		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 || *detail.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" {
+			continue
+		}
+		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
+			latest = detail
+		}
+	}
+	// Check if latest is equal to empty struct, and return error if that's the case.
+	if reflect.DeepEqual(latest, ecrpublictypes.ImageDetail{}) {
+		return nil, fmt.Errorf("error no images found")
+	}
+	return &api.SourceVersion{Name: latest.ImageTags[0], Digest: *latest.ImageDigest}, nil
 }

--- a/generatebundlefile/ecr_public.go
+++ b/generatebundlefile/ecr_public.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"reflect"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
@@ -63,7 +61,7 @@ func (c *ecrPublicClient) DescribePublic(describeInput *ecrpublic.DescribeImages
 	return images, nil
 }
 
-// GetShaForInputs returns a list of an images version/sha for given inputs to lookup
+// GetShaForPublicInputs returns a list of an images version/sha for given inputs to lookup
 func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVersion, error) {
 	sourceVersion := []api.SourceVersion{}
 	for _, tag := range project.Versions {
@@ -96,7 +94,12 @@ func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVe
 			if err != nil {
 				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
 			}
-			sha, err := getLastestImageSha(ImageDetails)
+			var images []ImageDetailsBothECR
+			for _, image := range ImageDetails {
+				details, _ := createECRImageDetails(ImageDetailsECR{PublicImageDetails: image})
+				images = append(images, details)
+			}
+			sha, err := getLastestImageSha(images)
 			if err != nil {
 				return nil, err
 			}
@@ -113,7 +116,13 @@ func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVe
 			if err != nil {
 				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
 			}
-			filteredImageDetails := imageTagFilter(ImageDetails, splitVersion[0])
+
+			var images []ImageDetailsBothECR
+			for _, image := range ImageDetails {
+				details, _ := createECRImageDetails(ImageDetailsECR{PublicImageDetails: image})
+				images = append(images, details)
+			}
+			filteredImageDetails := ImageTagFilter(images, splitVersion[0])
 			sha, err := getLastestImageSha(filteredImageDetails)
 			if err != nil {
 				return nil, err
@@ -124,63 +133,6 @@ func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVe
 	}
 	sourceVersion = removeDuplicates(sourceVersion)
 	return sourceVersion, nil
-}
-
-// getLastestImageSha Iterates list of ECR Public Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
-func getLastestImageSha(details []ecrpublictypes.ImageDetail) (*api.SourceVersion, error) {
-	if len(details) == 0 {
-		return nil, fmt.Errorf("no details provided")
-	}
-	var latest ecrpublictypes.ImageDetail
-	latest.ImagePushedAt = &time.Time{}
-	for _, detail := range details {
-		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 || *detail.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" {
-			continue
-		}
-		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
-			latest = detail
-		}
-	}
-	// Check if latest is equal to empty struct, and return error if that's the case.
-	if reflect.DeepEqual(latest, ecrpublictypes.ImageDetail{}) {
-		return nil, fmt.Errorf("error no images found")
-	}
-	return &api.SourceVersion{Name: latest.ImageTags[0], Digest: *latest.ImageDigest}, nil
-}
-
-// getLastestHelmTagandShaPublic Iterates list of ECR Public Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
-func getLastestHelmTagandShaPublic(details []ecrpublictypes.ImageDetail) (string, string, error) {
-	if len(details) == 0 {
-		return "", "", fmt.Errorf("no details provided")
-	}
-	var latest ecrpublictypes.ImageDetail
-	latest.ImagePushedAt = &time.Time{}
-	for _, detail := range details {
-		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 || *detail.ImageManifestMediaType != "application/vnd.oci.image.manifest.v1+json" {
-			continue
-		}
-		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
-			latest = detail
-		}
-	}
-	// Check if latest is equal to empty struct, and return error if that's the case.
-	if reflect.DeepEqual(latest, ecrpublictypes.ImageDetail{}) {
-		return "", "", fmt.Errorf("error no images found")
-	}
-	return latest.ImageTags[0], *latest.ImageDigest, nil
-}
-
-// imageTagFilter is used when filtering a list of images for a specific tag or tag substring
-func imageTagFilter(details []ecrpublictypes.ImageDetail, version string) []ecrpublictypes.ImageDetail {
-	var filteredDetails []ecrpublictypes.ImageDetail
-	for _, detail := range details {
-		for _, tag := range detail.ImageTags {
-			if strings.Contains(tag, version) {
-				filteredDetails = append(filteredDetails, detail)
-			}
-		}
-	}
-	return filteredDetails
 }
 
 // shaExistsInRepositoryPublic checks if a given OCI artifact exists in a destination repo using the sha sum.
@@ -281,7 +233,15 @@ func (c *SDKClients) getNameAndVersionPublic(repoName, registryURI string) (stri
 		if err != nil {
 			return "", "", "", err
 		}
-		version, sha, err = getLastestHelmTagandShaPublic(ImageDetails)
+		var images []ImageDetailsBothECR
+		for _, image := range ImageDetails {
+			details, err := createECRImageDetails(ImageDetailsECR{PublicImageDetails: image})
+			if err != nil {
+				return "", "", "", err
+			}
+			images = append(images, details)
+		}
+		version, sha, err = getLastestHelmTagandSha(images)
 		if err != nil {
 			return "", "", "", err
 		}

--- a/generatebundlefile/go.mod
+++ b/generatebundlefile/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
 	github.com/aws/eks-anywhere-packages v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.2.2
+	github.com/jinzhu/copier v0.3.5
 	github.com/pkg/errors v0.9.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.8.1

--- a/generatebundlefile/go.sum
+++ b/generatebundlefile/go.sum
@@ -589,6 +589,8 @@ github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItq
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/generatebundlefile/input.go
+++ b/generatebundlefile/input.go
@@ -137,7 +137,7 @@ func ParseInputConfig(fileName string, inputConfig *Input) error {
 	return fmt.Errorf("cluster spec file %s is invalid or does not contain kind %v", fileName, inputConfig)
 }
 
-func (c *ecrPublicClient) NewBundleFromInput(Input *Input) (api.PackageBundleSpec, string, error) {
+func (c *SDKClients) NewBundleFromInput(Input *Input) (api.PackageBundleSpec, string, error) {
 	packageBundleSpec := api.PackageBundleSpec{}
 	if Input.Name == "" || Input.KubernetesVersion == "" {
 		return packageBundleSpec, "", fmt.Errorf("error: Empty input field from `Name` or `KubernetesVersion`.")


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

Added support for writing bundles from ECR private.

In addition moved any functions dealing with GO SDK ecr or ecrpublic imagedetails, to shared function using a common data type. This is a step towards creating shared functions between ECR and ECRpublic, but didn't want the PR to be any bigger than needed so re-factored functions needed for this feature.