### PR TITLE
Update helm-docs location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ docker-push: ## Push docker image with the package-manager.
 helm/build: helm-build
 helm-build: kustomize ## Build helm chart into tar file
 	hack/helm.sh
+	helm-docs
+
+helm/package: helm-package
+helm-package: kustomize ## Build helm chart into tar file
+	hack/helm.sh
 
 ##@ Deployment
 

--- a/hack/helm.sh
+++ b/hack/helm.sh
@@ -34,6 +34,5 @@ sed \
         -e "s,{{eks-anywhere-packages}},${EKS_ANYWHERE_PACKAGES_TAG}," \
         eks-anywhere-packages/values.yaml >${OUTDIR}/eks-anywhere-packages/values.yaml
 cd $OUTDIR
-helm-docs
 RESULT=$(helm package eks-anywhere-packages| sed -e 's/Successfully packaged chart and saved it to: //g')
 echo "helm install eks-anywhere-packages ${RESULT}"


### PR DESCRIPTION
Move `helm-docs` under `helm/build` make target directly. This is to help create a separate `helm/package` make target, which will be called by `make presubmit`.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/365

*Description of changes:* create a new `helm/package` target; `helm/build` won't be impacted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
