### PR TITLE
Trigger Job when installing packages before and after install.

### DIFF
--- a/pkg/authenticator/ecrsecret.go
+++ b/pkg/authenticator/ecrsecret.go
@@ -2,10 +2,11 @@ package authenticator
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"strconv"
+	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -17,20 +18,23 @@ import (
 const (
 	ConfigMapName = "ns-secret-map"
 	ecrTokenName  = "ecr-token"
+	cronJobName   = "cron-ecr-renew"
 )
 
 type ecrSecret struct {
 	clientset     kubernetes.Interface
-	nsReleaseMap  map[string]string
 	targetCluster string
 }
 
 var _ Authenticator = (*ecrSecret)(nil)
 
-func NewECRSecret(config rest.Interface) (*ecrSecret, error) {
+func NewECRSecret(config *rest.Config) (*ecrSecret, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
 	return &ecrSecret{
-		clientset:     kubernetes.New(config),
-		nsReleaseMap:  make(map[string]string),
+		clientset:     clientset,
 		targetCluster: api.PackageNamespace,
 	}, nil
 }
@@ -67,61 +71,31 @@ func (s *ecrSecret) AddToConfigMap(ctx context.Context, name string, namespace s
 	if err != nil {
 		return err
 	}
-	// Store data
-	s.nsReleaseMap = cm.Data
 
 	return nil
 }
 
 func (s *ecrSecret) AddSecretToAllNamespace(ctx context.Context) error {
-	secret, err := s.clientset.CoreV1().Secrets(api.PackageNamespace).Get(ctx, ecrTokenName, metav1.GetOptions{})
+	cronjob, err := s.clientset.BatchV1().CronJobs(api.PackageNamespace).Get(ctx, cronJobName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	issue := false
-	for namespace := range s.nsReleaseMap {
-		// Create secret
-		// Check there is valid token data in the secret
-		secretData, exist := secret.Data[".dockerconfigjson"]
-		if !exist {
-			return fmt.Errorf("No dockerconfigjson data in secret %s", ecrTokenName)
-		}
 
-		newSecret, err := s.clientset.CoreV1().Secrets(namespace).Get(ctx, ecrTokenName, metav1.GetOptions{})
-		if err != nil {
-			newSecret = createSecret(ecrTokenName, namespace)
-			newSecret.Data[corev1.DockerConfigJsonKey] = secretData
-			_, err = s.clientset.CoreV1().Secrets(namespace).Create(context.TODO(), newSecret, metav1.CreateOptions{})
-			if err != nil {
-				issue = true
-			}
-		} else {
-			newSecret.Data[corev1.DockerConfigJsonKey] = secretData
-			_, err = s.clientset.CoreV1().Secrets(namespace).Update(context.TODO(), newSecret, metav1.UpdateOptions{})
-			if err != nil {
-				issue = true
-			}
-		}
+	jobSpec := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-controller-job-" + strconv.FormatInt(time.Now().UTC().UnixMilli(), 10),
+			Namespace: api.PackageNamespace,
+		},
+		Spec: cronjob.Spec.JobTemplate.Spec,
 	}
 
-	if issue {
-		return fmt.Errorf("failed to update namespaces")
+	jobs := s.clientset.BatchV1().Jobs(api.PackageNamespace)
+	_, err = jobs.Create(ctx, jobSpec, metav1.CreateOptions{})
+	if err != nil {
+		return err
 	}
 
 	return nil
-}
-
-func createSecret(name string, namespace string) *corev1.Secret {
-	object := metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-	}
-	secret := corev1.Secret{
-		ObjectMeta: object,
-		Type:       corev1.SecretTypeDockerConfigJson,
-		Data:       map[string][]byte{},
-	}
-	return &secret
 }
 
 func (s *ecrSecret) DelFromConfigMap(ctx context.Context, name string, namespace string) error {
@@ -143,23 +117,11 @@ func (s *ecrSecret) DelFromConfigMap(ctx context.Context, name string, namespace
 	if err != nil {
 		return err
 	}
-	// Store data
-	s.nsReleaseMap = cm.Data
 
 	return nil
 }
 
 func (s *ecrSecret) GetSecretValues(ctx context.Context, namespace string) (map[string]interface{}, error) {
-	secret, err := s.clientset.CoreV1().Secrets(api.PackageNamespace).Get(ctx, ecrTokenName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	// Check there is valid token data in the secret
-	_, exist := secret.Data[".dockerconfigjson"]
-	if !exist {
-		return nil, fmt.Errorf("No dockerconfigjson data in secret %s", ecrTokenName)
-	}
-
 	values := make(map[string]interface{})
 	var imagePullSecret [1]map[string]string
 	imagePullSecret[0] = make(map[string]string)

--- a/pkg/authenticator/ecrsecret_test.go
+++ b/pkg/authenticator/ecrsecret_test.go
@@ -7,23 +7,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/client-go/rest"
 
 	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )
 
 func TestAuthFilename(t *testing.T) {
-	fakeRestClient := fakerest.RESTClient{
-		GroupVersion: api.GroupVersion,
-	}
+	fakeConfig := rest.Config{}
 
 	t.Run("golden path for set HELM_REGISTRY_CONFIG", func(t *testing.T) {
 		testfile := "/test.txt"
 		t.Setenv("HELM_REGISTRY_CONFIG", testfile)
-		ecrAuth, err := NewECRSecret(&fakeRestClient)
+		ecrAuth, err := NewECRSecret(&fakeConfig)
 		require.NoError(t, err)
 		val := ecrAuth.AuthFilename()
 
@@ -32,7 +31,7 @@ func TestAuthFilename(t *testing.T) {
 
 	t.Run("golden path for no config or secrets", func(t *testing.T) {
 		t.Setenv("HELM_REGISTRY_CONFIG", "")
-		ecrAuth, _ := NewECRSecret(&fakeRestClient)
+		ecrAuth, _ := NewECRSecret(&fakeConfig)
 		val := ecrAuth.AuthFilename()
 
 		assert.Equal(t, val, "")
@@ -158,9 +157,11 @@ func TestDelFromConfigMap(t *testing.T) {
 		require.NoError(t, err)
 
 		err = ecrAuth.DelFromConfigMap(ctx, name, namespace)
+		require.NoError(t, err)
 
-		updatedCM, _ := mockClientset.CoreV1().ConfigMaps(targetClusterNamespace).
+		updatedCM, err := mockClientset.CoreV1().ConfigMaps(targetClusterNamespace).
 			Get(ctx, ConfigMapName, metav1.GetOptions{})
+		require.NoError(t, err)
 
 		val, exists := updatedCM.Data["eksa-packages"]
 		assert.Nil(t, err)
@@ -179,7 +180,6 @@ func TestDelFromConfigMap(t *testing.T) {
 			Data: cmdata,
 		})
 		ecrAuth := ecrSecret{clientset: mockClientset}
-
 		err := ecrAuth.Initialize(clusterName)
 		require.NoError(t, err)
 
@@ -197,8 +197,6 @@ func TestGetSecretValues(t *testing.T) {
 	ctx := context.TODO()
 	secretdata := make(map[string][]byte)
 	namespace := "eksa-packages"
-	releaseMap := make(map[string]string)
-	releaseMap[namespace] = "release1"
 
 	t.Run("golden path for Retrieving ECR Secret", func(t *testing.T) {
 		namespace = "test"
@@ -212,7 +210,7 @@ func TestGetSecretValues(t *testing.T) {
 			Data: secretdata,
 			Type: ".dockerconfigjson",
 		})
-		ecrAuth := ecrSecret{clientset: mockClientset, nsReleaseMap: releaseMap}
+		ecrAuth := ecrSecret{clientset: mockClientset}
 
 		values, err := ecrAuth.GetSecretValues(ctx, namespace)
 
@@ -232,7 +230,7 @@ func TestGetSecretValues(t *testing.T) {
 			Data: secretdata,
 			Type: ".dockerconfigjson",
 		})
-		ecrAuth := ecrSecret{clientset: mockClientset, nsReleaseMap: releaseMap}
+		ecrAuth := ecrSecret{clientset: mockClientset}
 
 		values, err := ecrAuth.GetSecretValues(ctx, namespace)
 
@@ -244,24 +242,53 @@ func TestGetSecretValues(t *testing.T) {
 		_, exists = values["pullSecretData"]
 		assert.False(t, exists)
 	})
+}
 
-	t.Run("fails when retrieving nonexistant secret", func(t *testing.T) {
-		namespace = "eksa-packages"
-		testdata := []byte("testdata")
-		secretdata[".dockerconfigjson"] = testdata
-		mockClientset := fake.NewSimpleClientset(&v1.Secret{
+func TestAddSecretToAllNamespace(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("golden path for adding ECR Secret to all namespaces", func(t *testing.T) {
+		mockClientset := fake.NewSimpleClientset(&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ecrTokenName,
-				Namespace: "wrong-ns",
+				Name:      cronJobName,
+				Namespace: api.PackageNamespace,
 			},
-			Data: secretdata,
-			Type: ".dockerconfigjson",
+			Spec: batchv1.CronJobSpec{},
 		})
+
 		ecrAuth := ecrSecret{clientset: mockClientset}
 
-		values, err := ecrAuth.GetSecretValues(ctx, namespace)
+		err := ecrAuth.AddSecretToAllNamespace(ctx)
+		assert.NoError(t, err)
+	})
 
+	t.Run("golden path for adding ECR Secret to all namespaces with missing job", func(t *testing.T) {
+		mockClientset := fake.NewSimpleClientset(&batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-name",
+				Namespace: api.PackageNamespace,
+			},
+			Spec: batchv1.CronJobSpec{},
+		})
+
+		ecrAuth := ecrSecret{clientset: mockClientset}
+
+		err := ecrAuth.AddSecretToAllNamespace(ctx)
 		assert.NotNil(t, err)
-		assert.Nil(t, values)
+	})
+
+	t.Run("golden path for adding ECR Secret to all namespaces with missing job in namespace", func(t *testing.T) {
+		mockClientset := fake.NewSimpleClientset(&batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cronJobName,
+				Namespace: "wrong-ns",
+			},
+			Spec: batchv1.CronJobSpec{},
+		})
+
+		ecrAuth := ecrSecret{clientset: mockClientset}
+
+		err := ecrAuth.AddSecretToAllNamespace(ctx)
+		assert.NotNil(t, err)
 	})
 }

--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -107,15 +107,24 @@ func (d *helmDriver) Install(ctx context.Context,
 	_, err = get.Run(name)
 	if err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
-			err = d.createRelease(ctx, install, helmChart, values)
-			if err != nil {
-				return err
-			}
+			// Trigger configmap updates and namespace before trying to install charts
 			if err := d.secretAuth.AddToConfigMap(ctx, name, namespace); err != nil {
 				d.log.Info("failed to Update ConfigMap with installed namespace")
 			}
 			if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
-				d.log.Info("Failed to Update Secret in all namespaces")
+				d.log.Info("failed to Update Secret in all namespaces", "error", err)
+			}
+			err = d.createRelease(ctx, install, helmChart, values)
+			if err != nil {
+				err1 := d.secretAuth.DelFromConfigMap(ctx, name, namespace)
+				if err1 != nil {
+					d.log.Info("failed to remove namespace from configmap")
+				}
+				return err
+			}
+			// Failsafe in event namespace is created via the charts
+			if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
+				d.log.Info("failed to Update Secret in all namespaces", "error", err)
 			}
 			return nil
 		}
@@ -133,7 +142,16 @@ func (d *helmDriver) Install(ctx context.Context,
 		d.log.Info("failed to Update ConfigMap with installed namespace")
 	}
 	if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
-		d.log.Info("Failed to Update Secret in all namespaces")
+		d.log.Info("failed to Update Secret in all namespaces", "error", err)
+	}
+
+	err = d.upgradeRelease(ctx, name, helmChart, values)
+	if err != nil {
+		return fmt.Errorf("upgrading helm chart %s: %w", name, err)
+	}
+
+	if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
+		d.log.Info("failed to Update Secret in all namespaces", "error", err)
 	}
 
 	return nil


### PR DESCRIPTION
To support updating ecr-token on remote clusters an instance of the cronjob is triggered. 

Two instances of the job are called. The first is to get the ecr-token into the namespaces before an install occurs so that the pods do not back off. A second instance is called to cover namespaces that are created via the helm charts.

Removed nsReleaseMap from ecrsecret as its no longer being used as the job handles keeping track of namespaces. Changed to accept config over rest client as corev1 path are not compatible with batchv1.