### PR TITLE
Create Configmap in Manager for Remote Management

### DIFF
--- a/pkg/authenticator/ecrsecret.go
+++ b/pkg/authenticator/ecrsecret.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	configMapName = "ns-secret-map"
+	ConfigMapName = "ns-secret-map"
 	ecrTokenName  = "ecr-token"
 )
 
@@ -46,7 +46,7 @@ func (s *ecrSecret) AuthFilename() string {
 
 func (s *ecrSecret) AddToConfigMap(ctx context.Context, name string, namespace string) error {
 	cm, err := s.clientset.CoreV1().ConfigMaps(api.PackageNamespace).
-		Get(ctx, configMapName, metav1.GetOptions{})
+		Get(ctx, ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func createSecret(name string, namespace string) *corev1.Secret {
 
 func (s *ecrSecret) DelFromConfigMap(ctx context.Context, name string, namespace string) error {
 	cm, err := s.clientset.CoreV1().ConfigMaps(api.PackageNamespace).
-		Get(ctx, configMapName, metav1.GetOptions{})
+		Get(ctx, ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/authenticator/ecrsecret_test.go
+++ b/pkg/authenticator/ecrsecret_test.go
@@ -49,7 +49,7 @@ func TestAddToConfigMap(t *testing.T) {
 		cmdata["otherns"] = "a"
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: api.PackageNamespace,
 			},
 			Data: cmdata,
@@ -60,7 +60,7 @@ func TestAddToConfigMap(t *testing.T) {
 		require.NoError(t, err)
 
 		updatedCM, err := mockClientset.CoreV1().ConfigMaps(api.PackageNamespace).
-			Get(ctx, configMapName, metav1.GetOptions{})
+			Get(ctx, ConfigMapName, metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.Equal(t, name, updatedCM.Data[namespace])
 			assert.Equal(t, "a", updatedCM.Data["otherns"])
@@ -71,7 +71,7 @@ func TestAddToConfigMap(t *testing.T) {
 		cmdata[namespace] = "a"
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: api.PackageNamespace,
 			},
 			Data: cmdata,
@@ -82,7 +82,7 @@ func TestAddToConfigMap(t *testing.T) {
 		require.NoError(t, err)
 
 		updatedCM, err := mockClientset.CoreV1().ConfigMaps(api.PackageNamespace).
-			Get(ctx, configMapName, metav1.GetOptions{})
+			Get(ctx, ConfigMapName, metav1.GetOptions{})
 		if assert.NoError(t, err) {
 			assert.ObjectsAreEqual([]string{"a", name},
 				strings.Split(updatedCM.Data[namespace], ","))
@@ -94,7 +94,7 @@ func TestAddToConfigMap(t *testing.T) {
 		cmdata[namespace] = "a"
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: api.PackageNamespace,
 			},
 			Data: cmdata,
@@ -105,14 +105,14 @@ func TestAddToConfigMap(t *testing.T) {
 		require.NoError(t, err)
 
 		updatedCM, _ := mockClientset.CoreV1().ConfigMaps(api.PackageNamespace).
-			Get(ctx, configMapName, metav1.GetOptions{})
+			Get(ctx, ConfigMapName, metav1.GetOptions{})
 		assert.Equal(t, "a", updatedCM.Data[namespace])
 	})
 
 	t.Run("fails if config map doesnt exist", func(t *testing.T) {
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: "wrong-ns",
 			},
 			Data: cmdata,
@@ -136,7 +136,7 @@ func TestDelFromConfigMap(t *testing.T) {
 		cmdata[namespace] = "a,b"
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: api.PackageNamespace,
 			},
 			Data: cmdata,
@@ -146,7 +146,7 @@ func TestDelFromConfigMap(t *testing.T) {
 		err := ecrAuth.DelFromConfigMap(ctx, name, namespace)
 
 		updatedCM, _ := mockClientset.CoreV1().ConfigMaps(api.PackageNamespace).
-			Get(ctx, configMapName, metav1.GetOptions{})
+			Get(ctx, ConfigMapName, metav1.GetOptions{})
 
 		val, exists := updatedCM.Data["eksa-packages"]
 		assert.Nil(t, err)
@@ -159,7 +159,7 @@ func TestDelFromConfigMap(t *testing.T) {
 		cmdata[namespace] = "a"
 		mockClientset := fake.NewSimpleClientset(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
+				Name:      ConfigMapName,
 				Namespace: api.PackageNamespace,
 			},
 			Data: cmdata,
@@ -169,7 +169,7 @@ func TestDelFromConfigMap(t *testing.T) {
 		err := ecrAuth.DelFromConfigMap(ctx, name, namespace)
 		require.NoError(t, err)
 		updatedCM, err := mockClientset.CoreV1().ConfigMaps(api.PackageNamespace).
-			Get(ctx, configMapName, metav1.GetOptions{})
+			Get(ctx, ConfigMapName, metav1.GetOptions{})
 		require.NoError(t, err)
 		_, exists := updatedCM.Data["eksa-packages"]
 		assert.False(t, exists)

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -8,10 +8,12 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	auth "github.com/aws/eks-anywhere-packages/pkg/authenticator"
 )
 
 type Client interface {
@@ -32,6 +34,9 @@ type Client interface {
 
 	// CreateClusterNamespace based on cluster name
 	CreateClusterNamespace(ctx context.Context, clusterName string) error
+
+	// CreateClusterConfigMap based on cluster name
+	CreateClusterConfigMap(ctx context.Context, clusterName string) error
 
 	// SaveStatus saves a resource status
 	SaveStatus(ctx context.Context, object client.Object) error
@@ -149,6 +154,41 @@ func (bc *bundleClient) CreateClusterNamespace(ctx context.Context, clusterName 
 
 	ns.Name = name
 	err = bc.Client.Create(ctx, ns)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bc *bundleClient) CreateClusterConfigMap(ctx context.Context, clusterName string) error {
+	name := auth.ConfigMapName
+	namespace := api.PackageNamespace + "-" + clusterName
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := bc.Get(ctx, key, cm)
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	cm.Data = make(map[string]string)
+	cm.Data[namespace] = "eksa-package-controller"
+	// Unfortunate workaround for emissary webhooks hard coded crd namespace
+	cm.Data["emissary-system"] = "eksa-package-placeholder"
+
+	err = bc.Client.Create(ctx, cm)
 	if err != nil {
 		return err
 	}

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -145,6 +145,7 @@ func (bc *bundleClient) CreateClusterNamespace(ctx context.Context, clusterName 
 	}
 	ns := &v1.Namespace{}
 	err := bc.Get(ctx, key, ns)
+	// Nil err check here means that the namespace exists thus we can just return with no error
 	if err == nil {
 		return nil
 	}
@@ -175,6 +176,7 @@ func (bc *bundleClient) CreateClusterConfigMap(ctx context.Context, clusterName 
 		},
 	}
 	err := bc.Get(ctx, key, cm)
+	// Nil err check here means that the config map exists thus we can just return with no error
 	if err == nil {
 		return nil
 	}

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -335,3 +335,77 @@ func TestBundleClient_CreateClusterNamespace(t *testing.T) {
 		assert.EqualError(t, err, "boom")
 	})
 }
+
+func TestBundleClient_CreateClusterConfigMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	name := "ns-secret-map"
+	namespace := "eksa-packages-bobby"
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	cm.Data = make(map[string]string)
+	cm.Data[namespace] = "eksa-package-controller"
+	cm.Data["emissary-system"] = "eksa-package-placeholder"
+
+	t.Run("already exists", func(t *testing.T) {
+		mockClient := givenMockClient(t)
+		bundleClient := NewPackageBundleClient(mockClient)
+		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(nil)
+
+		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("get error", func(t *testing.T) {
+		mockClient := givenMockClient(t)
+		bundleClient := NewPackageBundleClient(mockClient)
+		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(fmt.Errorf("boom"))
+
+		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
+
+		assert.EqualError(t, err, "boom")
+	})
+
+	t.Run("create configmap", func(t *testing.T) {
+		mockClient := givenMockClient(t)
+		bundleClient := NewPackageBundleClient(mockClient)
+		groupResource := schema.GroupResource{
+			Group:    key.Name,
+			Resource: "Namespace",
+		}
+		notFoundError := errors.NewNotFound(groupResource, key.Name)
+		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(notFoundError)
+		mockClient.EXPECT().Create(ctx, cm).Return(nil)
+
+		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("create configmap error", func(t *testing.T) {
+		mockClient := givenMockClient(t)
+		bundleClient := NewPackageBundleClient(mockClient)
+		groupResource := schema.GroupResource{
+			Group:    key.Name,
+			Resource: "Namespace",
+		}
+		notFoundError := errors.NewNotFound(groupResource, key.Name)
+		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(notFoundError)
+		mockClient.EXPECT().Create(ctx, cm).Return(fmt.Errorf("boom"))
+
+		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
+
+		assert.EqualError(t, err, "boom")
+	})
+}

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -126,6 +126,11 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("creating namespace for %s: %s", pbc.Name, err)
 		}
 
+		err = m.bundleClient.CreateClusterConfigMap(ctx, pbc.Name)
+		if err != nil {
+			return fmt.Errorf("creating configmap for %s: %s", pbc.Name, err)
+		}
+
 		if len(pbc.Spec.ActiveBundle) > 0 {
 			activeBundle, err := m.bundleClient.GetBundle(ctx, pbc.Spec.ActiveBundle)
 			if err != nil {

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -134,6 +134,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 
 		err := bm.ProcessBundleController(ctx, pbc)
@@ -150,6 +151,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
 		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(nil)
@@ -168,6 +170,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], fmt.Errorf("boom"))
 
@@ -185,6 +188,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
 		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(fmt.Errorf("boom"))
@@ -263,6 +267,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(nil)
 
@@ -288,6 +293,23 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		assert.EqualError(t, err, "creating namespace for eksa-packages-cluster01: boom")
 	})
 
+	t.Run("active to cm error", func(t *testing.T) {
+		tcc, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		latestBundle := givenBundle()
+		latestBundle.Name = testNextBundleName
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
+		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(fmt.Errorf("boom"))
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.EqualError(t, err, "creating configmap for eksa-packages-cluster01: boom")
+	})
+
 	t.Run("active to upgradeAvailable active bundle error", func(t *testing.T) {
 		tcc, rc, bc, bm := givenBundleManager(t)
 		pbc := givenPackageBundleController()
@@ -298,6 +320,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, fmt.Errorf("boom"))
 
 		err := bm.ProcessBundleController(ctx, pbc)
@@ -315,6 +338,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(fmt.Errorf("oops"))
 

--- a/pkg/bundle/mocks/client.go
+++ b/pkg/bundle/mocks/client.go
@@ -50,6 +50,20 @@ func (mr *MockClientMockRecorder) CreateBundle(ctx, bundle interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBundle", reflect.TypeOf((*MockClient)(nil).CreateBundle), ctx, bundle)
 }
 
+// CreateClusterConfigMap mocks base method.
+func (m *MockClient) CreateClusterConfigMap(ctx context.Context, clusterName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateClusterConfigMap", ctx, clusterName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateClusterConfigMap indicates an expected call of CreateClusterConfigMap.
+func (mr *MockClientMockRecorder) CreateClusterConfigMap(ctx, clusterName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterConfigMap", reflect.TypeOf((*MockClient)(nil).CreateClusterConfigMap), ctx, clusterName)
+}
+
 // CreateClusterNamespace mocks base method.
 func (m *MockClient) CreateClusterNamespace(ctx context.Context, clusterName string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Portion of remote management changes to support the ecr-token-refresher. This change is to create the config maps in the corresponding namespace eksa-packages-${CLUSTER_NAME} so token refresher can push to.
Example if management cluster is named mgmt, we will be creating a configmap in eksa-packages-mgmt which holds the namespaces we need to push ecr-tokens to. Config map would look like this

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: ns-secret-name
  namespace: eksa-packages-mgmt
data:
  eksa-packages-mgmt: eksa-packages-placeholder
  emissary-system: emissary-ingress
```