### PR TITLE
Add default registries

### DIFF
--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -14,6 +14,14 @@ func (config *PackageBundleController) IsIgnored() bool {
 	return config.Name != PackageBundleControllerName || config.Namespace != PackageNamespace
 }
 
+func (config *PackageBundleController) GetDefaultRegistry() string {
+	return defaultRegistry
+}
+
+func (config *PackageBundleController) GetDefaultImageRegistry() string {
+	return defaultImageRegistry
+}
+
 func (s *PackageBundleControllerSource) GetRef() (baseRef string) {
 	baseRef = s.Registry
 	if s.Repository != "" {

--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	DefaultPackageRegistry = "public.ecr.aws/eks-anywhere"
+	defaultRegistry      = "public.ecr.aws/eks-anywhere"
+	defaultImageRegistry = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -84,16 +84,6 @@ func (bc *bundleClient) GetActiveBundle(ctx context.Context) (activeBundle *api.
 		return nil, err
 	}
 
-	for i, bundlePackage := range activeBundle.Spec.Packages {
-		if len(bundlePackage.Source.Registry) < 1 {
-			if len(pbc.Spec.Source.Registry) < 1 {
-				activeBundle.Spec.Packages[i].Source.Registry = api.DefaultPackageRegistry
-			} else {
-				activeBundle.Spec.Packages[i].Source.Registry = pbc.Spec.Source.Registry
-			}
-		}
-	}
-
 	return activeBundle, nil
 }
 

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -171,41 +171,6 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("no registry", func(t *testing.T) {
-		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
-		testBundle := givenBundle()
-		testBundle.Spec.Packages[0].Source.Registry = ""
-
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(testBundle)).SetArg(2, *testBundle)
-
-		bundle, err := bundleClient.GetActiveBundle(ctx)
-
-		assert.Equal(t, bundle.Name, testBundleName)
-		assert.Equal(t, "hello-eks-anywhere", bundle.Spec.Packages[0].Name)
-		assert.Equal(t, "public.ecr.aws/j0a1m4z9", bundle.Spec.Packages[0].Source.Registry)
-		assert.Nil(t, err)
-	})
-
-	t.Run("no registry anywhere", func(t *testing.T) {
-		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
-		testBundle := givenBundle()
-		testBundle.Spec.Packages[0].Source.Registry = ""
-		pbc.Spec.Source.Registry = ""
-
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(testBundle)).SetArg(2, *testBundle)
-
-		bundle, err := bundleClient.GetActiveBundle(ctx)
-
-		assert.Equal(t, bundle.Name, testBundleName)
-		assert.Equal(t, "hello-eks-anywhere", bundle.Spec.Packages[0].Name)
-		assert.Equal(t, "public.ecr.aws/eks-anywhere", bundle.Spec.Packages[0].Source.Registry)
-		assert.Nil(t, err)
-	})
-
 	t.Run("no active bundle", func(t *testing.T) {
 		pbc := givenPackageBundleController()
 		mockClient := givenMockClient(t)

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -13,13 +13,12 @@ import (
 )
 
 const (
-	retryNever           = time.Duration(0)
-	retryNow             = time.Duration(1)
-	retryShort           = time.Duration(30) * time.Second
-	retryLong            = time.Duration(60) * time.Second
-	retryVeryLong        = time.Duration(180) * time.Second
-	sourceRegistry       = "sourceRegistry"
-	defaultGatedRegistry = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
+	retryNever     = time.Duration(0)
+	retryNow       = time.Duration(1)
+	retryShort     = time.Duration(30) * time.Second
+	retryLong      = time.Duration(60) * time.Second
+	retryVeryLong  = time.Duration(180) * time.Second
+	sourceRegistry = "sourceRegistry"
 )
 
 type ManagerContext struct {
@@ -50,7 +49,7 @@ func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
 	if mc.Source.Registry != "" {
 		return mc.Source.Registry
 	}
-	return defaultGatedRegistry
+	return mc.PBC.GetDefaultImageRegistry()
 }
 
 func processInitializing(mc *ManagerContext) bool {
@@ -78,6 +77,9 @@ func processInstalling(mc *ManagerContext) bool {
 		return true
 	}
 	values[sourceRegistry] = mc.getRegistry(values)
+	if mc.Source.Registry == "" {
+		mc.Source.Registry = mc.PBC.GetDefaultRegistry()
+	}
 	if err := mc.PackageDriver.Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, values); err != nil {
 		mc.Package.Status.Detail = err.Error()
 		mc.Log.Error(err, "Install failed")


### PR DESCRIPTION
The active bundle getter was overriding registry in the bundle with one of two values that are always going to be public ECR. This change is the minimal change to get gated packages working so we pull the images from private and the helm charts from public
