### PR TITLE
Revert "Use K8s-Specific Cluster Autoscaler Versions"

### DIFF
--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 9.21.0-1.21
+            - name: latest
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_122.yaml
+++ b/generatebundlefile/data/input_122.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 9.21.0-1.22
+            - name: latest
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_123.yaml
+++ b/generatebundlefile/data/input_123.yaml
@@ -29,7 +29,7 @@ packages:
         repository: autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 9.21.0-1.23
+            - name: latest
   - org: metallb 
     projects:
       - name: metallb 


### PR DESCRIPTION
Reverts aws/eks-anywhere-packages#499

This broke bundle generation because the necessary tags are missing from the public ECR due to an issue with the promotion job that moves things from private to public ECR. Reverting for now while we fix it. 