### PR TITLE
Do no use kubeconfig for self

### DIFF
--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
               value: {{ .Values.proxy.HTTPS_PROXY | quote}}
             - name: NO_PROXY
               value: {{ .Values.proxy.NO_PROXY | quote}}
+            - name: CLUSTER_NAME
+              value: {{ .Values.clusterName | quote}}
           ports:
             - name: webhook-server
               containerPort: 9443

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,8 @@ const (
 	retryVeryLong  = time.Duration(180) * time.Second
 	sourceRegistry = "sourceRegistry"
 	prefix         = api.PackageNamespace + "-"
+	oldPbcName     = "bundle-controller"
+	CLUSTER_NAME   = "CLUSTER_NAME"
 )
 
 type ManagerContext struct {
@@ -42,7 +45,16 @@ func (mc *ManagerContext) SetUninstalling(namespace string, name string) {
 
 func (mc *ManagerContext) getClusterName() string {
 	if strings.HasPrefix(mc.Package.Namespace, prefix) {
-		return strings.TrimPrefix(mc.Package.Namespace, prefix)
+		clusterName := strings.TrimPrefix(mc.Package.Namespace, prefix)
+		// Backward compatibility
+		if clusterName == oldPbcName {
+			return ""
+		}
+		// Avoid using kubeconfig for ourselves
+		if os.Getenv(CLUSTER_NAME) == clusterName {
+			return ""
+		}
+		return clusterName
 	}
 	return ""
 }


### PR DESCRIPTION
Do not use kubeconfig for self managed cluster. This fixes docker clusters for example that cannot access their apiserver with the IP in the kubeconfig.
