### PR TITLE
Use default registry instead of default account for authorization token

### DIFF
--- a/ecrtokenrefresher/pkg/aws/aws.go
+++ b/ecrtokenrefresher/pkg/aws/aws.go
@@ -22,11 +22,15 @@ const (
 	envWebTokenFile    = "AWS_WEB_IDENTITY_TOKEN_FILE" //#nosec G101
 	sessionName        = "GetECRTOKENSession"
 	sessionTimeSeconds = 1000
+	defaultAccountID   = "783794618700"
 )
 
 func GetECRCredentials() (*ECRAuth, error) {
+	var ecrRegs []*string
+	id := defaultAccountID
+	ecrRegs = append(ecrRegs, &id)
 	svc := ecr.New(session.Must(session.NewSession()))
-	token, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	token, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{RegistryIds: ecrRegs})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use default registry account for authorization token instead of the default registry associated with the authenticating AWS account.