### PR TITLE
Limiting Helmdriver Upgrade History to address OOMKill

### DIFF
--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -20,6 +20,10 @@ import (
 	auth "github.com/aws/eks-anywhere-packages/pkg/authenticator"
 )
 
+const (
+	varHelmUpgradeMaxHistory = 2
+)
+
 // helmDriver implements PackageDriver to install packages from Helm charts.
 type helmDriver struct {
 	cfg        *action.Configuration
@@ -161,6 +165,8 @@ func (d *helmDriver) upgradeRelease(ctx context.Context, name string,
 	// upgrade unless changes in the values are detected. For POC, run helm
 	// every time and rely on its idempotency.
 	upgrade := action.NewUpgrade(d.cfg)
+	// Limit history saved as secret for resource limit
+	upgrade.MaxHistory = varHelmUpgradeMaxHistory
 	_, err = upgrade.RunWithContext(ctx, name, helmChart, values)
 	if err != nil {
 		return fmt.Errorf("upgrading helm release %s: %w", name, err)


### PR DESCRIPTION
…on failed package installs

*Issue #473 *

Should prevent us from hitting the resource limit while still giving us some history on failed installs. The previous implementation used the default which keeps all the history.