### PR TITLE
Add default to defaultRegistry

### DIFF
--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -69,6 +69,7 @@ type PackageBundleControllerSpec struct {
 	// +optional
 	PrivateRegistry string `json:"privateRegistry"`
 
+	// +kubebuilder:default:="public.ecr.aws/eks-anywhere"
 	// DefaultRegistry for pulling helm charts and the bundle
 	// +optional
 	DefaultRegistry string `json:"defaultRegistry"`

--- a/charts/eks-anywhere-packages/crds/crd.yaml
+++ b/charts/eks-anywhere-packages/crds/crd.yaml
@@ -59,6 +59,7 @@ spec:
                 description: DefaultImageRegistry for pulling images
                 type: string
               defaultRegistry:
+                default: public.ecr.aws/eks-anywhere
                 description: DefaultRegistry for pulling helm charts and the bundle
                 type: string
               logLevel:

--- a/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
+++ b/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: eksa-packages
 spec:
   bundleRepository: eks-anywhere-packages-bundles
-  defaultImageRegistry: {{.Values.sourceRegistry}}
-  defaultRegistry: {{.Values.sourceRegistry}}
   upgradeCheckInterval: 24h
   upgradeCheckShortInterval: 1h

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -61,6 +61,7 @@ spec:
                 description: DefaultImageRegistry for pulling images
                 type: string
               defaultRegistry:
+                default: public.ecr.aws/eks-anywhere
                 description: DefaultRegistry for pulling helm charts and the bundle
                 type: string
               logLevel:


### PR DESCRIPTION
A a default to devaultRegistry and remove the entries from the helm chart that were only supposed to work before GA