### PR TITLE
Add default registry

### DIFF
--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -122,8 +122,8 @@ func (config *PackageBundle) IsValidVersion() bool {
 	return err == nil
 }
 
-func (s PackageOCISource) AsRepoURI() string {
-	return path.Join(s.Registry, s.Repository)
+func (s PackageOCISource) GetChartUri() string {
+	return "oci://" + path.Join(s.Registry, s.Repository)
 }
 
 // PackageMatches returns true if the given source locations match one another.

--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "path"
+
 const PackageBundleControllerKind = "PackageBundleController"
 
 func (config *PackageBundleController) MetaKind() string {
@@ -15,18 +17,19 @@ func (config *PackageBundleController) IsIgnored() bool {
 }
 
 func (config *PackageBundleController) GetDefaultRegistry() string {
+	if config.Spec.DefaultRegistry != "" {
+		return config.Spec.DefaultRegistry
+	}
 	return defaultRegistry
 }
 
 func (config *PackageBundleController) GetDefaultImageRegistry() string {
+	if config.Spec.DefaultImageRegistry != "" {
+		return config.Spec.DefaultImageRegistry
+	}
 	return defaultImageRegistry
 }
 
-func (s *PackageBundleControllerSource) GetRef() (baseRef string) {
-	baseRef = s.Registry
-	if s.Repository != "" {
-		baseRef += "/" + s.Repository
-	}
-
-	return baseRef
+func (config *PackageBundleController) GetBundleUri() (uri string) {
+	return path.Join(config.GetDefaultRegistry(), config.Spec.Source.Repository)
 }

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -9,6 +9,12 @@ import (
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )
 
+const (
+	TestBundleName       = "v1-21-1003"
+	TestBundleRegistry   = "public.ecr.aws/j0a1m4z9"
+	TestBundleRepository = "eks-anywhere-package-bundles"
+)
+
 func TestPackageBundleController_IsValid(t *testing.T) {
 	givenBundleController := func(name string, namespace string) *api.PackageBundleController {
 		return &api.PackageBundleController{
@@ -24,10 +30,28 @@ func TestPackageBundleController_IsValid(t *testing.T) {
 	assert.True(t, givenBundleController(api.PackageBundleControllerName, "default").IsIgnored())
 }
 
-func TestPackageBundleControllerSource_GetRef(t *testing.T) {
-	sut := api.PackageBundleControllerSource{
-		Registry:   "public.ecr.aws/l0g8r8j6",
-		Repository: "eks-anywhere-packages-bundles",
+func GivenPackageBundleController() *api.PackageBundleController {
+	return &api.PackageBundleController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      api.PackageBundleControllerName,
+			Namespace: api.PackageNamespace,
+		},
+		Spec: api.PackageBundleControllerSpec{
+			ActiveBundle:         TestBundleName,
+			DefaultRegistry:      "public.ecr.aws/j0a1m4z9",
+			DefaultImageRegistry: "783794618700.dkr.ecr.us-west-2.amazonaws.com",
+			Source: api.PackageBundleControllerSource{
+				Registry:   TestBundleRegistry,
+				Repository: TestBundleRepository,
+			},
+		},
+		Status: api.PackageBundleControllerStatus{
+			State: api.BundleControllerStateActive,
+		},
 	}
-	assert.Equal(t, "public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles", sut.GetRef())
+}
+
+func TestPackageBundleControllerSource_GetRef(t *testing.T) {
+	sut := GivenPackageBundleController()
+	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-package-bundles", sut.GetBundleUri())
 }

--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -69,6 +69,14 @@ type PackageBundleControllerSpec struct {
 	// +optional
 	PrivateRegistry string `json:"privateRegistry"`
 
+	// DefaultRegistry for pulling helm charts and the bundle
+	// +optional
+	DefaultRegistry string `json:"defaultRegistry"`
+
+	// DefaultImageRegistry for pulling images
+	// +optional
+	DefaultImageRegistry string `json:"defaultImageRegistry"`
+
 	// +kubebuilder:validation:Required
 	// Source of the bundle.
 	Source PackageBundleControllerSource `json:"source"`

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -52,6 +52,12 @@ spec:
                 description: ActiveBundle is name of the bundle from which packages
                   should be sourced.
                 type: string
+              defaultImageRegistry:
+                description: DefaultImageRegistry for pulling images
+                type: string
+              defaultRegistry:
+                description: DefaultRegistry for pulling helm charts and the bundle
+                type: string
               logLevel:
                 description: LogLevel controls the verbosity of logging in the controller.
                 format: int32

--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -153,6 +153,17 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		managerContext.SetUninstalling(req.Name)
 	} else {
+		pbc, err := r.bundleClient.GetPackageBundleController(ctx)
+		if err != nil {
+			r.Log.Error(err, "Getting package bundle controller")
+			managerContext.Package.Status.Detail = err.Error()
+			if err = r.Status().Update(ctx, &managerContext.Package); err != nil {
+				return ctrl.Result{RequeueAfter: retryLong}, err
+			}
+			return ctrl.Result{RequeueAfter: retryLong}, nil
+		}
+		managerContext.PBC = *pbc
+
 		bundle, err := r.bundleClient.GetActiveBundle(ctx)
 		if err != nil {
 			r.Log.Error(err, "Getting active bundle")

--- a/controllers/package_controller_test.go
+++ b/controllers/package_controller_test.go
@@ -24,9 +24,12 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
+	pbc := givenPackageBundleController()
+
 	t.Run("happy path", func(t *testing.T) {
 		tf, ctx := newTestFixtures(t)
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(tf.mockBundle(), nil)
 
 		fn, pkg := tf.mockGetFnPkg()
@@ -65,6 +68,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("happy path no status update", func(t *testing.T) {
 		tf, ctx := newTestFixtures(t)
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(tf.mockBundle(), nil)
 
 		fn, pkg := tf.mockGetFnPkg()
@@ -116,6 +120,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("handles errors getting the active bundle", func(t *testing.T) {
 		tf, ctx := newTestFixtures(t)
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		testErr := errors.New("active bundle test error")
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(nil, testErr)
 		status := tf.mockStatusWriter()
@@ -143,6 +148,7 @@ func TestReconcile(t *testing.T) {
 	t.Run("status error getting active bundle", func(t *testing.T) {
 		tf, ctx := newTestFixtures(t)
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		testErr := errors.New("active bundle test error")
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(nil, testErr)
 		statusErr := errors.New("status update test error")
@@ -173,6 +179,7 @@ func TestReconcile(t *testing.T) {
 		tf.ctrlClient.EXPECT().
 			Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pkg)).
 			DoAndReturn(fn)
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(tf.mockBundle(), nil)
 
 		tf.packageManager.EXPECT().
@@ -211,6 +218,7 @@ func TestReconcile(t *testing.T) {
 			Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pkg)).
 			DoAndReturn(fn)
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		newBundle := tf.mockBundle()
 		newBundle.ObjectMeta.Name = "fake bundle"
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(newBundle, nil)
@@ -248,6 +256,7 @@ func TestReconcile(t *testing.T) {
 			DoAndReturn(fn).Times(2)
 		pkg.Spec.PackageVersion = ""
 
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(tf.mockBundle(), nil)
 
 		newBundle := tf.mockBundle()
@@ -255,6 +264,7 @@ func TestReconcile(t *testing.T) {
 			Name:   "0.2.0",
 			Digest: "sha256:deadbeef020",
 		}}
+		tf.bundleClient.EXPECT().GetPackageBundleController(gomock.Any()).Return(&pbc, nil)
 		tf.bundleClient.EXPECT().GetActiveBundle(gomock.Any()).Return(newBundle, nil)
 
 		tf.packageManager.EXPECT().

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -55,7 +55,9 @@ func givenPackageBundleController() *api.PackageBundleController {
 			Namespace: api.PackageNamespace,
 		},
 		Spec: api.PackageBundleControllerSpec{
-			ActiveBundle: testBundleName,
+			ActiveBundle:         testBundleName,
+			DefaultRegistry:      "public.ecr.aws/j0a1m4z9",
+			DefaultImageRegistry: "783794618700.dkr.ecr.us-west-2.amazonaws.com",
 			Source: api.PackageBundleControllerSource{
 				Registry:   testBundleRegistry,
 				Repository: testBundleRepository,

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -82,7 +82,7 @@ func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
 	kubeVersion := FormatKubeServerVersion(m.info)
-	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.Spec.Source.GetRef(), kubeVersion)
+	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), kubeVersion)
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")
 		if pbc.Status.State == api.BundleControllerStateActive {

--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -89,16 +89,12 @@ func (d *helmDriver) Install(ctx context.Context,
 }
 
 func (d *helmDriver) getChart(install *action.Install, source api.PackageOCISource) (*chart.Chart, error) {
-	url := getChartURL(source)
+	url := source.GetChartUri()
 	chartPath, err := install.LocateChart(url, d.settings)
 	if err != nil {
 		return nil, fmt.Errorf("locating helm chart %s tag %s: %w", url, source.Digest, err)
 	}
 	return loader.Load(chartPath)
-}
-
-func getChartURL(source api.PackageOCISource) string {
-	return "oci://" + source.AsRepoURI()
 }
 
 func (d *helmDriver) createRelease(ctx context.Context,


### PR DESCRIPTION
A development friend change so we can use something other than our private registry. This configuration would return us to a current configuration for example:

```
apiVersion: packages.eks.amazonaws.com/v1alpha1
kind: PackageBundleController
metadata:
  name: eksa-packages-bundle-controller
  namespace: eksa-packages
spec:
  defaultRegistry: public.ecr.aws/eks-anywhere
  defaultImageRegistry: public.ecr.aws/eks-anywhere
  source:
    registry: public.ecr.aws/eks-anywhere
    repository: eks-anywhere-packages-bundles
```