### PR TITLE
generatebundlefile: More work to revert back to older oras

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -18,18 +18,16 @@
 # functions, source this file, e.g.:
 #    . <path-to-this-file>/common.sh
 
-# awsAuth logins into the registry
+# awsAuth echoes an AWS ECR password
 function awsAuth () {
-    local  ecr=$1
-    if [[ $ecr = "ecr-public" ]]; then
-        local region=us-east-1
-    else
-        local region=us-west-2
+    local repo=${1?:no repo specified}
+    local awsCmd="ecr"
+    local region="--region=us-west-2"
+
+    if [[ $repo =~ "public.ecr.aws" ]]; then
+        awsCmd="ecr-public"
+        region="--region=us-east-1"
     fi
 
-    local -a flags=()
-    if [ -n "${PROFILE:-}" ]; then
-	flags+=("--profile=${PROFILE}")
-    fi
-    aws $ecr --region $region get-login-password "${flags[@]}"
+    aws "$awsCmd" "$region" "--profile=${PROFILE:-}" get-login-password
 }

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -35,19 +35,19 @@ make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin
 
 function generate () {
-    local version=$1
-    local kms_key=signingPackagesKey
+    local version=${1?:no version specified}
 
     cd "${BASE_DIRECTORY}/generatebundlefile"
     ./bin/generatebundlefile --input "./data/input_${version/-}.yaml" \
-                 --key alias/${kms_key}
+			     --key alias/signingPackagesKey
 }
 
 function push () {
-    local version=$1
+    local version=${1?:no version specified}
     cd "${BASE_DIRECTORY}/generatebundlefile/output"
-    awsAuth "ecr-public" | "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
-    awsAuth "ecr-public" | "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml
+    awsAuth "$REPO" | "$ORAS_BIN" login "$REPO" --username AWS --password-stdin
+    "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
+    "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml
 }
 
 for version in 1-21 1-22; do


### PR DESCRIPTION
Older versions of oras don't support --password-stdin, so we have to perform a
separate login action before we push things.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
