### PR TITLE
package bundle controller: requeue quickly if webhook offline

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -114,7 +114,7 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 	if !latestBundleIsKnown {
 		err = m.bundleClient.CreateBundle(ctx, latestBundle)
 		if err != nil {
-			return fmt.Errorf("creating new package bundle: %s", err)
+			return err
 		}
 	}
 

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -276,7 +276,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "creating new package bundle: oops")
+		assert.EqualError(t, err, "oops")
 	})
 
 	t.Run("upgradeAvailable to upgradeAvailable", func(t *testing.T) {


### PR DESCRIPTION
Upon cluster startup, the package bundle controller finds itself without a
bundle. So it reaches out the registry, and tries to create and activate the
newest bundle the registry has. If the package bundle validating webhook has
not yet come online (indicated by a connection refused error), then this code
will requeue a reconcile request for just a short time, so things aren't held
up for hours.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
