### PR TITLE
Use full path for setup-envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ GOTESTS ?= ./...
 # go help testflags to see all options.
 GOTESTFLAGS ?= ""
 test: manifests generate vet mocks ${SIGNED_ARTIFACTS} $(GOBIN)/setup-envtest ## Run tests.
-	source <(setup-envtest use -i -p env 1.23.x)
+	source <($(GOBIN)/setup-envtest use -i -p env 1.23.x)
 	$(GO) test $(GOTESTFLAGS) `$(GO) list $(GOTESTS) | grep -v mocks | grep -v fake | grep -v testutil` -coverprofile cover.out
 
 $(GOBIN)/setup-envtest: ## Install setup-envtest


### PR DESCRIPTION
This avoids the expectation that GOBIN is in your PATH

github actions failed for https://github.com/aws/eks-anywhere-packages/pull/361 so I created this new PR