### PR TITLE
Include workloadonly changes for bundle and add cert manager as a pac…

### DIFF
--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -96,7 +96,8 @@ func (c *SDKClients) NewPackageFromInput(project Project) (*api.BundlePackage, e
 		return nil, fmt.Errorf("unable to find SHA sum for given input tag %v", project.Versions)
 	}
 	bundlePkg := &api.BundlePackage{
-		Name: project.Name,
+		Name:         project.Name,
+		WorkloadOnly: project.WorkloadOnly,
 		Source: api.BundlePackageSource{
 			Repository: project.Repository,
 			Registry:   project.Registry,

--- a/generatebundlefile/bundle_types.go
+++ b/generatebundlefile/bundle_types.go
@@ -73,10 +73,11 @@ type Org struct {
 
 // Repos is the object containing the project within the github org, and the release tag
 type Project struct {
-	Name       string `json:"name,omitempty"`
-	Registry   string `json:"registry,omitempty"`
-	Repository string `json:"repository,omitempty"`
-	Versions   []Tag  `json:"versions,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Registry     string `json:"registry,omitempty"`
+	Repository   string `json:"repository,omitempty"`
+	Versions     []Tag  `json:"versions,omitempty"`
+	WorkloadOnly bool   `json:"workloadonly,omitempty""`
 }
 
 // Tag is the release tag

--- a/generatebundlefile/data/input_120.yaml
+++ b/generatebundlefile/data/input_120.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest
+  - org: cert-manager
+    projects:
+        - name: cert-manager
+          workloadonly: true
+          repository: cert-manager/cert-manager
+          registry: public.ecr.aws/l0g8r8j6
+          versions:
+            - name: latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -18,12 +18,12 @@ packages:
             - name: latest
   - org: cert-manager
     projects:
-        - name: cert-manager
-          workloadonly: true
-          repository: cert-manager/cert-manager
-          registry: public.ecr.aws/l0g8r8j6
-          versions:
-            - name: latest
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_122.yaml
+++ b/generatebundlefile/data/input_122.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_123.yaml
+++ b/generatebundlefile/data/input_123.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/input.go
+++ b/generatebundlefile/input.go
@@ -130,7 +130,7 @@ func ParseInputConfig(fileName string, inputConfig *Input) error {
 		}
 		err = yaml.UnmarshalStrict([]byte(c), inputConfig)
 		if err != nil {
-			return fmt.Errorf("unable to UnmarshalStrict %s\nyaml: %s\n %v", inputConfig, string(c), err)
+			return fmt.Errorf("unable to UnmarshalStrict %s\nyaml: %s\n %v", fileName, string(c), err)
 		}
 		return nil
 	}


### PR DESCRIPTION
*Description of changes:*
- Include cert manager as a package in the bundle
- Include workloadOnly support for cert manager.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
