### PR TITLE
Use K8s-Specific Cluster Autoscaler Versions

### DIFF
--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: latest
+            - name: 9.21.0-1.21
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_122.yaml
+++ b/generatebundlefile/data/input_122.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: latest
+            - name: 9.21.0-1.22
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_123.yaml
+++ b/generatebundlefile/data/input_123.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: latest
+            - name: 9.21.0-1.23
   - org: metallb 
     projects:
       - name: metallb 


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Ties autoscaler to specific helm chart versions for each version of kubernetes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.