### PR TITLE
Rename autoscaler->cluster-autoscaler

### DIFF
--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -25,7 +25,7 @@ packages:
             - name: latest
   - org: kubernetes
     projects:
-      - name: autoscaler
+      - name: cluster-autoscaler
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:

--- a/generatebundlefile/data/input_122.yaml
+++ b/generatebundlefile/data/input_122.yaml
@@ -25,7 +25,7 @@ packages:
             - name: latest
   - org: kubernetes
     projects:
-      - name: autoscaler
+      - name: cluster-autoscaler
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:

--- a/generatebundlefile/data/input_123.yaml
+++ b/generatebundlefile/data/input_123.yaml
@@ -25,7 +25,7 @@ packages:
             - name: latest
   - org: kubernetes
     projects:
-      - name: autoscaler
+      - name: cluster-autoscaler
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Renames autoscaler->cluster-autoscaler.

**This is the first part of a refactor I will have to do changing autoscaler->cluster-autoscaler throughout the build infrastructure**. I think this is the lowest lift piece though and can be disconnected from the rest of the work.

Holding to merge this on https://github.com/aws/eks-anywhere-build-tooling/pull/1360.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.