### PR TITLE
Make uninstall idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	kubectl delete packages -n eksa-packages $(kubectl get packages -n eksa-packages --no-headers -o custom-columns=":metadata.name") && sleep 5 || true
 	helm delete eks-anywhere-packages || true
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | kubectl delete -f - || true
 	kubectl delete namespace eksa-packages || true
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
I like to run `make uninstall install run` to get a clean slate with functionally testing and if I don't have anything installed, this fails. This change makes it work every time.
