### PR TITLE
Move active bundle download

### DIFF
--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -33,10 +33,10 @@ func (config *PackageBundleController) GetDefaultImageRegistry() string {
 	return defaultImageRegistry
 }
 
-func (config *PackageBundleController) GetBundleUri() (uri string) {
+func (config *PackageBundleController) GetBundleURI() (uri string) {
 	return path.Join(config.GetDefaultRegistry(), config.Spec.BundleRepository)
 }
 
-func (config *PackageBundleController) GetActiveBundleUri() (uri string) {
-	return config.GetBundleUri() + ":" + config.Spec.ActiveBundle
+func (config *PackageBundleController) GetActiveBundleURI() (uri string) {
+	return config.GetBundleURI() + ":" + config.Spec.ActiveBundle
 }

--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -36,3 +36,7 @@ func (config *PackageBundleController) GetDefaultImageRegistry() string {
 func (config *PackageBundleController) GetBundleUri() (uri string) {
 	return path.Join(config.GetDefaultRegistry(), config.Spec.BundleRepository)
 }
+
+func (config *PackageBundleController) GetActiveBundleUri() (uri string) {
+	return config.GetBundleUri() + ":" + config.Spec.ActiveBundle
+}

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -9,11 +9,7 @@ import (
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )
 
-const (
-	TestBundleName       = "v1-21-1003"
-	TestBundleRegistry   = "public.ecr.aws/j0a1m4z9"
-	TestBundleRepository = "eks-anywhere-packages-bundles"
-)
+const TestBundleName = "v1-21-1003"
 
 func TestPackageBundleController_IsValid(t *testing.T) {
 	givenBundleController := func(name string, namespace string) *api.PackageBundleController {
@@ -51,4 +47,9 @@ func GivenPackageBundleController() *api.PackageBundleController {
 func TestPackageBundleController_GetBundleUri(t *testing.T) {
 	sut := GivenPackageBundleController()
 	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles", sut.GetBundleUri())
+}
+
+func TestPackageBundleController_GetActiveBundleUri(t *testing.T) {
+	sut := GivenPackageBundleController()
+	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003", sut.GetActiveBundleUri())
 }

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -44,12 +44,12 @@ func GivenPackageBundleController() *api.PackageBundleController {
 	}
 }
 
-func TestPackageBundleController_GetBundleUri(t *testing.T) {
+func TestPackageBundleController_GetBundleURI(t *testing.T) {
 	sut := GivenPackageBundleController()
 	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles", sut.GetBundleURI())
 }
 
-func TestPackageBundleController_GetActiveBundleUri(t *testing.T) {
+func TestPackageBundleController_GetActiveBundleURI(t *testing.T) {
 	sut := GivenPackageBundleController()
 	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003", sut.GetActiveBundleURI())
 }

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -46,10 +46,10 @@ func GivenPackageBundleController() *api.PackageBundleController {
 
 func TestPackageBundleController_GetBundleUri(t *testing.T) {
 	sut := GivenPackageBundleController()
-	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles", sut.GetBundleUri())
+	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles", sut.GetBundleURI())
 }
 
 func TestPackageBundleController_GetActiveBundleUri(t *testing.T) {
 	sut := GivenPackageBundleController()
-	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003", sut.GetActiveBundleUri())
+	assert.Equal(t, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003", sut.GetActiveBundleURI())
 }

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -105,6 +105,7 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
+		// ignore deletes
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -24,6 +24,9 @@ type Client interface {
 	// GetBundleList get list of bundles worthy of consideration
 	GetBundleList(ctx context.Context, serverVersion string) (bundles []api.PackageBundle, err error)
 
+	// GetBundle retrieves the named bundle.
+	GetBundle(ctx context.Context, name string) (namedBundle *api.PackageBundle, err error)
+
 	// CreateBundle add a new bundle custom resource
 	CreateBundle(ctx context.Context, bundle *api.PackageBundle) error
 
@@ -87,6 +90,27 @@ func (bc *bundleClient) GetPackageBundleController(ctx context.Context, clusterN
 		return nil, fmt.Errorf("getting PackageBundleController: %v", err)
 	}
 	return &pbc, nil
+}
+
+func (bc *bundleClient) GetBundle(ctx context.Context, name string) (namedBundle *api.PackageBundle, err error) {
+	namedBundle = &api.PackageBundle{}
+	if name == "" {
+		return namedBundle, nil
+	}
+
+	nn := types.NamespacedName{
+		Namespace: api.PackageNamespace,
+		Name:      name,
+	}
+	err = bc.Get(ctx, nn, namedBundle)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return namedBundle, nil
 }
 
 func (bc *bundleClient) GetBundleList(ctx context.Context, serverVersion string) (bundles []api.PackageBundle, err error) {

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -93,15 +93,11 @@ func (bc *bundleClient) GetPackageBundleController(ctx context.Context, clusterN
 }
 
 func (bc *bundleClient) GetBundle(ctx context.Context, name string) (namedBundle *api.PackageBundle, err error) {
-	namedBundle = &api.PackageBundle{}
-	if name == "" {
-		return namedBundle, nil
-	}
-
 	nn := types.NamespacedName{
 		Namespace: api.PackageNamespace,
 		Name:      name,
 	}
+	namedBundle = &api.PackageBundle{}
 	err = bc.Get(ctx, nn, namedBundle)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -160,6 +160,11 @@ func doAndReturnBundleList(_ context.Context, bundles *api.PackageBundleList, _ 
 	return nil
 }
 
+func doAndReturnBundle(_ context.Context, nn types.NamespacedName, theBundle *api.PackageBundle) error {
+	theBundle.Name = nn.Name
+	return nil
+}
+
 func TestBundleClient_GetBundle(t *testing.T) {
 	t.Parallel()
 
@@ -174,19 +179,9 @@ func TestBundleClient_GetBundle(t *testing.T) {
 	t.Run("already exists", func(t *testing.T) {
 		mockClient := givenMockClient(t)
 		bundleClient := NewPackageBundleClient(mockClient)
-		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(namedBundle)).Return(nil)
+		mockClient.EXPECT().Get(ctx, key, gomock.Any()).DoAndReturn(doAndReturnBundle)
 
 		actualBundle, err := bundleClient.GetBundle(ctx, "v1-21-1003")
-
-		assert.NotNil(t, actualBundle)
-		assert.NoError(t, err)
-	})
-
-	t.Run("no active bundle", func(t *testing.T) {
-		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
-
-		actualBundle, err := bundleClient.GetBundle(ctx, "")
 
 		assert.NotNil(t, actualBundle)
 		assert.NoError(t, err)
@@ -203,7 +198,7 @@ func TestBundleClient_GetBundle(t *testing.T) {
 		assert.EqualError(t, err, "boom")
 	})
 
-	t.Run("Does not exist", func(t *testing.T) {
+	t.Run("returns nil when bundle does not", func(t *testing.T) {
 		mockClient := givenMockClient(t)
 		bundleClient := NewPackageBundleClient(mockClient)
 		groupResource := schema.GroupResource{

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -81,7 +81,7 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 		return nil
 	}
 
-	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleUri(), info.String())
+	latestBundle, err := m.registryClient.LatestBundle(ctx, pbc.GetBundleURI(), info.String())
 	if err != nil {
 		m.log.Error(err, "Unable to get latest bundle")
 		if pbc.Status.State == api.BundleControllerStateActive || pbc.Status.State == "" {
@@ -133,7 +133,7 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 		}
 
 		if activeBundle == nil {
-			activeBundle, err = m.registryClient.DownloadBundle(ctx, pbc.GetActiveBundleUri())
+			activeBundle, err = m.registryClient.DownloadBundle(ctx, pbc.GetActiveBundleURI())
 			if err != nil {
 				m.log.Error(err, "Active bundle download failed", "bundle", pbc.Spec.ActiveBundle)
 				return nil

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -126,6 +126,28 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("creating namespace for %s: %s", pbc.Name, err)
 		}
 
+		activeBundle, err := m.bundleClient.GetBundle(ctx, pbc.Spec.ActiveBundle)
+		if err != nil {
+			m.log.Error(err, "Unable to get active bundle", "bundle", pbc.Spec.ActiveBundle)
+			return nil
+		}
+
+		if activeBundle == nil {
+			activeBundle, err = m.registryClient.DownloadBundle(ctx, pbc.GetActiveBundleUri())
+			if err != nil {
+				m.log.Error(err, "Active bundle download failed", "bundle", pbc.Spec.ActiveBundle)
+				return nil
+			}
+			m.log.Info("Bundle downloaded", "bundle", pbc.Spec.ActiveBundle)
+
+			err = m.bundleClient.CreateBundle(ctx, activeBundle)
+			if err != nil {
+				m.log.Error(err, "Recreate active bundle failed", "bundle", pbc.Spec.ActiveBundle)
+				return nil
+			}
+			m.log.Info("Bundle created", "bundle", pbc.Spec.ActiveBundle)
+		}
+
 		if latestBundleIsCurrentBundle {
 			break
 		}

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -144,12 +144,13 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	})
 
 	t.Run("active missing active bundle", func(t *testing.T) {
-		_, rc, bc, bm := givenBundleManager(t)
+		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
 		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
-		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
@@ -162,12 +163,13 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	})
 
 	t.Run("active missing active bundle download error", func(t *testing.T) {
-		_, rc, bc, bm := givenBundleManager(t)
+		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
 		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
-		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], fmt.Errorf("boom"))
@@ -179,12 +181,13 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	})
 
 	t.Run("active missing active bundle create error", func(t *testing.T) {
-		_, rc, bc, bm := givenBundleManager(t)
+		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
 		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
-		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
@@ -290,12 +293,13 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	})
 
 	t.Run("active to upgradeAvailable active bundle error", func(t *testing.T) {
-		_, rc, bc, bm := givenBundleManager(t)
+		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
 		latestBundle := givenBundle()
 		latestBundle.Name = testNextBundleName
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
-		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, fmt.Errorf("boom"))

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -135,6 +135,60 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, api.BundleControllerStateActive, pbc.Status.State)
+	})
+
+	t.Run("active missing active bundle", func(t *testing.T) {
+		_, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
+		latestBundle := givenBundle()
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
+		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
+		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(nil)
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, api.BundleControllerStateActive, pbc.Status.State)
+	})
+
+	t.Run("active missing active bundle download error", func(t *testing.T) {
+		_, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
+		latestBundle := givenBundle()
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
+		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], fmt.Errorf("boom"))
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.NoError(t, err)
+		assert.Equal(t, api.BundleControllerStateActive, pbc.Status.State)
+	})
+
+	t.Run("active missing active bundle create error", func(t *testing.T) {
+		_, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
+		latestBundle := givenBundle()
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
+		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
+		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(fmt.Errorf("boom"))
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
@@ -210,6 +264,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(nil)
 
 		err := bm.ProcessBundleController(ctx, pbc)
@@ -234,6 +289,22 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		assert.EqualError(t, err, "creating namespace for eksa-packages-bundle-controller: boom")
 	})
 
+	t.Run("active to upgradeAvailable active bundle error", func(t *testing.T) {
+		_, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		latestBundle := givenBundle()
+		latestBundle.Name = testNextBundleName
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
+		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, fmt.Errorf("boom"))
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("active to upgradeAvailable error", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
@@ -244,6 +315,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(fmt.Errorf("oops"))
 
 		err := bm.ProcessBundleController(ctx, pbc)

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -129,7 +129,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	t.Run("active to active", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
-		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
@@ -146,7 +145,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	t.Run("active missing active bundle", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
-		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
@@ -165,7 +163,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	t.Run("active missing active bundle download error", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
-		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
@@ -183,7 +180,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 	t.Run("active missing active bundle create error", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
-		assert.Equal(t, pbc.Spec.ActiveBundle, testBundleName)
 		latestBundle := givenBundle()
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -79,6 +79,21 @@ func (mr *MockClientMockRecorder) GetActiveBundle(ctx, clusterName interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveBundle", reflect.TypeOf((*MockClient)(nil).GetActiveBundle), ctx, clusterName)
 }
 
+// GetBundle mocks base method.
+func (m *MockClient) GetBundle(ctx context.Context, name string) (*v1alpha1.PackageBundle, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBundle", ctx, name)
+	ret0, _ := ret[0].(*v1alpha1.PackageBundle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBundle indicates an expected call of GetBundle.
+func (mr *MockClientMockRecorder) GetBundle(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockClient)(nil).GetBundle), ctx, name)
+}
+
 // GetBundleList mocks base method.
 func (m *MockClient) GetBundleList(ctx context.Context, serverVersion string) ([]v1alpha1.PackageBundle, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Move the active bundle download to PBC reconciliation

The reason for the move is if we were to reconcile on a deleted bundle, we'd have to iterate through all the PBCs to find out if it was an active bundle. That is possible, but I'd sooner the dependency went one way PBC knows about bundles, but bundles don't know necessarily about PBCs.