### PR TITLE
Handle get PBC and active bundle

### DIFF
--- a/api/v1alpha1/package.go
+++ b/api/v1alpha1/package.go
@@ -1,12 +1,18 @@
 package v1alpha1
 
 import (
+	"os"
+	"strings"
+
 	"sigs.k8s.io/yaml"
 )
 
 const (
-	PackageKind      = "Package"
-	PackageNamespace = "eksa-packages"
+	PackageKind       = "Package"
+	PackageNamespace  = "eksa-packages"
+	namespacePrefix   = PackageNamespace + "-"
+	oldPbcName        = "bundle-controller"
+	clusterNameEnvVar = "CLUSTER_NAME"
 )
 
 func (config *Package) MetaKind() string {
@@ -22,4 +28,25 @@ func (config *Package) GetValues() (values map[string]interface{}, err error) {
 	mapInterfaces := make(map[string]interface{})
 	err = yaml.Unmarshal([]byte(config.Spec.Config), &mapInterfaces)
 	return mapInterfaces, err
+}
+
+func (config *Package) GetClusterName() string {
+	if strings.HasPrefix(config.Namespace, namespacePrefix) {
+		clusterName := strings.TrimPrefix(config.Namespace, namespacePrefix)
+		// Backward compatibility
+		if clusterName == oldPbcName {
+			return os.Getenv(clusterNameEnvVar)
+		}
+		return clusterName
+	}
+	return ""
+}
+
+func (config *Package) IsValidNamespace() bool {
+	if !strings.HasPrefix(config.Namespace, namespacePrefix) {
+		if config.Namespace != PackageNamespace {
+			return false
+		}
+	}
+	return true
 }

--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -173,7 +173,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		managerContext.SetUninstalling(req.Namespace, req.Name)
 	} else {
-		pbc, err := r.bundleClient.GetPackageBundleController(ctx)
+		pbc, err := r.bundleClient.GetPackageBundleController(ctx, managerContext.Package.GetClusterName())
 		if err != nil {
 			r.Log.Error(err, "Getting package bundle controller")
 			managerContext.Package.Status.Detail = err.Error()
@@ -184,7 +184,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		managerContext.PBC = *pbc
 
-		bundle, err := r.bundleClient.GetActiveBundle(ctx)
+		bundle, err := r.bundleClient.GetActiveBundle(ctx, managerContext.Package.GetClusterName())
 		if err != nil {
 			r.Log.Error(err, "Getting active bundle")
 			managerContext.Package.Status.Detail = err.Error()

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -105,43 +105,6 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
-
-		// If the bundle controller detects that the active bundle is deleted,
-		// the bundle controller will validate the active bundle by namespace
-		// and name, redownload and recreate the bundle.
-		nn, err := r.bundleClient.GetActiveBundleNamespacedName(ctx)
-		if err != nil {
-			r.Log.Info("Unable to get active bundle namespace and name",
-				"NamespaceName", nn)
-			return ctrl.Result{}, nil
-		}
-
-		// Verify the namespace and name of the active bundle.
-		if nn.Namespace != req.Namespace || nn.Name != req.Name {
-			r.Log.Info("Bundle deleted", "bundle", req.NamespacedName)
-			return ctrl.Result{}, nil
-		}
-
-		// Download the bundle using name tag.
-		bundle, err := r.registryClient.DownloadBundle(ctx, req.Name)
-		if err != nil {
-			r.Log.Error(err, "Active bundle deleted and failed to download",
-				"bundle", req.NamespacedName)
-			return ctrl.Result{}, nil
-		}
-
-		r.Log.Info("Bundle downloaded", "bundle", req.NamespacedName)
-
-		// Use the client interface to recreate the bundle.
-		err = r.Client.Create(ctx, bundle)
-		if err != nil {
-			r.Log.Error(err, "Unable to recreate package bundle",
-				"bundle", req.NamespacedName)
-			return ctrl.Result{}, nil
-		}
-
-		r.Log.Info("Bundle created", "bundle", req.NamespacedName)
-
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/packagebundle_controller_test.go
+++ b/controllers/packagebundle_controller_test.go
@@ -109,14 +109,10 @@ func TestPackageBundleReconciler_ReconcileDelete(t *testing.T) {
 	notFoundError := errors.NewNotFound(groupResource, request.Name)
 	mockClient := mocks.NewMockClient(gomock.NewController(t))
 	mockBundleClient := bundleMocks.NewMockClient(gomock.NewController(t))
-	mockClient.EXPECT().Get(ctx, request.NamespacedName, gomock.Any()).Return(notFoundError)
-	mockBundleClient.EXPECT().GetActiveBundleNamespacedName(ctx).Return(request.NamespacedName, nil)
-	myBundle := GivenBundle()
 	bm := bundleMocks.NewMockManager(gomock.NewController(t))
 	mockRegistryClient := bundleMocks.NewMockRegistryClient(gomock.NewController(t))
-	mockRegistryClient.EXPECT().DownloadBundle(ctx, request.Name).Return(myBundle, nil)
-	mockClient.EXPECT().Create(ctx, myBundle).Return(nil)
 	sut := controllers.NewPackageBundleReconciler(mockClient, nil, mockBundleClient, bm, mockRegistryClient, logr.Discard())
+	mockClient.EXPECT().Get(ctx, request.NamespacedName, gomock.Any()).Return(notFoundError)
 
 	_, actualError := sut.Reconcile(ctx, request)
 

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -93,11 +93,10 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 		bundleClient := NewPackageBundleClient(mockClient)
 		testBundle := givenBundle()
 
-		mockClient.EXPECT().List(ctx, gomock.Any())
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(testBundle)).SetArg(2, *testBundle)
 
-		bundle, err := bundleClient.GetActiveBundle(ctx)
+		bundle, err := bundleClient.GetActiveBundle(ctx, "billy")
 
 		assert.Equal(t, bundle.Name, testBundleName)
 		assert.Equal(t, "hello-eks-anywhere", bundle.Spec.Packages[0].Name)
@@ -110,10 +109,9 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 		mockClient := givenMockClient(t)
 		bundleClient := NewPackageBundleClient(mockClient)
 		pbc.Spec.ActiveBundle = ""
-		mockClient.EXPECT().List(ctx, gomock.Any())
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
 
-		bundle, err := bundleClient.GetActiveBundle(ctx)
+		bundle, err := bundleClient.GetActiveBundle(ctx, "billy")
 
 		assert.Nil(t, bundle)
 		assert.EqualError(t, err, "no activeBundle set in PackageBundleController")
@@ -122,10 +120,9 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 	t.Run("error path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
 		bundleClient := NewPackageBundleClient(mockClient)
-		mockClient.EXPECT().List(ctx, gomock.Any())
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("oops"))
 
-		_, err := bundleClient.GetActiveBundle(ctx)
+		_, err := bundleClient.GetActiveBundle(ctx, "billy")
 
 		assert.EqualError(t, err, "getting PackageBundleController: oops")
 	})
@@ -133,46 +130,12 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 	t.Run("other error path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
 		bundleClient := NewPackageBundleClient(mockClient)
-		mockClient.EXPECT().List(ctx, gomock.Any())
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("oops"))
 
-		_, err := bundleClient.GetActiveBundle(ctx)
+		_, err := bundleClient.GetActiveBundle(ctx, "billy")
 
 		assert.EqualError(t, err, "oops")
-	})
-}
-
-func TestBundleClient_GetActiveBundleNamespacedName(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	pbc := givenPackageBundleController()
-
-	t.Run("golden path", func(t *testing.T) {
-		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
-		mockClient.EXPECT().List(ctx, gomock.Any())
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc))
-
-		namespacedNames, err := bundleClient.GetActiveBundleNamespacedName(ctx)
-
-		assert.Equal(t, api.PackageNamespace, namespacedNames.Namespace)
-		assert.Equal(t, "", namespacedNames.Name)
-		assert.NoError(t, err)
-	})
-
-	t.Run("error path", func(t *testing.T) {
-		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
-		mockClient.EXPECT().List(ctx, gomock.Any())
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("oops"))
-
-		namespacedNames, err := bundleClient.GetActiveBundleNamespacedName(ctx)
-
-		assert.Equal(t, "", namespacedNames.Namespace)
-		assert.Equal(t, "", namespacedNames.Name)
-		assert.EqualError(t, err, "getting PackageBundleController: oops")
 	})
 }
 

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -10,7 +10,6 @@ import (
 
 	v1alpha1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
-	types "k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -66,33 +65,18 @@ func (mr *MockClientMockRecorder) CreateClusterNamespace(ctx, clusterName interf
 }
 
 // GetActiveBundle mocks base method.
-func (m *MockClient) GetActiveBundle(ctx context.Context) (*v1alpha1.PackageBundle, error) {
+func (m *MockClient) GetActiveBundle(ctx context.Context, clusterName string) (*v1alpha1.PackageBundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActiveBundle", ctx)
+	ret := m.ctrl.Call(m, "GetActiveBundle", ctx, clusterName)
 	ret0, _ := ret[0].(*v1alpha1.PackageBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetActiveBundle indicates an expected call of GetActiveBundle.
-func (mr *MockClientMockRecorder) GetActiveBundle(ctx interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetActiveBundle(ctx, clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveBundle", reflect.TypeOf((*MockClient)(nil).GetActiveBundle), ctx)
-}
-
-// GetActiveBundleNamespacedName mocks base method.
-func (m *MockClient) GetActiveBundleNamespacedName(ctx context.Context) (types.NamespacedName, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActiveBundleNamespacedName", ctx)
-	ret0, _ := ret[0].(types.NamespacedName)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActiveBundleNamespacedName indicates an expected call of GetActiveBundleNamespacedName.
-func (mr *MockClientMockRecorder) GetActiveBundleNamespacedName(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveBundleNamespacedName", reflect.TypeOf((*MockClient)(nil).GetActiveBundleNamespacedName), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveBundle", reflect.TypeOf((*MockClient)(nil).GetActiveBundle), ctx, clusterName)
 }
 
 // GetBundleList mocks base method.
@@ -111,18 +95,18 @@ func (mr *MockClientMockRecorder) GetBundleList(ctx, serverVersion interface{}) 
 }
 
 // GetPackageBundleController mocks base method.
-func (m *MockClient) GetPackageBundleController(ctx context.Context) (*v1alpha1.PackageBundleController, error) {
+func (m *MockClient) GetPackageBundleController(ctx context.Context, clusterName string) (*v1alpha1.PackageBundleController, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPackageBundleController", ctx)
+	ret := m.ctrl.Call(m, "GetPackageBundleController", ctx, clusterName)
 	ret0, _ := ret[0].(*v1alpha1.PackageBundleController)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPackageBundleController indicates an expected call of GetPackageBundleController.
-func (mr *MockClientMockRecorder) GetPackageBundleController(ctx interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetPackageBundleController(ctx, clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackageBundleController", reflect.TypeOf((*MockClient)(nil).GetPackageBundleController), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackageBundleController", reflect.TypeOf((*MockClient)(nil).GetPackageBundleController), ctx, clusterName)
 }
 
 // Save mocks base method.

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -57,7 +57,7 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 			fmt.Errorf("decoding request: %w", err))
 	}
 
-	activeBundle, err := v.BundleClient.GetActiveBundle(ctx)
+	activeBundle, err := v.BundleClient.GetActiveBundle(ctx, p.GetClusterName())
 
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("getting PackageBundle: %v", err))


### PR DESCRIPTION
Get a PBC for a specific cluster

* Pass clusterName to the get PBC method
* Do not use kubeadmcontrolplane
* Get active bundle based on PBC for the cluster
* Do not reconcile activeBundle delete on bundle reconciliation
