### PR TITLE
Kubeversion fix when writing bundles

### DIFF
--- a/generatebundlefile/.gitignore
+++ b/generatebundlefile/.gitignore
@@ -3,5 +3,8 @@ dist/
 
 # directory of output from build and run of tool
 output/
+output-*/
 bin/
 hack/pullpush.sh
+hello-eks-anywhere/
+

--- a/generatebundlefile/hack/release.sh
+++ b/generatebundlefile/hack/release.sh
@@ -76,12 +76,13 @@ function generate () {
 
     cd "${BASE_DIRECTORY}/generatebundlefile"
     ./bin/generatebundlefile --input "./data/input_${version/-}_prod.yaml" \
-                 --key alias/${kms_key}
+                 --key alias/${kms_key} \
+                 --output "output-${version}"
 }
 
 function push () {
     local version=${1?:no version specified}
-    cd "${BASE_DIRECTORY}/generatebundlefile/output"
+    cd "${BASE_DIRECTORY}/generatebundlefile/output-${version}"
     awsAuth "$REPO" | "$ORAS_BIN" login "$REPO" --username AWS --password-stdin
     "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml
     "$ORAS_BIN" push "${REPO}:v${version}-latest" bundle.yaml


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

When we changed the auth flow with recent ORAS changes, it messed up the flow of writing bundles with multiple kube versions. This should fix the for prod, it's not an issue for dev bundles with the way it's currently done.
