### PR TITLE
Update PackageOCISource

### DIFF
--- a/api/v1alpha1/package_types.go
+++ b/api/v1alpha1/package_types.go
@@ -87,6 +87,21 @@ type PackageStatus struct {
 	UpgradesAvailable []PackageAvailableUpgrade `json:"upgradesAvailable,omitempty"`
 }
 
+type PackageOCISource struct {
+	// +kubebuilder:validation:Required
+	// Versions of the package supported.
+	Version string `json:"version"`
+	// +kubebuilder:validation:Required
+	// Registry in which the package is found.
+	Registry string `json:"registry"`
+	// +kubebuilder:validation:Required
+	// Repository within the Registry where the package is found.
+	Repository string `json:"repository"`
+	// +kubebuilder:validation:Required
+	// Digest is a checksum value identifying the version of the package and its contents.
+	Digest string `json:"digest"`
+}
+
 // PackageAvailableUpgrade details the package's available upgrades' versions.
 type PackageAvailableUpgrade struct {
 	// +kubebuilder:validation:Required

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -11,13 +11,6 @@ import (
 	"strings"
 )
 
-type PackageOCISource struct {
-	Version    string `json:"version"`
-	Registry   string `json:"registry"`
-	Repository string `json:"repository"`
-	Digest     string `json:"digest"`
-}
-
 const (
 	PackageBundleKind           = "PackageBundle"
 	PackageBundleControllerName = "eksa-packages-bundle-controller"

--- a/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packages.yaml
@@ -85,12 +85,18 @@ spec:
                 description: Source associated with the installation
                 properties:
                   digest:
+                    description: Digest is a checksum value identifying the version
+                      of the package and its contents.
                     type: string
                   registry:
+                    description: Registry in which the package is found.
                     type: string
                   repository:
+                    description: Repository within the Registry where the package
+                      is found.
                     type: string
                   version:
+                    description: Versions of the package supported.
                     type: string
                 required:
                 - digest


### PR DESCRIPTION
PackageOCISource should be part of Package, not packageBundle.

*Issue #, if available:* N/A

*Description of changes:* `Moved PackageOCISource to package_types.go`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
