### PR TITLE
Creating Secret in namespace via API instead of Helm Chart

### DIFF
--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -27,4 +27,7 @@ type Authenticator interface {
 
 	// GetSecretValues Retrieves ImagePullSecrets data to pass to helm chart
 	GetSecretValues(ctx context.Context, namespace string) (map[string]interface{}, error)
+
+	// AddSecretToAllNamespace Add Secrets to all namespaces
+	AddSecretToAllNamespace(ctx context.Context) error
 }

--- a/pkg/authenticator/ecrsecret_test.go
+++ b/pkg/authenticator/ecrsecret_test.go
@@ -2,7 +2,6 @@ package authenticator
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -202,8 +201,6 @@ func TestGetSecretValues(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.NotNil(t, values["imagePullSecrets"])
-		assert.Equal(t, ecrTokenName, values["pullSecretName"])
-		assert.Equal(t, base64.StdEncoding.EncodeToString(testdata), values["pullSecretData"])
 	})
 
 	t.Run("golden path for Retrieving ECR Secret when namespace already exists", func(t *testing.T) {


### PR DESCRIPTION
Create secret in namespace through API instead of relying on helm charts. Address issue that occurs when multiple packages are installed in the same namespace causing issues with helm driver.

Also adding in remove namespace from config map when uninstalling