### PR TITLE
Remove support for eksa-packages-bundle-controller PBC

### DIFF
--- a/api/testdata/package_webhook_bundle_controller.yaml
+++ b/api/testdata/package_webhook_bundle_controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: PackageBundleController
 metadata:
-  name: eksa-packages-bundle-controller
+  name: eksa-packages-cluster01
   namespace: eksa-packages
 spec:
   activeBundle: "package-webhook-bundle"

--- a/api/testdata/packagebundlecontroller.yaml
+++ b/api/testdata/packagebundlecontroller.yaml
@@ -1,7 +1,7 @@
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: PackageBundleController
 metadata:
-  name: eksa-packages-bundle-controller
+  name: eksa-packages-cluster01
   namespace: eksa-packages
 spec:
   activeBundle: "v1-21-1001"

--- a/api/v1alpha1/package.go
+++ b/api/v1alpha1/package.go
@@ -1,18 +1,15 @@
 package v1alpha1
 
 import (
-	"os"
 	"strings"
 
 	"sigs.k8s.io/yaml"
 )
 
 const (
-	PackageKind       = "Package"
-	PackageNamespace  = "eksa-packages"
-	namespacePrefix   = PackageNamespace + "-"
-	oldPbcName        = "bundle-controller"
-	clusterNameEnvVar = "CLUSTER_NAME"
+	PackageKind      = "Package"
+	PackageNamespace = "eksa-packages"
+	namespacePrefix  = PackageNamespace + "-"
 )
 
 func (config *Package) MetaKind() string {
@@ -33,10 +30,6 @@ func (config *Package) GetValues() (values map[string]interface{}, err error) {
 func (config *Package) GetClusterName() string {
 	if strings.HasPrefix(config.Namespace, namespacePrefix) {
 		clusterName := strings.TrimPrefix(config.Namespace, namespacePrefix)
-		// Backward compatibility
-		if clusterName == oldPbcName {
-			return os.Getenv(clusterNameEnvVar)
-		}
 		return clusterName
 	}
 	return ""

--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -2,10 +2,7 @@ package v1alpha1
 
 import "path"
 
-const (
-	PackageBundleControllerKind = "PackageBundleController"
-	PackageBundleControllerName = "eksa-packages-bundle-controller"
-)
+const PackageBundleControllerKind = "PackageBundleController"
 
 func (config *PackageBundleController) MetaKind() string {
 	return config.TypeMeta.Kind

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -25,15 +25,15 @@ func TestPackageBundleController_IsValid(t *testing.T) {
 		}
 	}
 
-	assert.False(t, givenBundleController(api.PackageBundleControllerName, api.PackageNamespace).IsIgnored())
+	assert.False(t, givenBundleController("eksa-packaages-bundle-controller", api.PackageNamespace).IsIgnored())
 	assert.False(t, givenBundleController("billy", api.PackageNamespace).IsIgnored())
-	assert.True(t, givenBundleController(api.PackageBundleControllerName, "default").IsIgnored())
+	assert.True(t, givenBundleController("eksa-packages-bundle-controller", "default").IsIgnored())
 }
 
 func GivenPackageBundleController() *api.PackageBundleController {
 	return &api.PackageBundleController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      api.PackageBundleControllerName,
+			Name:      "eksa-packages-bundle-controller",
 			Namespace: api.PackageNamespace,
 		},
 		Spec: api.PackageBundleControllerSpec{

--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -15,7 +15,7 @@ additionalAnnotations: {}
 # -- sourceRegistry for all container images in chart.
 sourceRegistry: public.ecr.aws/eks-anywhere
 # -- clusterName managed by a particular PBC
-clusterName: eksa-packages-bundle-controller
+clusterName: bundle-controller
 # -- Image pull policy for Docker images.
 imagePullPolicy: IfNotPresent
 proxy:

--- a/controllers/packagebundlecontroller_controller_test.go
+++ b/controllers/packagebundlecontroller_controller_test.go
@@ -27,7 +27,7 @@ const testBundleName = "v1.21-1001"
 func givenPackageBundleController() api.PackageBundleController {
 	return api.PackageBundleController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      api.PackageBundleControllerName,
+			Name:      "eksa-packages-cluster01",
 			Namespace: api.PackageNamespace,
 		},
 		Spec: api.PackageBundleControllerSpec{
@@ -49,7 +49,7 @@ func TestPackageBundleControllerReconcilerReconcile(t *testing.T) {
 
 	controllerNN := types.NamespacedName{
 		Namespace: api.PackageNamespace,
-		Name:      api.PackageBundleControllerName,
+		Name:      "eksa-packages-cluster01",
 	}
 	req := ctrl.Request{
 		NamespacedName: controllerNN,

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -54,7 +54,7 @@ func givenBundle() *api.PackageBundle {
 func givenPackageBundleController() *api.PackageBundleController {
 	return &api.PackageBundleController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      api.PackageBundleControllerName,
+			Name:      "eksa-packages-cluster01",
 			Namespace: api.PackageNamespace,
 		},
 		Spec: api.PackageBundleControllerSpec{

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -197,7 +197,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller status to disconnected: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to disconnected: oops")
 	})
 
 	t.Run("active to upgradeAvailable", func(t *testing.T) {
@@ -231,7 +231,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "creating namespace for eksa-packages-bundle-controller: boom")
+		assert.EqualError(t, err, "creating namespace for eksa-packages-cluster01: boom")
 	})
 
 	t.Run("active to upgradeAvailable error", func(t *testing.T) {
@@ -248,7 +248,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller status to upgrade available: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to upgrade available: oops")
 	})
 
 	t.Run("active to upgradeAvailable create error", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller status to active: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
 	})
 
 	t.Run("disconnected to active", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller status to active: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
 	})
 
 	t.Run("nothing to active bundle set", func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller activeBundle to v1-21-1004: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 activeBundle to v1-21-1004: oops")
 	})
 
 	t.Run("nothing to active state", func(t *testing.T) {
@@ -414,6 +414,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-bundle-controller status to active: oops")
+		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
 	})
 }


### PR DESCRIPTION
During our beta, the only PBC name that was supproted was `eksa-packages-bundle-controller`, but at GA we created `eksa-package-${clusterName}`. This removes support for PBCs using the old name so people are not confused about what PBC they are using.
