### PR TITLE
generatebundlefile: update oras to 0.13.0.

### DIFF
--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -61,7 +61,7 @@ test:
 presubmit: build test # lint is run via github action
 
 ## ORAS Make commands
-ORAS_VERSION := "0.12.0"
+ORAS_VERSION := "0.13.0"
 ifeq ($(OS),Windows_NT)
         # no op
 else

--- a/generatebundlefile/go.sum
+++ b/generatebundlefile/go.sum
@@ -774,7 +774,6 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -27,9 +27,9 @@ function awsAuth () {
         local region=us-west-2
     fi
 
-    if [[ ! -v PROFILE  ]]; then
-        aws $ecr --region $region get-login-password | docker login --username AWS --password-stdin ${REPO}
-    else
-        aws $ecr --region $region get-login-password --profile ${PROFILE:-default} | docker login --username AWS --password-stdin ${REPO}
+    local -a flags=()
+    if [ -n "$PROFILE" ]; then
+	flags+=("--profile=${PROFILE}")
     fi
+    aws $ecr --region $region get-login-password "${flags[@]}"
 }

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -46,9 +46,10 @@ function generate () {
 function push () {
     local version=$1
     cd "${BASE_DIRECTORY}/generatebundlefile/output"
-    awsAuth "ecr-public"
-    "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-    "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
+        "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
+        "${REPO}:v${version}-latest" bundle.yaml
 }
 
 for version in 1-21 1-22; do

--- a/generatebundlefile/hack/release.sh
+++ b/generatebundlefile/hack/release.sh
@@ -82,9 +82,10 @@ function generate () {
 function push () {
     local version=$1
     cd "${BASE_DIRECTORY}/generatebundlefile/output"
-    awsAuth "ecr-public"
-    "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-    "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
+        "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
+        "${REPO}:v${version}-latest" bundle.yaml
 }
 
 docker logout public.ecr.aws


### PR DESCRIPTION
This upgrades our oras cli to 0.13.0 which adds the --password-stdin flag to the push and pull commands, which in turn allows us to simplify our authentication with oras.