### PR TITLE
Updating ecrtokenrefresher to support updating secret on workload clusters

### DIFF
--- a/ecrtokenrefresher/cmd/ecr-token-refresher/main.go
+++ b/ecrtokenrefresher/cmd/ecr-token-refresher/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	err, failedList := k8s.UpdateTokens(secretname, credentials.Username, credentials.Token, credentials.Registry)
 	if len(failedList) > 0 {
-		warningLogger.Printf("Failed to update the following namespaces: %s", failedList)
+		warningLogger.Printf("Failed the following: %s", failedList)
 	}
 	checkErrAndLog(err, errorLogger)
 

--- a/ecrtokenrefresher/go.mod
+++ b/ecrtokenrefresher/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.44.61
+	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
@@ -14,6 +15,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -30,6 +32,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/ecrtokenrefresher/go.sum
+++ b/ecrtokenrefresher/go.sum
@@ -77,6 +77,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -231,6 +232,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/ecrtokenrefresher/pkg/kubernetes/kubernetes.go
+++ b/ecrtokenrefresher/pkg/kubernetes/kubernetes.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,14 +28,16 @@ type auth struct {
 }
 
 const (
-	defaultEmail      = "test@test.com"
-	configMapName     = "ns-secret-map"
-	packagesNamespace = "eksa-packages"
+	defaultEmail        = "test@test.com"
+	configMapName       = "ns-secret-map"
+	eksaSystemNamespace = "eksa-system"
+	packagesNamespace   = "eksa-packages"
+	namespacePrefix     = packagesNamespace + "-"
 )
 
 func UpdateTokens(secretname string, username string, token string, registries string) (error, []string) {
 	failedList := make([]string, 0)
-	clientset, err := getClientSet()
+	clientset, err := getDefaultClientSet()
 	if err != nil {
 		return err, failedList
 	}
@@ -43,11 +47,62 @@ func UpdateTokens(secretname string, username string, token string, registries s
 		return err, failedList
 	}
 
-	targetNamespaces, err := getNamespacesFromConfigMap(clientset)
+	clusterNames, err := getClusterNameFromNamespaces(clientset)
 	if err != nil {
 		return err, failedList
 	}
 
+	for _, clusterName := range clusterNames {
+		targetNamespaces, err := getTargetNamespacesFromConfigMap(clientset, clusterName)
+		if err != nil {
+			failedList = append(failedList, fmt.Sprintf("Failed to find config map for %s cluster, ", clusterName))
+			continue
+		}
+
+		remoteClientset, err := getRemoteClient(clusterName, clientset)
+		if err != nil {
+			failedList = append(failedList, fmt.Sprintf("Failed to create client for %s cluster, ", clusterName))
+			continue
+		}
+
+		failedList = append(failedList, pushECRAuthToSecret(secretname, targetNamespaces, remoteClientset, ecrAuth)...)
+	}
+
+	return nil, failedList
+}
+
+func getRemoteClient(clusterName string, defaultClientset *kubernetes.Clientset) (*kubernetes.Clientset, error) {
+	secretName := clusterName + "-kubeconfig"
+	kubeconfigSecret, err := getSecret(defaultClientset, secretName, eksaSystemNamespace)
+	if err != nil {
+		return nil, err
+	}
+	kubeconfig := kubeconfigSecret.Data["value"]
+
+	if len(kubeconfig) <= 0 {
+		return nil, fmt.Errorf("Kubeconfig string in secret not set")
+	}
+
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating client config: %s", err)
+	}
+
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating rest config config: %s", err)
+	}
+
+	remoteClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return remoteClient, nil
+}
+
+func pushECRAuthToSecret(secretname string, targetNamespaces []string, clientset kubernetes.Interface, ecrAuth []byte) []string {
+	failedList := make([]string, 0)
 	for _, ns := range targetNamespaces {
 		secret, err := getSecret(clientset, secretname, ns)
 		if secret == nil {
@@ -55,21 +110,20 @@ func UpdateTokens(secretname string, username string, token string, registries s
 			secret.Data[corev1.DockerConfigJsonKey] = ecrAuth
 			_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
-				failedList = append(failedList, ns)
+				failedList = append(failedList, fmt.Sprintf("Failed to create %s in %s namespace, ", secretname, ns))
 			}
 		} else {
 			secret.Data[corev1.DockerConfigJsonKey] = ecrAuth
 			_, err = clientset.CoreV1().Secrets(ns).Update(context.TODO(), secret, metav1.UpdateOptions{})
 			if err != nil {
-				failedList = append(failedList, ns)
+				failedList = append(failedList, fmt.Sprintf("Failed to update %s in %s namespace, ", secretname, ns))
 			}
 		}
 	}
-
-	return nil, failedList
+	return failedList
 }
 
-func getClientSet() (*kubernetes.Clientset, error) {
+func getDefaultClientSet() (*kubernetes.Clientset, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		// Program is not being run from inside cluster. Try default kubeconfig
@@ -88,7 +142,7 @@ func getClientSet() (*kubernetes.Clientset, error) {
 	return clientset, err
 }
 
-func getSecret(clientset *kubernetes.Clientset, name, namespace string) (*corev1.Secret, error) {
+func getSecret(clientset kubernetes.Interface, name, namespace string) (*corev1.Secret, error) {
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -127,8 +181,25 @@ func createSecret(name string, namespace string) *corev1.Secret {
 	return &secret
 }
 
-func getNamespacesFromConfigMap(clientset *kubernetes.Clientset) ([]string, error) {
-	cm, err := clientset.CoreV1().ConfigMaps(packagesNamespace).
+func getClusterNameFromNamespaces(clientset kubernetes.Interface) ([]string, error) {
+	clusterNameList := make([]string, 0)
+	nslist, err := clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ns := range nslist.Items {
+		if strings.HasPrefix(ns.Name, namespacePrefix) {
+			clusterName := strings.TrimPrefix(ns.Name, namespacePrefix)
+			clusterNameList = append(clusterNameList, clusterName)
+		}
+	}
+
+	return clusterNameList, nil
+}
+
+func getTargetNamespacesFromConfigMap(clientset kubernetes.Interface, clusterName string) ([]string, error) {
+	cm, err := clientset.CoreV1().ConfigMaps(namespacePrefix+clusterName).
 		Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/ecrtokenrefresher/pkg/kubernetes/kubernetes_test.go
+++ b/ecrtokenrefresher/pkg/kubernetes/kubernetes_test.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPushECRAuthToSecret(t *testing.T) {
+	secretname := "ecr-token"
+	ecrAuth, err := createECRAuthConfig("user", "test", "test@test.com")
+	assert.NoError(t, err)
+	targetNamespaces := []string{"ns1", "ns2"}
+
+	t.Run("golden path for creating secret if doesnt exist", func(t *testing.T) {
+		mockClientset := fake.NewSimpleClientset()
+		failedList := pushECRAuthToSecret(secretname, targetNamespaces, mockClientset, ecrAuth)
+
+		assert.Empty(t, failedList)
+		for _, ns := range targetNamespaces {
+			secret, err := getSecret(mockClientset, secretname, ns)
+			assert.NoError(t, err)
+
+			assert.Equal(t, ecrAuth, secret.Data[v1.DockerConfigJsonKey])
+		}
+	})
+
+	t.Run("golden path for updating secret if exists", func(t *testing.T) {
+		oldSecretData := map[string][]byte{}
+		oldSecretData[v1.DockerConfigJsonKey] = []byte{}
+		mockClientset := fake.NewSimpleClientset(&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretname,
+				Namespace: targetNamespaces[0],
+			},
+			Data: oldSecretData,
+		})
+
+		failedList := pushECRAuthToSecret(secretname, targetNamespaces, mockClientset, ecrAuth)
+
+		assert.Empty(t, failedList)
+		for _, ns := range targetNamespaces {
+			secret, err := getSecret(mockClientset, secretname, ns)
+			assert.NoError(t, err)
+
+			assert.Equal(t, ecrAuth, secret.Data[v1.DockerConfigJsonKey])
+		}
+	})
+}
+
+func TestGetClusterNameFromNamespaces(t *testing.T) {
+	mockClientSet := createMockClientsetWithNamespaces()
+
+	t.Run("golden path getting cluster names for namespaces", func(t *testing.T) {
+		clusterNames, err := getClusterNameFromNamespaces(mockClientSet)
+		assert.NoError(t, err)
+
+		expected := []string{"mgmt", "w1", "w2"}
+
+		assert.ElementsMatch(t, expected, clusterNames)
+	})
+}
+
+func TestGetTargetNamespacesFromConfigMap(t *testing.T) {
+	mockClientSet := createMockClientsetWithConfigMaps()
+
+	t.Run("golden path for getting target namespace from config map", func(t *testing.T) {
+		clusterName := "mgmt"
+		expected := []string{"test-ns"}
+
+		targetNamespaces, err := getTargetNamespacesFromConfigMap(mockClientSet, clusterName)
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, expected, targetNamespaces)
+
+	})
+}
+
+func createMockClientsetWithConfigMaps() kubernetes.Interface {
+	cmdata := make(map[string]string)
+	cmdata["test-ns"] = "test-name"
+	cmMgmt := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespacePrefix + "mgmt",
+		},
+		Data: cmdata,
+	}
+
+	cmW1 := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespacePrefix + "w1",
+		},
+		Data: cmdata,
+	}
+
+	cmW2 := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespacePrefix + "w2",
+		},
+		Data: cmdata,
+	}
+
+	mockClientset := fake.NewSimpleClientset(cmMgmt, cmW1, cmW2)
+
+	return mockClientset
+}
+
+func createMockClientsetWithNamespaces() kubernetes.Interface {
+	nsMgmt := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespacePrefix + "mgmt",
+		},
+	}
+
+	nsW1 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespacePrefix + "w1",
+		},
+	}
+
+	nsW2 := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespacePrefix + "w2",
+		},
+	}
+
+	wrongNs := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bad-name",
+		},
+	}
+
+	mockClientset := fake.NewSimpleClientset(nsMgmt, nsW1, nsW2, wrongNs)
+
+	return mockClientset
+}


### PR DESCRIPTION
Updating ecr-token-refresher to look for workload clusters via parsing namespaces. Token push was also updated to target each of the workload clusters using a kubeconfig via a secret.