### PR TITLE
Tag length check failing release script

### DIFF
--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -135,7 +135,7 @@ func createECRImageDetails(images ImageDetailsECR) (ImageDetailsBothECR, error) 
 		return ImageDetailsBothECR{}, fmt.Errorf("Error marshalling image details from ECR lookup.")
 	}
 	if reflect.DeepEqual(images.PrivateImageDetails, ecrtypes.ImageDetail{}) {
-		if images.PublicImageDetails.ImageDigest != nil && images.PublicImageDetails.ImagePushedAt != nil && len(images.PublicImageDetails.ImageTags) > 0 && images.PublicImageDetails.RegistryId != nil && images.PublicImageDetails.RepositoryName != nil {
+		if images.PublicImageDetails.ImageDigest != nil && images.PublicImageDetails.ImagePushedAt != nil && images.PublicImageDetails.RegistryId != nil && images.PublicImageDetails.RepositoryName != nil {
 			copier.Copy(&t, &images.PublicImageDetails)
 			return *t, nil
 		}


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

Failure on lookup from ECR where some images get tags overridden, and have a tag length of 0.
