### PR TITLE
Use default gated registry for installation

### DIFF
--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	retryNever     = time.Duration(0)
-	retryNow       = time.Duration(1)
-	retryShort     = time.Duration(30) * time.Second
-	retryLong      = time.Duration(60) * time.Second
-	retryVeryLong  = time.Duration(180) * time.Second
-	sourceRegistry = "sourceRegistry"
+	retryNever           = time.Duration(0)
+	retryNow             = time.Duration(1)
+	retryShort           = time.Duration(30) * time.Second
+	retryLong            = time.Duration(60) * time.Second
+	retryVeryLong        = time.Duration(180) * time.Second
+	sourceRegistry       = "sourceRegistry"
+	defaultGatedRegistry = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
 )
 
 type ManagerContext struct {
@@ -49,7 +50,7 @@ func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
 	if mc.Source.Registry != "" {
 		return mc.Source.Registry
 	}
-	return mc.PBC.Spec.Source.Registry
+	return defaultGatedRegistry
 }
 
 func processInitializing(mc *ManagerContext) bool {

--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -112,13 +112,13 @@ func TestManagerContext_getRegistry(t *testing.T) {
 		assert.Equal(t, "public.ecr.aws/j0a1m4z9/", sut.getRegistry(values))
 	})
 
-	t.Run("registry from bundle source", func(t *testing.T) {
+	t.Run("registry from default gated registry", func(t *testing.T) {
 		sut := givenManagerContext(givenMockDriver(t))
 		values := make(map[string]interface{})
 		sut.PBC.Spec.PrivateRegistry = ""
 		sut.Source.Registry = ""
 
-		assert.Equal(t, "sourceRegistry", sut.getRegistry(values))
+		assert.Equal(t, "783794618700.dkr.ecr.us-west-2.amazonaws.com", sut.getRegistry(values))
 	})
 }
 


### PR DESCRIPTION
If nothing else is set, use our default gated private registry
