### PR TITLE
add helm/build target to match build tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ docker-build: test ## Build docker image with the package-manager.
 docker-push: ## Push docker image with the package-manager.
 	docker push ${IMG}
 
+helm/build: helm-build
 helm-build: kustomize ## Build helm chart into tar file
 	hack/helm.sh
 


### PR DESCRIPTION
Build tooling uses helm/build, so helm-build target I never remember
