### PR TITLE
Named version for profile commands, and better docs

### DIFF
--- a/generatebundlefile/.gitignore
+++ b/generatebundlefile/.gitignore
@@ -7,4 +7,4 @@ output-*/
 bin/
 hack/pullpush.sh
 hello-eks-anywhere/
-
+data/tests

--- a/generatebundlefile/README.md
+++ b/generatebundlefile/README.md
@@ -41,10 +41,132 @@ generatebundlefile --generate-sample
 
 This will output a sample bundle file to ./output.
 
+
+### Public Promotion to another Account
+
+```sh
+generatebundlefile --private-profile "profile-name" --input data/sample_input.yaml
+```
+
+This command will move **Only** the helm chart from the listed input files to the target **public** ECR in another account.
+
+### Private Promotion to another Account
+
+```sh
+generatebundlefile --private-profile "profile-name" --input data/sample_input.yaml
+```
+
+This command will move **Only** the images from the listed helm charts in the input files to the target **private** ECR in another account.
+
 ### Package Promotion
 
 To promote a package from a private ECR to public you need the repository name. This repository must contain a Helm chart built by the process in the eks-anywhere-build-tooling git repository.
+This will **both** for the helm chart, and the imgaes required to the public ECR of the calling user.
+
+**This command only supports promotion of the latest helm chart from the private repository.**
 
 ```sh
 generatebundlefile --promote hello-eks-anywhere
+```
+
+### Input File Supported Formats
+
+Currently the following formats can be used as input files each of the following command flags.
+
+--key alias/signingPackagesKey
+--private-profile
+--public--profile
+
+#### Private Registry
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: 646717423341.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+```
+
+#### Public Registry
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: latest
+```
+
+#### Latest Version
+
+The "latest" tag will tell the program to use a timestamp lookup, and find the most recently pushed helm chart for information, even if it does have the actual latest tag.
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: latest
+```
+
+#### Named Version
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.1.1-083e68edbbc62ca0228a5669e89e4d3da99ff73b
+```
+
+#### Multiple Versions
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.1.1-92904119e6e1bae35bf88663d0875259d42346f8
+            - name: 0.1.1-083e68edbbc62ca0228a5669e89e4d3da99ff73b
+```
+
+#### Mixed Format (Latest + Named)
+
+```yaml
+name: "v1-21-1001"
+kubernetesVersion: "1.21"
+packages:
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.1.1-92904119e6e1bae35bf88663d0875259d42346f8
+            - name: latest
 ```

--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -103,7 +103,7 @@ func (c *SDKClients) GetProfileSDKConnection(service, profile string) (*SDKClien
 }
 
 // PromoteHelmChart will take a given repository, and authFile and handle helm and image promotion for the mentioned chart.
-func (c *SDKClients) PromoteHelmChart(repository, authFile string, copyImages bool) error {
+func (c *SDKClients) PromoteHelmChart(repository, authFile, tag string, copyImages bool) error {
 	var name, version, sha string
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -114,14 +114,14 @@ func (c *SDKClients) PromoteHelmChart(repository, authFile string, copyImages bo
 	// The first scenario runs for flags --private-profile and --promote.
 	// The 2nd scenario runs for flags and --public-profile.
 	if c.ecrClientRelease != nil || c.ecrClient != nil {
-		name, version, sha, err = c.getNameAndVersion(repository, c.stsClient.AccountID)
+		name, version, sha, err = c.getNameAndVersion(repository, tag, c.stsClient.AccountID)
 		if err != nil {
 			return fmt.Errorf("Error getting name and version from helmchart %s", err)
 		}
 	}
 
 	if c.ecrPublicClientRelease != nil {
-		name, version, sha, err = c.getNameAndVersionPublic(repository, c.stsClient.AccountID)
+		name, version, sha, err = c.getNameAndVersionPublic(repository, tag, c.stsClient.AccountID)
 		if err != nil {
 			return fmt.Errorf("Error getting name and version from helmchart %s", err)
 		}


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Named version support was never added for the profile commands, and it always defaulted to looking up the latest and messing up the private-profile run since it's calling this file https://github.com/aws/eks-anywhere-packages/blob/main/generatebundlefile/data/input_release.yaml.  

Noticed this issue the new `hello-eks-anywhere` changes recently.