### PR TITLE
Rename PrivateRegistry to LocalRegistry

### DIFF
--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -65,9 +65,9 @@ type PackageBundleControllerSpec struct {
 	// +optional
 	ActiveBundle string `json:"activeBundle"`
 
-	// PrivateRegistry is the registry being used for all images, charts and bundles
+	// LocalRegistry is the registry being used for all images, charts and bundles
 	// +optional
-	PrivateRegistry string `json:"privateRegistry"`
+	LocalRegistry string `json:"privateRegistry"`
 
 	// DefaultRegistry for pulling helm charts and the bundle
 	// +optional

--- a/charts/eks-anywhere-packages/crds/crd.yaml
+++ b/charts/eks-anywhere-packages/crds/crd.yaml
@@ -66,7 +66,7 @@ spec:
                 format: int32
                 type: integer
               privateRegistry:
-                description: PrivateRegistry is the registry being used for all images,
+                description: LocalRegistry is the registry being used for all images,
                   charts and bundles
                 type: string
               upgradeCheckInterval:

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -68,7 +68,7 @@ spec:
                 format: int32
                 type: integer
               privateRegistry:
-                description: PrivateRegistry is the registry being used for all images,
+                description: LocalRegistry is the registry being used for all images,
                   charts and bundles
                 type: string
               upgradeCheckInterval:

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -43,8 +43,8 @@ func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
 			return val.(string)
 		}
 	}
-	if mc.PBC.Spec.PrivateRegistry != "" {
-		return mc.PBC.Spec.PrivateRegistry
+	if mc.PBC.Spec.LocalRegistry != "" {
+		return mc.PBC.Spec.LocalRegistry
 	}
 	if mc.Source.Registry != "" {
 		return mc.Source.Registry

--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -55,7 +55,7 @@ func givenManagerContext(driver *mocks.MockPackageDriver) *ManagerContext {
 		},
 		PBC: api.PackageBundleController{
 			Spec: api.PackageBundleControllerSpec{
-				PrivateRegistry: "privateRegistry",
+				LocalRegistry: "privateRegistry",
 			},
 		},
 		RequeueAfter: time.Duration(100),
@@ -100,7 +100,7 @@ func TestManagerContext_getRegistry(t *testing.T) {
 	t.Run("registry from bundle package", func(t *testing.T) {
 		sut := givenManagerContext(givenMockDriver(t))
 		values := make(map[string]interface{})
-		sut.PBC.Spec.PrivateRegistry = ""
+		sut.PBC.Spec.LocalRegistry = ""
 
 		assert.Equal(t, "public.ecr.aws/j0a1m4z9/", sut.getRegistry(values))
 	})
@@ -108,7 +108,7 @@ func TestManagerContext_getRegistry(t *testing.T) {
 	t.Run("registry from default gated registry", func(t *testing.T) {
 		sut := givenManagerContext(givenMockDriver(t))
 		values := make(map[string]interface{})
-		sut.PBC.Spec.PrivateRegistry = ""
+		sut.PBC.Spec.LocalRegistry = ""
 		sut.Source.Registry = ""
 
 		assert.Equal(t, "783794618700.dkr.ecr.us-west-2.amazonaws.com", sut.getRegistry(values))


### PR DESCRIPTION
The Name LocalRegistry is perhaps less confusing than PrivateRegistry 
