### PR TITLE
Short term workaround for Emissary Hardcoded namespace

### DIFF
--- a/charts/eks-anywhere-packages/templates/configmap.yaml
+++ b/charts/eks-anywhere-packages/templates/configmap.yaml
@@ -36,3 +36,4 @@ metadata:
   {{- end }}
 data:
   {{ .Values.namespace }}: {{ include "eks-anywhere-packages.fullname" . }}
+  emissary-system: emissary-ingress

--- a/ecrtokenrefresher/cmd/ecr-token-refresher/main.go
+++ b/ecrtokenrefresher/cmd/ecr-token-refresher/main.go
@@ -45,8 +45,7 @@ func main() {
 
 	err, failedList := k8s.UpdateTokens(secretname, credentials.Username, credentials.Token, credentials.Registry)
 	if len(failedList) > 0 {
-		errorLogger.Fatalf("Failed to update the following namespaces", failedList)
-		checkErrAndLog(err, errorLogger)
+		errorLogger.Printf("Failed to update the following namespaces", failedList)
 	}
 	checkErrAndLog(err, errorLogger)
 

--- a/ecrtokenrefresher/pkg/kubernetes/kubernetes.go
+++ b/ecrtokenrefresher/pkg/kubernetes/kubernetes.go
@@ -66,7 +66,7 @@ func UpdateTokens(secretname string, username string, token string, registries s
 		}
 	}
 
-	return err, failedList
+	return nil, failedList
 }
 
 func getClientSet() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
Short term workaround to add emissary-system to config map so that ecrtokenrefresher to always updates that namespace. Also removed failure in case namespace secret couldn't be updated in case emissary was not installed to not trigger unnecessary cronjob runs.
