### PR TITLE
 Fix kube version again

### DIFF
--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -56,25 +56,27 @@ func (config *PackageBundle) LessThan(rhsBundle *PackageBundle) bool {
 
 // getMajorMinorBuild returns the Kubernetes major version, Kubernetes minor
 // version, and bundle build version.
-func (config *PackageBundle) getMajorMinorBuild() (major string, minor string, build string, err error) {
+func (config *PackageBundle) getMajorMinorBuild() (major int, minor int, build int, err error) {
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
 	s[0] = strings.TrimPrefix(s[0], "v")
-	_, err = strconv.Atoi(s[0])
+	build = 0
+	minor = 0
+	major, err = strconv.Atoi(s[0])
 	if err != nil {
 		return major, minor, build, fmt.Errorf("invalid major number <%s>", config.Name)
 	} else {
-		_, err = strconv.Atoi(s[1])
+		minor, err = strconv.Atoi(s[1])
 		if err != nil {
 			return major, minor, build, fmt.Errorf("invalid minor number <%s>", config.Name)
 		} else {
-			_, err = strconv.Atoi(s[2])
+			build, err = strconv.Atoi(s[2])
 			if err != nil {
 				return major, minor, build, fmt.Errorf("invalid build number <%s>", config.Name)
 			}
 		}
 	}
-	return s[0], s[1], s[2], err
+	return major, minor, build, err
 }
 
 // getMajorMinorFromString returns the Kubernetes major and minor version.
@@ -99,7 +101,7 @@ func (config *PackageBundle) KubeVersionMatches(targetKubeVersion *version.Info)
 	if err != nil {
 		return false, err
 	}
-	return currKubeMajor == targetKubeVersion.Major && currKubeMinor == targetKubeVersion.Minor, nil
+	return fmt.Sprint(currKubeMajor) == targetKubeVersion.Major && fmt.Sprint(currKubeMinor) == targetKubeVersion.Minor, nil
 }
 
 func (config *PackageBundle) GetPackageFromBundle(packageName string) (*BundlePackage, error) {

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -60,6 +60,13 @@ func (config *PackageBundle) getMajorMinorBuild() (major string, minor string, b
 	s := strings.Split(config.Name, "-")
 	s = append(s, "", "", "")
 	s[0] = strings.TrimPrefix(s[0], "v")
+	_, err = strconv.Atoi(s[0])
+	if err == nil {
+		_, err = strconv.Atoi(s[1])
+		if err == nil {
+			_, err = strconv.Atoi(s[2])
+		}
+	}
 	return s[0], s[1], s[2], err
 }
 

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -61,10 +61,17 @@ func (config *PackageBundle) getMajorMinorBuild() (major string, minor string, b
 	s = append(s, "", "", "")
 	s[0] = strings.TrimPrefix(s[0], "v")
 	_, err = strconv.Atoi(s[0])
-	if err == nil {
+	if err != nil {
+		return major, minor, build, fmt.Errorf("invalid major number <%s>", config.Name)
+	} else {
 		_, err = strconv.Atoi(s[1])
-		if err == nil {
+		if err != nil {
+			return major, minor, build, fmt.Errorf("invalid minor number <%s>", config.Name)
+		} else {
 			_, err = strconv.Atoi(s[2])
+			if err != nil {
+				return major, minor, build, fmt.Errorf("invalid build number <%s>", config.Name)
+			}
 		}
 	}
 	return s[0], s[1], s[2], err
@@ -89,6 +96,9 @@ func getMajorMinorFromString(kubeVersion string) (major int, minor int) {
 // ignore the patch numbers.
 func (config *PackageBundle) KubeVersionMatches(targetKubeVersion *version.Info) (matches bool, err error) {
 	currKubeMajor, currKubeMinor, _, err := config.getMajorMinorBuild()
+	if err != nil {
+		return false, err
+	}
 	return currKubeMajor == targetKubeVersion.Major && currKubeMinor == targetKubeVersion.Minor, nil
 }
 

--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -6,10 +6,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/version"
 	"path"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/version"
 )
 
 const (

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -1,11 +1,11 @@
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/version"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 func TestPackageBundle_Find(t *testing.T) {

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -151,7 +151,7 @@ func TestKubeVersionMatches(t *testing.T) {
 		Name: "v1-21-1001"}}
 
 	t.Run("Kubernetes version matches", func(t *testing.T) {
-		var targetVersion = &version.Info{Major: "1", Minor: "21", GitVersion: "1"}
+		var targetVersion = &version.Info{Major: "1", Minor: "21"}
 
 		result, err := bundle.KubeVersionMatches(targetVersion)
 
@@ -160,7 +160,7 @@ func TestKubeVersionMatches(t *testing.T) {
 	})
 
 	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
-		var targetVersion = &version.Info{Major: "2", Minor: "21", GitVersion: "1"}
+		var targetVersion = &version.Info{Major: "2", Minor: "21"}
 
 		result, err := bundle.KubeVersionMatches(targetVersion)
 
@@ -169,7 +169,7 @@ func TestKubeVersionMatches(t *testing.T) {
 	})
 
 	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
-		var targetVersion = &version.Info{Major: "1", Minor: "22", GitVersion: "1"}
+		var targetVersion = &version.Info{Major: "1", Minor: "22"}
 
 		result, err := bundle.KubeVersionMatches(targetVersion)
 
@@ -202,7 +202,7 @@ func TestKubeVersionMatches(t *testing.T) {
 	t.Run("bogus build", func(t *testing.T) {
 		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
 			Name: "v1-21-x"}}
-		var targetVersion = &version.Info{Major: "1", Minor: "22"}
+		var targetVersion = &version.Info{Major: "1", Minor: "21"}
 
 		result, err := bundle.KubeVersionMatches(targetVersion)
 

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/version"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -144,74 +145,71 @@ func TestGetMajorMinorFromString(t *testing.T) {
 	})
 }
 
-//func TestKubeVersionMatches(t *testing.T) {
-//
-//	bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-//		Name: "v1-21-1001"}}
-//
-//	t.Run("Kubernetes version matches", func(t *testing.T) {
-//
-//		targetVersion := "v1-21-1"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.True(t, result)
-//		assert.NoError(t, err)
-//	})
-//
-//	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
-//
-//		targetVersion := "v2-21-1"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.False(t, result)
-//		assert.NoError(t, err)
-//	})
-//
-//	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
-//
-//		targetVersion := "v1-22-1"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.False(t, result)
-//		assert.NoError(t, err)
-//	})
-//
-//	t.Run("bogus major", func(t *testing.T) {
-//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-//			Name: "vx-21-1001"}}
-//		targetVersion := "v1-21"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.False(t, result)
-//		assert.EqualError(t, err, "inavlid major number <vx-21-1001>")
-//	})
-//
-//	t.Run("bogus minor", func(t *testing.T) {
-//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-//			Name: "v1-x-1001"}}
-//		targetVersion := "v1-21"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.False(t, result)
-//		assert.EqualError(t, err, "inavlid minor number <v1-x-1001>")
-//	})
-//
-//	t.Run("bogus build", func(t *testing.T) {
-//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-//			Name: "v1-21-x"}}
-//		targetVersion := "v1-22"
-//
-//		result, err := bundle.KubeVersionMatches(targetVersion)
-//
-//		assert.False(t, result)
-//		assert.EqualError(t, err, "inavlid build number <v1-21-x>")
-//	})
-//}
+func TestKubeVersionMatches(t *testing.T) {
+
+	bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+		Name: "v1-21-1001"}}
+
+	t.Run("Kubernetes version matches", func(t *testing.T) {
+		var targetVersion = &version.Info{Major: "1", Minor: "21", GitVersion: "1"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.True(t, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
+		var targetVersion = &version.Info{Major: "2", Minor: "21", GitVersion: "1"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.False(t, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
+		var targetVersion = &version.Info{Major: "1", Minor: "22", GitVersion: "1"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.False(t, result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("bogus major", func(t *testing.T) {
+		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+			Name: "vx-21-1001"}}
+		var targetVersion = &version.Info{Major: "1", Minor: "21"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.False(t, result)
+		assert.EqualError(t, err, "invalid major number <vx-21-1001>")
+	})
+
+	t.Run("bogus minor", func(t *testing.T) {
+		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+			Name: "v1-x-1001"}}
+		var targetVersion = &version.Info{Major: "1", Minor: "21"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.False(t, result)
+		assert.EqualError(t, err, "invalid minor number <v1-x-1001>")
+	})
+
+	t.Run("bogus build", func(t *testing.T) {
+		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+			Name: "v1-21-x"}}
+		var targetVersion = &version.Info{Major: "1", Minor: "22"}
+
+		result, err := bundle.KubeVersionMatches(targetVersion)
+
+		assert.False(t, result)
+		assert.EqualError(t, err, "invalid build number <v1-21-x>")
+	})
+}
 
 func TestIsValidVersion(t *testing.T) {
 	t.Run("valid version", func(t *testing.T) {

--- a/api/v1alpha1/packagebundle_test.go
+++ b/api/v1alpha1/packagebundle_test.go
@@ -144,74 +144,74 @@ func TestGetMajorMinorFromString(t *testing.T) {
 	})
 }
 
-func TestKubeVersionMatches(t *testing.T) {
-
-	bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-		Name: "v1-21-1001"}}
-
-	t.Run("Kubernetes version matches", func(t *testing.T) {
-
-		targetVersion := "v1-21-1"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.True(t, result)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
-
-		targetVersion := "v2-21-1"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.False(t, result)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
-
-		targetVersion := "v1-22-1"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.False(t, result)
-		assert.NoError(t, err)
-	})
-
-	t.Run("bogus major", func(t *testing.T) {
-		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-			Name: "vx-21-1001"}}
-		targetVersion := "v1-21"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.False(t, result)
-		assert.EqualError(t, err, "inavlid major number <vx-21-1001>")
-	})
-
-	t.Run("bogus minor", func(t *testing.T) {
-		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-			Name: "v1-x-1001"}}
-		targetVersion := "v1-21"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.False(t, result)
-		assert.EqualError(t, err, "inavlid minor number <v1-x-1001>")
-	})
-
-	t.Run("bogus build", func(t *testing.T) {
-		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
-			Name: "v1-21-x"}}
-		targetVersion := "v1-22"
-
-		result, err := bundle.KubeVersionMatches(targetVersion)
-
-		assert.False(t, result)
-		assert.EqualError(t, err, "inavlid build number <v1-21-x>")
-	})
-}
+//func TestKubeVersionMatches(t *testing.T) {
+//
+//	bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+//		Name: "v1-21-1001"}}
+//
+//	t.Run("Kubernetes version matches", func(t *testing.T) {
+//
+//		targetVersion := "v1-21-1"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.True(t, result)
+//		assert.NoError(t, err)
+//	})
+//
+//	t.Run("Kubernetes major version doesn't match", func(t *testing.T) {
+//
+//		targetVersion := "v2-21-1"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.False(t, result)
+//		assert.NoError(t, err)
+//	})
+//
+//	t.Run("Kubernetes minor version doesn't match", func(t *testing.T) {
+//
+//		targetVersion := "v1-22-1"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.False(t, result)
+//		assert.NoError(t, err)
+//	})
+//
+//	t.Run("bogus major", func(t *testing.T) {
+//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+//			Name: "vx-21-1001"}}
+//		targetVersion := "v1-21"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.False(t, result)
+//		assert.EqualError(t, err, "inavlid major number <vx-21-1001>")
+//	})
+//
+//	t.Run("bogus minor", func(t *testing.T) {
+//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+//			Name: "v1-x-1001"}}
+//		targetVersion := "v1-21"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.False(t, result)
+//		assert.EqualError(t, err, "inavlid minor number <v1-x-1001>")
+//	})
+//
+//	t.Run("bogus build", func(t *testing.T) {
+//		bundle := PackageBundle{ObjectMeta: metav1.ObjectMeta{
+//			Name: "v1-21-x"}}
+//		targetVersion := "v1-22"
+//
+//		result, err := bundle.KubeVersionMatches(targetVersion)
+//
+//		assert.False(t, result)
+//		assert.EqualError(t, err, "inavlid build number <v1-21-x>")
+//	})
+//}
 
 func TestIsValidVersion(t *testing.T) {
 	t.Run("valid version", func(t *testing.T) {

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -82,7 +82,6 @@ func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
 	kubeVersion := FormatKubeServerVersion(m.info)
-	m.log.Info("ASDFASDFASDF", "kubeVersion", kubeVersion)
 	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), kubeVersion)
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -82,6 +82,7 @@ func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
 	kubeVersion := FormatKubeServerVersion(m.info)
+	m.log.Info("ASDFASDFASDF", "kubeVersion", kubeVersion)
 	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), kubeVersion)
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")
@@ -172,7 +173,7 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 // FormatKubeServerVersion builds a string representation of the kubernetes
 // server version.
 func FormatKubeServerVersion(info version.Info) string {
-	version := fmt.Sprintf("v%s-%s", info.Major, info.Minor)
+	version := fmt.Sprintf("v%s.%s", info.Major, info.Minor)
 	// The minor version can have a trailing + character that we don't want.
 	return strings.ReplaceAll(version, "+", "")
 }

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -3,11 +3,9 @@ package bundle
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
-
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/version"
+	"sort"
 
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )
@@ -81,8 +79,7 @@ func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
 }
 
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
-	kubeVersion := FormatKubeServerVersion(m.info)
-	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), kubeVersion)
+	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), m.info.String())
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")
 		if pbc.Status.State == api.BundleControllerStateActive {
@@ -167,12 +164,4 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 	}
 
 	return nil
-}
-
-// FormatKubeServerVersion builds a string representation of the kubernetes
-// server version.
-func FormatKubeServerVersion(info version.Info) string {
-	version := fmt.Sprintf("v%s.%s", info.Major, info.Minor)
-	// The minor version can have a trailing + character that we don't want.
-	return strings.ReplaceAll(version, "+", "")
 }

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -3,9 +3,10 @@ package bundle
 import (
 	"context"
 	"fmt"
+	"sort"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/version"
-	"sort"
 
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -51,7 +51,7 @@ func mockGetBundleList(_ context.Context, bundles *api.PackageBundleList) error 
 func givenBundleManager(t *testing.T) (version.Info, *bundleMocks.MockRegistryClient, *bundleMocks.MockClient, *bundleManager) {
 	rc := bundleMocks.NewMockRegistryClient(gomock.NewController(t))
 	bc := bundleMocks.NewMockClient(gomock.NewController(t))
-	info := version.Info{Major: "1", Minor: "21+"}
+	info := version.Info{GitVersion: testKubernetesVersion}
 	bm := NewBundleManager(logr.Discard(), info, rc, bc)
 	return info, rc, bc, bm
 }

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -19,7 +19,7 @@ import (
 const testPreviousBundleName = "v1-21-1002"
 const testBundleName = "v1-21-1003"
 const testNextBundleName = "v1-21-1004"
-const testKubernetesVersion = "v1-21"
+const testKubernetesVersion = "v1.21"
 
 func GivenBundle(state api.PackageBundleStateEnum) *api.PackageBundle {
 	return &api.PackageBundle{

--- a/pkg/bundle/registry_client.go
+++ b/pkg/bundle/registry_client.go
@@ -41,8 +41,9 @@ var _ RegistryClient = (*registryClient)(nil)
 // returned, which is not acceptable.
 func (rc *registryClient) LatestBundle(ctx context.Context, baseRef string, kubeVersion string) (*api.PackageBundle, error) {
 	tag := "latest"
+	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
 	kubeVersionSplit := strings.Split(kubeVersion, ".")
-	if len(kubeVersionSplit) < 1 {
+	if len(kubeVersionSplit) < 2 {
 		return nil, fmt.Errorf("kubeversion should be in <major>.<minor> format")
 	}
 	major, minor := kubeVersionSplit[0], kubeVersionSplit[1]

--- a/pkg/webhook/packagebundlecontroller_webhook_test.go
+++ b/pkg/webhook/packagebundlecontroller_webhook_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/version"
 	"log"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestHandleInner(t *testing.T) {
 
 	t.Run("validates successfully", func(t *testing.T) {
 		v := &activeBundleValidator{
-			kubeVersion: "v1-21",
+			info: &version.Info{Major: "1", Minor: "21"},
 		}
 		pbc := &v1alpha1.PackageBundleController{
 			Spec: v1alpha1.PackageBundleControllerSpec{
@@ -66,7 +67,7 @@ func TestHandleInner(t *testing.T) {
 
 	t.Run("invalidates successfully", func(t *testing.T) {
 		v := &activeBundleValidator{
-			kubeVersion: "v1-20",
+			info: &version.Info{Major: "1", Minor: "20"},
 		}
 		pbc := &v1alpha1.PackageBundleController{
 			Spec: v1alpha1.PackageBundleControllerSpec{

--- a/pkg/webhook/packagebundlecontroller_webhook_test.go
+++ b/pkg/webhook/packagebundlecontroller_webhook_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/version"
 	"log"
 	"testing"
 
@@ -27,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"


### PR DESCRIPTION
With all these kubeVersion changes lately, it got borked and I guess I didn't notice because I had a bundle. This fixes the latest bundle call for the package controller without breaking the usage for the CLI. I also tried to clean up kubeVersion handling in general and avoid things like make it a string and then parse the string.
