### PR TITLE
Clean up log name a bit

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -71,7 +71,7 @@ func NewPackageReconciler(client client.Client, scheme *runtime.Scheme,
 		Manager:       manager,
 		bundleManager: bundleManager,
 		bundleClient:  bundleClient,
-		Log:           log.WithName(packageName),
+		Log:           log,
 	}
 }
 

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -54,7 +54,7 @@ func NewPackageBundleReconciler(client client.Client, scheme *runtime.Scheme,
 	return &(PackageBundleReconciler{
 		Client:         client,
 		Scheme:         scheme,
-		Log:            log.WithName(packageBundleName),
+		Log:            log,
 		bundleClient:   bundleClient,
 		registryClient: registryClient,
 		bundleManager:  bundleManager,


### PR DESCRIPTION
Log names were showing up duplicated, so this change makes it
```
1.6625157014696069e+09	LEVEL(-6)	PackageBundle	Reconcile:	{"bundle": "eksa-packages/v1-21-70"}
```
with PackageBundle instead of PackageBundle.PackageBundle
