### PR TITLE
Move method out of generated code

### DIFF
--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -13,3 +13,12 @@ func (config *PackageBundleController) ExpectedKind() string {
 func (config *PackageBundleController) IsIgnored() bool {
 	return config.Name != PackageBundleControllerName || config.Namespace != PackageNamespace
 }
+
+func (s *PackageBundleControllerSource) GetRef() (baseRef string) {
+	baseRef = s.Registry
+	if s.Repository != "" {
+		baseRef += "/" + s.Repository
+	}
+
+	return baseRef
+}

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -23,3 +23,11 @@ func TestPackageBundleController_IsValid(t *testing.T) {
 	assert.True(t, givenBundleController("billy", api.PackageNamespace).IsIgnored())
 	assert.True(t, givenBundleController(api.PackageBundleControllerName, "default").IsIgnored())
 }
+
+func TestPackageBundleControllerSource_GetRef(t *testing.T) {
+	sut := api.PackageBundleControllerSource{
+		Registry:   "public.ecr.aws/l0g8r8j6",
+		Repository: "eks-anywhere-packages-bundles",
+	}
+	assert.Equal(t, "public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles", sut.GetRef())
+}

--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -79,15 +79,6 @@ type PackageBundleControllerSource struct {
 	Repository string `json:"repository"`
 }
 
-func (s *PackageBundleControllerSource) BaseRef() (baseRef string) {
-	baseRef = s.Registry
-	if s.Repository != "" {
-		baseRef += "/" + s.Repository
-	}
-
-	return baseRef
-}
-
 // +kubebuilder:validation:Enum=ignored;active;disconnected
 type BundleControllerStateEnum string
 

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -82,7 +82,7 @@ func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
 	kubeVersion := FormatKubeServerVersion(m.info)
-	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.Spec.Source.BaseRef(), kubeVersion)
+	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.Spec.Source.GetRef(), kubeVersion)
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")
 		if pbc.Status.State == api.BundleControllerStateActive {


### PR DESCRIPTION
Our standard is to put code in the file without `_type` in the name.

Also, I found the name BaseRef a bit confusing.
