### PR TITLE
Bump metrics-server Versions

### DIFF
--- a/generatebundlefile/data/input_121.yaml
+++ b/generatebundlefile/data/input_121.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-21-18-latest
+            - name: 0.6.1-eks-1-21-19-latest
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_122.yaml
+++ b/generatebundlefile/data/input_122.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-22-10-latest
+            - name: 0.6.1-eks-1-22-11-latest
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/input_123.yaml
+++ b/generatebundlefile/data/input_123.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-23-5-latest
+            - name: 0.6.1-eks-1-23-6-latest
   - org: metallb 
     projects:
       - name: metallb 

--- a/generatebundlefile/data/metrics-server/input_promote.yaml
+++ b/generatebundlefile/data/metrics-server/input_promote.yaml
@@ -15,18 +15,18 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.1-eks-1-23-5-latest
+            - name: 0.6.1-eks-1-23-6-latest
   - org: metrics-server
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.1-eks-1-22-10-latest
+            - name: 0.6.1-eks-1-22-11-latest
   - org: metrics-server
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.1-eks-1-21-18-latest
+            - name: 0.6.1-eks-1-21-19-latest


### PR DESCRIPTION
*Description of changes:*
Bump metrics-server versions due to EKS-D release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.