### PR TITLE
Remove empty strings from depends fields

### DIFF
--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -52,6 +52,16 @@ func removeStringSlice(l []string, item string) []string {
 	return l
 }
 
+func deleteEmptyStringSlice(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}
+
 // ExecCommand runs a given command, and constructs the log/output.
 func ExecCommand(cmd *exec.Cmd) (string, error) {
 	stdout, err := cmd.Output()

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -256,7 +256,7 @@ func cmdGenerate(opts *Options) error {
 			charts.Source.Versions[0].Images = helmImage
 			// Populate Configurations to bundle spec from Requires.yaml
 
-			if len(helmRequires.Spec.Dependencies) > 0 {
+			if len(deleteEmptyStringSlice(helmRequires.Spec.Dependencies)) > 0 {
 				charts.Source.Versions[0].Dependencies = helmRequires.Spec.Dependencies
 			}
 			charts.Source.Versions[0].Schema = helmRequires.Spec.Schema


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

If the depends field in the requires.yaml is an empty string we don't want it in the bundle.
