### PR TITLE
fixing image copy source file

### DIFF
--- a/generatebundlefile/hack/release.sh
+++ b/generatebundlefile/hack/release.sh
@@ -42,7 +42,7 @@ aws ecr get-login-password --region us-west-2 | HELM_EXPERIMENTAL_OCI=1 helm reg
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
 
 ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
-    --input ${BASE_DIRECTORY}/generatebundlefile/data/input_121.yaml \
+    --input ${BASE_DIRECTORY}/generatebundlefile/data/input_release.yaml \
     --private-profile ${PROFILE}
 
 # Release Helm Chart, and bundle to Production account


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

Had missed this during the GA, but for the image copy source we should be using this new release file, and not a Dev bundle file for copying over images pinned to a helm version.
