### PR TITLE
Downgrade oras version due to ECR bug.

### DIFF
--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -61,7 +61,7 @@ test:
 presubmit: build test # lint is run via github action
 
 ## ORAS Make commands
-ORAS_VERSION := "0.13.0"
+ORAS_VERSION := "0.12.0"
 ifeq ($(OS),Windows_NT)
         # no op
 else

--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -28,7 +28,7 @@ function awsAuth () {
     fi
 
     local -a flags=()
-    if [ -n "$PROFILE" ]; then
+    if [ -n "${PROFILE:-}" ]; then
 	flags+=("--profile=${PROFILE}")
     fi
     aws $ecr --region $region get-login-password "${flags[@]}"

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -46,10 +46,8 @@ function generate () {
 function push () {
     local version=$1
     cd "${BASE_DIRECTORY}/generatebundlefile/output"
-    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
-        "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-    awsAuth "ecr-public" | "$ORAS_BIN" push --password-stdin \
-        "${REPO}:v${version}-latest" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
+    awsAuth "ecr-public" | "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml
 }
 
 for version in 1-21 1-22; do


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

This is issue actively blocking pipelines.

*Description of changes:*

Oras 13 is not working correctly, and blocking pipeline. 

Link to [issue](https://github.com/oras-project/oras/issues/456#issuecomment-1195531498
), and comment from maintainers.

```
As a registry client, ORAS should do the layer pushing in two step:

Try to initiate an upload process via a POST request
Do the blob upload via PUT or PATCHes
During PUT(step 2), ORAS fails to reuse the token obtained by POST(step 1) and ends in rewinding the request body.

Why it only fails for ECR:
An credential cache was introduced in oras-go v2. The cache was keyed by the scopes in the oauth challenge. An OCI-compliant format of the scope should be like repository:some-project/some-repo:pull,push. ECR returns aws and that unexpected key prevents PUT(step 2) from getting the token cached by POST(step 1).

We had a fix in oras-go and will apply the change to CLI. This issue will be fixed in upcoming ORAS release.

cc @nima
```