### PR TITLE
Private registry

### DIFF
--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -64,6 +64,10 @@ type PackageBundleControllerSpec struct {
 	// +optional
 	ActiveBundle string `json:"activeBundle"`
 
+	// PrivateRegistry is the registry being used for all images, charts and bundles
+	// +optional
+	PrivateRegistry string `json:"privateRegistry"`
+
 	// +kubebuilder:validation:Required
 	// Source of the bundle.
 	Source PackageBundleControllerSource `json:"source"`

--- a/charts/eks-anywhere-packages/crds/crd.yaml
+++ b/charts/eks-anywhere-packages/crds/crd.yaml
@@ -27,34 +27,45 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PackageBundleController is the Schema for the packagebundlecontrollers API
+        description: PackageBundleController is the Schema for the packagebundlecontrollers
+          API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: PackageBundleControllerSpec defines the desired state of PackageBundleController
+            description: PackageBundleControllerSpec defines the desired state of
+              PackageBundleController.
             properties:
               activeBundle:
-                description: ActiveBundle is name of the bundle from which packages should be sourced.
+                description: ActiveBundle is name of the bundle from which packages
+                  should be sourced.
                 type: string
               logLevel:
                 description: LogLevel controls the verbosity of logging in the controller.
                 format: int32
                 type: integer
+              privateRegistry:
+                description: PrivateRegistry is the registry being used for all images,
+                  charts and bundles
+                type: string
               source:
                 description: Source of the bundle.
                 properties:
                   registry:
-                    description: Registry is the OCR address hosting the bundle.
+                    description: Registry portion of an OCI address to the bundle
                     type: string
                   repository:
-                    description: Repository is the location of the bundle within the OCR registry.
+                    description: Repository portion of an OCI address to the bundle
                     type: string
                 required:
                 - registry
@@ -62,23 +73,26 @@ spec:
                 type: object
               upgradeCheckInterval:
                 default: 1d
-                description: "UpgradeCheckInterval is the time between upgrade checks. \n The format is that of time's ParseDuration."
+                description: "UpgradeCheckInterval is the time between upgrade checks.
+                  \n The format is that of time's ParseDuration."
                 type: string
               upgradeCheckShortInterval:
                 default: 1h
-                description: "UpgradeCheckShortInterval if there is a problem this is the time between upgrade checks. \n The format is that of time's ParseDuration."
+                description: "UpgradeCheckShortInterval time between upgrade checks
+                  if there is a problem. \n The format is that of time's ParseDuration."
                 type: string
             required:
             - source
             type: object
           status:
-            description: PackageBundleControllerStatus defines the observed state of PackageBundleController
+            description: PackageBundleControllerStatus defines the observed state
+              of PackageBundleController.
             properties:
               detail:
-                description: Detail of the state
+                description: Detail of the state.
                 type: string
               state:
-                description: State of the bundle controller
+                description: State of the bundle controller.
                 enum:
                 - ignored
                 - active
@@ -130,18 +144,22 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PackageBundle is the Schema for the packagebundles API
+        description: PackageBundle is the Schema for the packagebundles API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: PackageBundleSpec defines the desired state of PackageBundle
+            description: PackageBundleSpec defines the desired state of PackageBundle.
             properties:
               packages:
                 description: Packages supported by this bundle.
@@ -149,55 +167,43 @@ spec:
                   description: BundlePackage specifies a package within a bundle.
                   properties:
                     name:
-                      description: Name of the package
+                      description: Name of the package.
                       type: string
                     source:
-                      description: Source location for the package (probably a helm chart).
+                      description: Source location for the package (probably a helm
+                        chart).
                       properties:
                         registry:
                           description: Registry in which the package is found.
                           type: string
                         repository:
-                          description: Repository within the Registry where the package is found.
+                          description: Repository within the Registry where the package
+                            is found.
                           type: string
                         versions:
                           description: Versions of the package supported by this bundle.
                           items:
-                            description: SourceVersion describes a version of a package within a repository.
+                            description: SourceVersion describes a version of a package
+                              within a repository.
                             properties:
-                              configurations:
-                                description: Configurations is a list of configurations used by this version of the package. The configurations are used for configuration validation and to generate sample configurations for users.
-                                items:
-                                  description: VersionConfiguration is a configuration used by a version of a package.
-                                  properties:
-                                    default:
-                                      description: Default is the name of the configuration
-                                      type: string
-                                    name:
-                                      description: Name is the name of the configuration
-                                      type: string
-                                    required:
-                                      description: Required configuration parameter the user must specify
-                                      type: boolean
-                                  required:
-                                  - default
-                                  - name
-                                  - required
-                                  type: object
-                                type: array
                               digest:
-                                description: Digest is a checksum value identifying the version of the package and its contents.
+                                description: Digest is a checksum value identifying
+                                  the version of the package and its contents.
                                 type: string
                               images:
-                                description: Images is a list of images used by this version of the package
+                                description: Images is a list of images used by this
+                                  version of the package.
                                 items:
-                                  description: VersionImages is an image used by a version of a package.
+                                  description: VersionImages is an image used by a
+                                    version of a package.
                                   properties:
                                     digest:
-                                      description: Digest is a checksum value identifying the version of the package and its contents.
+                                      description: Digest is a checksum value identifying
+                                        the version of the package and its contents.
                                       type: string
                                     repository:
-                                      description: Repository is source in the registry for the image
+                                      description: Repository within the Registry
+                                        where the package is found.
                                       type: string
                                   required:
                                   - digest
@@ -205,10 +211,12 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: Name is a human-friendly description of the version, e.g. "v1.0".
+                                description: Name is a human-friendly description
+                                  of the version, e.g. "v1.0".
                                 type: string
                               schema:
-                                description: Schema is a base64 encoded, gzipped json schema used to validate package configurations
+                                description: Schema is a base64 encoded, gzipped json
+                                  schema used to validate package configurations.
                                 type: string
                             required:
                             - digest
@@ -228,10 +236,10 @@ spec:
             - packages
             type: object
           status:
-            description: PackageBundleStatus defines the observed state of PackageBundle
+            description: PackageBundleStatus defines the observed state of PackageBundle.
             properties:
               spec:
-                description: PackageBundleSpec defines the desired state of PackageBundle
+                description: PackageBundleSpec defines the desired state of PackageBundle.
                 properties:
                   packages:
                     description: Packages supported by this bundle.
@@ -239,55 +247,45 @@ spec:
                       description: BundlePackage specifies a package within a bundle.
                       properties:
                         name:
-                          description: Name of the package
+                          description: Name of the package.
                           type: string
                         source:
-                          description: Source location for the package (probably a helm chart).
+                          description: Source location for the package (probably a
+                            helm chart).
                           properties:
                             registry:
                               description: Registry in which the package is found.
                               type: string
                             repository:
-                              description: Repository within the Registry where the package is found.
+                              description: Repository within the Registry where the
+                                package is found.
                               type: string
                             versions:
-                              description: Versions of the package supported by this bundle.
+                              description: Versions of the package supported by this
+                                bundle.
                               items:
-                                description: SourceVersion describes a version of a package within a repository.
+                                description: SourceVersion describes a version of
+                                  a package within a repository.
                                 properties:
-                                  configurations:
-                                    description: Configurations is a list of configurations used by this version of the package. The configurations are used for configuration validation and to generate sample configurations for users.
-                                    items:
-                                      description: VersionConfiguration is a configuration used by a version of a package.
-                                      properties:
-                                        default:
-                                          description: Default is the name of the configuration
-                                          type: string
-                                        name:
-                                          description: Name is the name of the configuration
-                                          type: string
-                                        required:
-                                          description: Required configuration parameter the user must specify
-                                          type: boolean
-                                      required:
-                                      - default
-                                      - name
-                                      - required
-                                      type: object
-                                    type: array
                                   digest:
-                                    description: Digest is a checksum value identifying the version of the package and its contents.
+                                    description: Digest is a checksum value identifying
+                                      the version of the package and its contents.
                                     type: string
                                   images:
-                                    description: Images is a list of images used by this version of the package
+                                    description: Images is a list of images used by
+                                      this version of the package.
                                     items:
-                                      description: VersionImages is an image used by a version of a package.
+                                      description: VersionImages is an image used
+                                        by a version of a package.
                                       properties:
                                         digest:
-                                          description: Digest is a checksum value identifying the version of the package and its contents.
+                                          description: Digest is a checksum value
+                                            identifying the version of the package
+                                            and its contents.
                                           type: string
                                         repository:
-                                          description: Repository is source in the registry for the image
+                                          description: Repository within the Registry
+                                            where the package is found.
                                           type: string
                                       required:
                                       - digest
@@ -295,10 +293,12 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: Name is a human-friendly description of the version, e.g. "v1.0".
+                                    description: Name is a human-friendly description
+                                      of the version, e.g. "v1.0".
                                     type: string
                                   schema:
-                                    description: Schema is a base64 encoded, gzipped json schema used to validate package configurations
+                                    description: Schema is a base64 encoded, gzipped
+                                      json schema used to validate package configurations.
                                     type: string
                                 required:
                                 - digest
@@ -318,6 +318,8 @@ spec:
                 - packages
                 type: object
               state:
+                description: PackageBundleStateEnum defines the observed state of
+                  PackageBundle.
                 enum:
                 - available
                 - ignored
@@ -376,13 +378,17 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Package is the Schema for the package API
+        description: Package is the Schema for the package API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -390,39 +396,48 @@ spec:
             description: PackageSpec defines the desired state of an package.
             properties:
               config:
-                description: Config for the package
+                description: Config for the package.
                 type: string
               packageName:
-                description: PackageName is the name of the package as specified in the bundle.
+                description: PackageName is the name of the package as specified in
+                  the bundle.
                 type: string
               packageVersion:
-                description: PackageVersion is a human-friendly version name or sha256 checksum for the package, as specified in the bundle.
+                description: PackageVersion is a human-friendly version name or sha256
+                  checksum for the package, as specified in the bundle.
                 type: string
               targetNamespace:
-                description: TargetNamespace where package resources will be deployed.
+                description: TargetNamespace defines where package resources will
+                  be deployed.
                 type: string
             required:
             - packageName
             type: object
           status:
-            description: PackageStatus defines the observed state of Package
+            description: PackageStatus defines the observed state of Package.
             properties:
               currentVersion:
-                description: Version currently installed
+                description: Version currently installed.
                 type: string
               detail:
-                description: Detail of the state
+                description: Detail of the state.
                 type: string
               source:
-                description: Source associated with the installation
+                description: Source associated with the installation.
                 properties:
                   digest:
+                    description: Digest is a checksum value identifying the version
+                      of the package and its contents.
                     type: string
                   registry:
+                    description: Registry in which the package is found.
                     type: string
                   repository:
+                    description: Repository within the Registry where the package
+                      is found.
                     type: string
                   version:
+                    description: Versions of the package supported.
                     type: string
                 required:
                 - digest
@@ -431,7 +446,7 @@ spec:
                 - version
                 type: object
               state:
-                description: State of the installation
+                description: State of the installation.
                 enum:
                 - initializing
                 - installing
@@ -441,18 +456,22 @@ spec:
                 - unknown
                 type: string
               targetVersion:
-                description: Version to be installed
+                description: Version to be installed.
                 type: string
               upgradesAvailable:
-                description: UpgradesAvailable indicates upgraded versions in the bundle.
+                description: UpgradesAvailable indicates upgraded versions in the
+                  bundle.
                 items:
-                  description: PackageAvailableUpgrade details the package's available upgrades' versions.
+                  description: PackageAvailableUpgrade details the package's available
+                    upgrades' versions.
                   properties:
                     tag:
-                      description: Tag is a specific version number or sha256 checksum for the package upgrade.
+                      description: Tag is a specific version number or sha256 checksum
+                        for the package upgrade.
                       type: string
                     version:
-                      description: Version is a human-friendly version name for the package upgrade.
+                      description: Version is a human-friendly version name for the
+                        package upgrade.
                       type: string
                   required:
                   - tag

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -56,6 +56,10 @@ spec:
                 description: LogLevel controls the verbosity of logging in the controller.
                 format: int32
                 type: integer
+              privateRegistry:
+                description: PrivateRegistry is the registry being used for all images,
+                  charts and bundles
+                type: string
               source:
                 description: Source of the bundle.
                 properties:

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -21,6 +21,9 @@ type Client interface {
 	// currently active bundle.
 	GetActiveBundleNamespacedName(ctx context.Context) (types.NamespacedName, error)
 
+	// GetPrivateRegistry retrieves the currently active bundle.
+	GetPrivateRegistry(ctx context.Context) (registry string, err error)
+
 	// GetBundleList get list of bundles worthy of consideration
 	GetBundleList(ctx context.Context, bundles *api.PackageBundleList) error
 
@@ -105,6 +108,15 @@ func (bc *bundleClient) GetActiveBundle(ctx context.Context) (activeBundle *api.
 	}
 
 	return activeBundle, nil
+}
+
+func (bc *bundleClient) GetPrivateRegistry(ctx context.Context) (registry string, err error) {
+	pbc, err := bc.getPackageBundleController(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return pbc.Spec.PrivateRegistry, nil
 }
 
 // GetActiveBundleNamespacedName retrieves the namespace and name of the

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -95,19 +95,19 @@ func (mr *MockClientMockRecorder) GetBundleList(ctx, bundles interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleList", reflect.TypeOf((*MockClient)(nil).GetBundleList), ctx, bundles)
 }
 
-// GetPrivateRegistry mocks base method.
-func (m *MockClient) GetPrivateRegistry(ctx context.Context) (string, error) {
+// GetPackageBundleController mocks base method.
+func (m *MockClient) GetPackageBundleController(ctx context.Context) (*v1alpha1.PackageBundleController, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPrivateRegistry", ctx)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetPackageBundleController", ctx)
+	ret0, _ := ret[0].(*v1alpha1.PackageBundleController)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetPrivateRegistry indicates an expected call of GetPrivateRegistry.
-func (mr *MockClientMockRecorder) GetPrivateRegistry(ctx interface{}) *gomock.Call {
+// GetPackageBundleController indicates an expected call of GetPackageBundleController.
+func (mr *MockClientMockRecorder) GetPackageBundleController(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateRegistry", reflect.TypeOf((*MockClient)(nil).GetPrivateRegistry), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackageBundleController", reflect.TypeOf((*MockClient)(nil).GetPackageBundleController), ctx)
 }
 
 // IsActive mocks base method.

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -95,6 +95,21 @@ func (mr *MockClientMockRecorder) GetBundleList(ctx, bundles interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleList", reflect.TypeOf((*MockClient)(nil).GetBundleList), ctx, bundles)
 }
 
+// GetPrivateRegistry mocks base method.
+func (m *MockClient) GetPrivateRegistry(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateRegistry", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPrivateRegistry indicates an expected call of GetPrivateRegistry.
+func (mr *MockClientMockRecorder) GetPrivateRegistry(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateRegistry", reflect.TypeOf((*MockClient)(nil).GetPrivateRegistry), ctx)
+}
+
 // IsActive mocks base method.
 func (m *MockClient) IsActive(ctx context.Context, packageBundle *v1alpha1.PackageBundle) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -26,7 +26,7 @@ type ManagerContext struct {
 	Package       api.Package
 	PackageDriver driver.PackageDriver
 	Source        api.PackageOCISource
-	Controller    api.PackageBundleController
+	PBC           api.PackageBundleController
 	Version       string
 	RequeueAfter  time.Duration
 	Log           logr.Logger
@@ -43,13 +43,13 @@ func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
 			return val.(string)
 		}
 	}
-	if mc.Controller.Spec.PrivateRegistry != "" {
-		return mc.Controller.Spec.PrivateRegistry
+	if mc.PBC.Spec.PrivateRegistry != "" {
+		return mc.PBC.Spec.PrivateRegistry
 	}
 	if mc.Source.Registry != "" {
 		return mc.Source.Registry
 	}
-	return mc.Controller.Spec.Source.Registry
+	return mc.PBC.Spec.Source.Registry
 }
 
 func processInitializing(mc *ManagerContext) bool {

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -26,6 +26,7 @@ type ManagerContext struct {
 	Package       api.Package
 	PackageDriver driver.PackageDriver
 	Source        api.PackageOCISource
+	Registry      string
 	Version       string
 	RequeueAfter  time.Duration
 	Log           logr.Logger
@@ -60,7 +61,9 @@ func processInstalling(mc *ManagerContext) bool {
 		mc.Log.Error(err, "Install failed")
 		return true
 	}
-	values[sourceRegistry] = mc.Source.Registry
+	if mc.Registry != "" && values[sourceRegistry] == "" {
+		values[sourceRegistry] = mc.Registry
+	}
 	if err := mc.PackageDriver.Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, values); err != nil {
 		mc.Package.Status.Detail = err.Error()
 		mc.Log.Error(err, "Install failed")
@@ -91,7 +94,9 @@ func processInstalled(mc *ManagerContext) bool {
 			return true
 		}
 
-		newValues[sourceRegistry] = mc.Source.Registry
+		if mc.Registry != "" && newValues[sourceRegistry] == "" {
+			newValues[sourceRegistry] = mc.Registry
+		}
 		needs, err := mc.PackageDriver.IsConfigChanged(mc.Ctx, mc.Package.Name,
 			newValues)
 		if err != nil {

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -26,7 +26,7 @@ type ManagerContext struct {
 	Package       api.Package
 	PackageDriver driver.PackageDriver
 	Source        api.PackageOCISource
-	Registry      string
+	Controller    api.PackageBundleController
 	Version       string
 	RequeueAfter  time.Duration
 	Log           logr.Logger
@@ -35,6 +35,21 @@ type ManagerContext struct {
 func (mc *ManagerContext) SetUninstalling(name string) {
 	mc.Package.Name = name
 	mc.Package.Status.State = api.StateUninstalling
+}
+
+func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
+	if val, ok := values[sourceRegistry]; ok {
+		if val != "" {
+			return val.(string)
+		}
+	}
+	if mc.Controller.Spec.PrivateRegistry != "" {
+		return mc.Controller.Spec.PrivateRegistry
+	}
+	if mc.Source.Registry != "" {
+		return mc.Source.Registry
+	}
+	return mc.Controller.Spec.Source.Registry
 }
 
 func processInitializing(mc *ManagerContext) bool {
@@ -61,9 +76,7 @@ func processInstalling(mc *ManagerContext) bool {
 		mc.Log.Error(err, "Install failed")
 		return true
 	}
-	if mc.Registry != "" && values[sourceRegistry] == "" {
-		values[sourceRegistry] = mc.Registry
-	}
+	values[sourceRegistry] = mc.getRegistry(values)
 	if err := mc.PackageDriver.Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, values); err != nil {
 		mc.Package.Status.Detail = err.Error()
 		mc.Log.Error(err, "Install failed")
@@ -94,9 +107,7 @@ func processInstalled(mc *ManagerContext) bool {
 			return true
 		}
 
-		if mc.Registry != "" && newValues[sourceRegistry] == "" {
-			newValues[sourceRegistry] = mc.Registry
-		}
+		newValues[sourceRegistry] = mc.getRegistry(newValues)
 		needs, err := mc.PackageDriver.IsConfigChanged(mc.Ctx, mc.Package.Name,
 			newValues)
 		if err != nil {

--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -53,6 +53,14 @@ func givenManagerContext(driver *mocks.MockPackageDriver) *ManagerContext {
 			Repository: "hello-eks-anywhere",
 			Digest:     "sha256:f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
 		},
+		PBC: api.PackageBundleController{
+			Spec: api.PackageBundleControllerSpec{
+				PrivateRegistry: "privateRegistry",
+				Source: api.PackageBundleControllerSource{
+					Registry: "sourceRegistry",
+				},
+			},
+		},
 		RequeueAfter: time.Duration(100),
 		Log:          logr.Discard(),
 	}
@@ -78,6 +86,40 @@ func TestManagerContext_SetUninstalling(t *testing.T) {
 	if sut.Package.Status.State != expectedState {
 		t.Errorf("expected <%s> actual <%s>", expectedState, sut.Package.Status.State)
 	}
+}
+
+func TestManagerContext_getRegistry(t *testing.T) {
+	t.Run("registry from values", func(t *testing.T) {
+		sut := givenManagerContext(givenMockDriver(t))
+		values := make(map[string]interface{})
+		values["sourceRegistry"] = "valuesRegistry"
+
+		assert.Equal(t, "valuesRegistry", sut.getRegistry(values))
+	})
+
+	t.Run("registry from privateRegistry", func(t *testing.T) {
+		sut := givenManagerContext(givenMockDriver(t))
+		values := make(map[string]interface{})
+
+		assert.Equal(t, "privateRegistry", sut.getRegistry(values))
+	})
+
+	t.Run("registry from bundle package", func(t *testing.T) {
+		sut := givenManagerContext(givenMockDriver(t))
+		values := make(map[string]interface{})
+		sut.PBC.Spec.PrivateRegistry = ""
+
+		assert.Equal(t, "public.ecr.aws/j0a1m4z9/", sut.getRegistry(values))
+	})
+
+	t.Run("registry from bundle source", func(t *testing.T) {
+		sut := givenManagerContext(givenMockDriver(t))
+		values := make(map[string]interface{})
+		sut.PBC.Spec.PrivateRegistry = ""
+		sut.Source.Registry = ""
+
+		assert.Equal(t, "sourceRegistry", sut.getRegistry(values))
+	})
 }
 
 func TestNewManager(t *testing.T) {


### PR DESCRIPTION
Currently, we use the registry for the bundle to install every package so that we can support private registries. This works for now since we currently only support everything from public ecr or a private registry. This change allows us to support:

1. private registries
2. sourceRegistry specified in the package custom resource
3. registry specified in the bundle
4. default registry will be the source registry of the bundle if nothing else is specified.