### PR TITLE
Change the default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 GOBIN=$(shell $(GO) env GOBIN)
 endif
 
-all: presubmit
+all: vet generate manifests build helm/package test # lint is run via github action
 
 ##@ General
 


### PR DESCRIPTION
Once you modify a file, the make never works again now. Change it so the default target is just like presubmit, but doesn't expect no git diffs.
