### PR TITLE
Move sort into bundle list

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -3,7 +3,6 @@ package bundle
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/version"
@@ -17,9 +16,6 @@ type Manager interface {
 
 	// ProcessBundleController process the bundle controller
 	ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error
-
-	// SortBundlesDescending sort bundles latest first
-	SortBundlesDescending(bundles []api.PackageBundle)
 }
 
 type bundleManager struct {
@@ -70,15 +66,6 @@ func (m bundleManager) ProcessBundle(ctx context.Context, newBundle *api.Package
 	return false, nil
 }
 
-// SortBundlesDescending will sort a slice of bundles in descending order so
-// that the newest (greatest) bundle will be displayed first.
-func (m bundleManager) SortBundlesDescending(bundles []api.PackageBundle) {
-	sortFn := func(i, j int) bool {
-		return bundles[j].LessThan(&bundles[i])
-	}
-	sort.Slice(bundles, sortFn)
-}
-
 func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.PackageBundleController) error {
 	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), m.info.String())
 	if err != nil {
@@ -93,13 +80,10 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 		return nil
 	}
 
-	knownBundles := &api.PackageBundleList{}
-	err = m.bundleClient.GetBundleList(ctx, knownBundles)
+	sortedBundles, err := m.bundleClient.GetBundleList(ctx)
 	if err != nil {
 		return fmt.Errorf("getting bundle list: %s", err)
 	}
-	sortedBundles := knownBundles.Items
-	m.SortBundlesDescending(sortedBundles)
 
 	latestBundleIsKnown := false
 	latestBundleIsCurrentBundle := true

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -82,17 +82,18 @@ func (mr *MockClientMockRecorder) GetActiveBundleNamespacedName(ctx interface{})
 }
 
 // GetBundleList mocks base method.
-func (m *MockClient) GetBundleList(ctx context.Context, bundles *v1alpha1.PackageBundleList) error {
+func (m *MockClient) GetBundleList(ctx context.Context) ([]v1alpha1.PackageBundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundleList", ctx, bundles)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetBundleList", ctx)
+	ret0, _ := ret[0].([]v1alpha1.PackageBundle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBundleList indicates an expected call of GetBundleList.
-func (mr *MockClientMockRecorder) GetBundleList(ctx, bundles interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetBundleList(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleList", reflect.TypeOf((*MockClient)(nil).GetBundleList), ctx, bundles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleList", reflect.TypeOf((*MockClient)(nil).GetBundleList), ctx)
 }
 
 // GetPackageBundleController mocks base method.

--- a/pkg/bundle/mocks/manager.go
+++ b/pkg/bundle/mocks/manager.go
@@ -63,15 +63,3 @@ func (mr *MockManagerMockRecorder) ProcessBundleController(ctx, pbc interface{})
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBundleController", reflect.TypeOf((*MockManager)(nil).ProcessBundleController), ctx, pbc)
 }
-
-// SortBundlesDescending mocks base method.
-func (m *MockManager) SortBundlesDescending(bundles []v1alpha1.PackageBundle) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SortBundlesDescending", bundles)
-}
-
-// SortBundlesDescending indicates an expected call of SortBundlesDescending.
-func (mr *MockManagerMockRecorder) SortBundlesDescending(bundles interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SortBundlesDescending", reflect.TypeOf((*MockManager)(nil).SortBundlesDescending), bundles)
-}


### PR DESCRIPTION
The get bundle list method needs to be a bit more selective for remote management (by k8s version), so this takes it one baby step by combining the get with the sort.