### PR TITLE
Use generic invalid bundle state

### DIFF
--- a/api/v1alpha1/packagebundle_types.go
+++ b/api/v1alpha1/packagebundle_types.go
@@ -120,9 +120,9 @@ type PackageBundleStatus struct {
 type PackageBundleStateEnum string
 
 const (
-	PackageBundleStateAvailable      PackageBundleStateEnum = "available"
-	PackageBundleStateIgnored        PackageBundleStateEnum = "ignored"
-	PackageBundleStateInvalidVersion PackageBundleStateEnum = "invalid version"
+	PackageBundleStateAvailable PackageBundleStateEnum = "available"
+	PackageBundleStateIgnored   PackageBundleStateEnum = "ignored"
+	PackageBundleStateInvalid   PackageBundleStateEnum = "invalid"
 )
 
 //+kubebuilder:object:root=true

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -53,9 +53,9 @@ func (m bundleManager) ProcessBundle(ctx context.Context, newBundle *api.Package
 	}
 
 	if !newBundle.IsValidVersion() {
-		if newBundle.Status.State != api.PackageBundleStateInvalidVersion {
+		if newBundle.Status.State != api.PackageBundleStateInvalid {
 			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
-			newBundle.Status.State = api.PackageBundleStateInvalidVersion
+			newBundle.Status.State = api.PackageBundleStateInvalid
 			m.log.V(6).Info("update", "bundle", newBundle.Name, "state", newBundle.Status.State)
 			return true, nil
 		}

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -91,7 +91,7 @@ func TestProcessBundle(t *testing.T) {
 
 		assert.True(t, update)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, api.PackageBundleStateInvalidVersion, bundle.Status.State)
+		assert.Equal(t, api.PackageBundleStateInvalid, bundle.Status.State)
 	})
 
 	t.Run("marks state available", func(t *testing.T) {


### PR DESCRIPTION
Change this state name to something generic so we can avoid future crd changes
