### PR TITLE
Cronjob needs v1beta1 for Kubernetes 1.20

### DIFF
--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.21" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Capabilities.KubeVersion.Major|int) 1 }}
 {{- if ge (.Capabilities.KubeVersion.Minor|int) 21 }}
 apiVersion: batch/v1
 {{- else }}
@@ -42,3 +43,4 @@ spec:
                       name: aws-secret
                       key: REGION
                       optional: true
+{{- end }}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,4 +1,8 @@
+{{- if ge (.Capabilities.KubeVersion.Minor|int) 21 }}
 apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   namespace: {{ .Values.namespace }}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,5 +1,4 @@
-{{- if eq (.Capabilities.KubeVersion.Major|int) 1 }}
-{{- if ge (.Capabilities.KubeVersion.Minor|int) 21 }}
+{{- if semverCompare ">=1.21" .Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1
@@ -43,4 +42,3 @@ spec:
                       name: aws-secret
                       key: REGION
                       optional: true
-{{- end }}


### PR DESCRIPTION
Fixing issue that batch v1 is not part of kubernetes 1.20 and instead needs batch v1beta1