### PR TITLE
Create target namespace

### DIFF
--- a/pkg/authenticator/mocks/target_cluster_client.go
+++ b/pkg/authenticator/mocks/target_cluster_client.go
@@ -39,6 +39,20 @@ func (m *MockTargetClusterClient) EXPECT() *MockTargetClusterClientMockRecorder 
 	return m.recorder
 }
 
+// CreateClusterNamespace mocks base method.
+func (m *MockTargetClusterClient) CreateClusterNamespace(ctx context.Context, clusterName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateClusterNamespace", ctx, clusterName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateClusterNamespace indicates an expected call of CreateClusterNamespace.
+func (mr *MockTargetClusterClientMockRecorder) CreateClusterNamespace(ctx, clusterName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterNamespace", reflect.TypeOf((*MockTargetClusterClient)(nil).CreateClusterNamespace), ctx, clusterName)
+}
+
 // GetServerVersion mocks base method.
 func (m *MockTargetClusterClient) GetServerVersion(ctx context.Context, clusterName string) (*version.Info, error) {
 	m.ctrl.T.Helper()
@@ -54,7 +68,7 @@ func (mr *MockTargetClusterClientMockRecorder) GetServerVersion(ctx, clusterName
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerVersion", reflect.TypeOf((*MockTargetClusterClient)(nil).GetServerVersion), ctx, clusterName)
 }
 
-// Init mocks base method.
+// Initialize mocks base method.
 func (m *MockTargetClusterClient) Initialize(ctx context.Context, clusterName string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", ctx, clusterName)
@@ -62,8 +76,8 @@ func (m *MockTargetClusterClient) Initialize(ctx context.Context, clusterName st
 	return ret0
 }
 
-// Init indicates an expected call of Init.
-func (mr *MockTargetClusterClientMockRecorder) Init(ctx, clusterName interface{}) *gomock.Call {
+// Initialize indicates an expected call of Initialize.
+func (mr *MockTargetClusterClientMockRecorder) Initialize(ctx, clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTargetClusterClient)(nil).Initialize), ctx, clusterName)
 }

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -54,7 +54,7 @@ func givenBundle() *api.PackageBundle {
 func givenPackageBundleController() *api.PackageBundleController {
 	return &api.PackageBundleController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eksa-packages-cluster01",
+			Name:      "cluster01",
 			Namespace: api.PackageNamespace,
 		},
 		Spec: api.PackageBundleControllerSpec{

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -131,6 +131,11 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("creating configmap for %s: %s", pbc.Name, err)
 		}
 
+		err = m.targetClient.CreateClusterNamespace(ctx, pbc.GetName())
+		if err != nil {
+			return fmt.Errorf("creating workload cluster namespace eksa-packages for %s: %s", pbc.Name, err)
+		}
+
 		if len(pbc.Spec.ActiveBundle) > 0 {
 			activeBundle, err := m.bundleClient.GetBundle(ctx, pbc.Spec.ActiveBundle)
 			if err != nil {

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -135,6 +135,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 
 		err := bm.ProcessBundleController(ctx, pbc)
@@ -152,6 +153,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
 		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(nil)
@@ -171,6 +173,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], fmt.Errorf("boom"))
 
@@ -189,6 +192,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, nil)
 		rc.EXPECT().DownloadBundle(ctx, "public.ecr.aws/j0a1m4z9/eks-anywhere-packages-bundles:v1-21-1003").Return(&allBundles[0], nil)
 		bc.EXPECT().CreateBundle(ctx, gomock.Any()).Return(fmt.Errorf("boom"))
@@ -254,7 +258,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to disconnected: oops")
+		assert.EqualError(t, err, "updating cluster01 status to disconnected: oops")
 	})
 
 	t.Run("active to upgradeAvailable", func(t *testing.T) {
@@ -268,6 +272,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(nil)
 
@@ -290,7 +295,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "creating namespace for eksa-packages-cluster01: boom")
+		assert.EqualError(t, err, "creating namespace for cluster01: boom")
 	})
 
 	t.Run("active to cm error", func(t *testing.T) {
@@ -307,7 +312,25 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "creating configmap for eksa-packages-cluster01: boom")
+		assert.EqualError(t, err, "creating configmap for cluster01: boom")
+	})
+
+	t.Run("workload create cluster error", func(t *testing.T) {
+		tcc, rc, bc, bm := givenBundleManager(t)
+		pbc := givenPackageBundleController()
+		latestBundle := givenBundle()
+		latestBundle.Name = testNextBundleName
+		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
+		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubernetesVersion).Return(latestBundle, nil)
+		bc.EXPECT().GetBundleList(ctx, "v1-21").Return(allBundles, nil)
+		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
+		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(fmt.Errorf("boom"))
+
+		err := bm.ProcessBundleController(ctx, pbc)
+
+		assert.EqualError(t, err, "creating workload cluster namespace eksa-packages for cluster01: boom")
 	})
 
 	t.Run("active to upgradeAvailable active bundle error", func(t *testing.T) {
@@ -321,6 +344,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(nil, fmt.Errorf("boom"))
 
 		err := bm.ProcessBundleController(ctx, pbc)
@@ -339,12 +363,13 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
 		bc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		bc.EXPECT().GetBundle(ctx, pbc.Spec.ActiveBundle).Return(&allBundles[0], nil)
 		bc.EXPECT().SaveStatus(ctx, pbc).Return(fmt.Errorf("oops"))
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to upgrade available: oops")
+		assert.EqualError(t, err, "updating cluster01 status to upgrade available: oops")
 	})
 
 	t.Run("active to upgradeAvailable create error", func(t *testing.T) {
@@ -407,7 +432,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
+		assert.EqualError(t, err, "updating cluster01 status to active: oops")
 	})
 
 	t.Run("disconnected to active", func(t *testing.T) {
@@ -438,7 +463,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
+		assert.EqualError(t, err, "updating cluster01 status to active: oops")
 	})
 
 	t.Run("nothing to active bundle set", func(t *testing.T) {
@@ -476,7 +501,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 activeBundle to v1-21-1004: oops")
+		assert.EqualError(t, err, "updating cluster01 activeBundle to v1-21-1004: oops")
 	})
 
 	t.Run("nothing to active state", func(t *testing.T) {
@@ -510,6 +535,6 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.EqualError(t, err, "updating eksa-packages-cluster01 status to active: oops")
+		assert.EqualError(t, err, "updating cluster01 status to active: oops")
 	})
 }

--- a/pkg/driver/helmdriver_test.go
+++ b/pkg/driver/helmdriver_test.go
@@ -142,7 +142,7 @@ func givenHelmDriver(t *testing.T) (*helmDriver, error) {
 	mockSecretAuth.EXPECT().AuthFilename()
 
 	mockTargetClusterClient := mocks.NewMockTargetClusterClient(gomock.NewController(t))
-	mockTargetClusterClient.EXPECT().Init(ctx, "billy")
+	mockTargetClusterClient.EXPECT().Initialize(ctx, "billy")
 	return NewHelm(logr.Discard(), mockSecretAuth, mockTargetClusterClient)
 }
 


### PR DESCRIPTION
Create the `eksa-packages` namespace on the workload cluster to store helm information.

Couple other things in here:
* test data had the pbc name as "eksa-packages-cluster01" instead of cluster01 which just wasn't realistic
* mock was not up to date and had Init instead of Initialize as a method name
