### PR TITLE
Add workloadonly flag

### DIFF
--- a/api/v1alpha1/packagebundle_types.go
+++ b/api/v1alpha1/packagebundle_types.go
@@ -49,6 +49,10 @@ type BundlePackage struct {
 	// +kubebuilder:validation:Required
 	// Source location for the package (probably a helm chart).
 	Source BundlePackageSource `json:"source"`
+
+	// WorkloadOnly specifies if the package should be installed
+	// only on the workload cluster
+	WorkloadOnly bool `json:"workloadonly,omitempty"`
 }
 
 // BundlePackageSource identifies the location of a package.


### PR DESCRIPTION
*Description of changes:*
- This is part of cert manager package installation. Cert manager will only be installed on a workload cluster and hence this flag is necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
