### PR TITLE
Remove manager context source from install

### DIFF
--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -53,7 +53,7 @@ func (mc *ManagerContext) SetUninstalling(namespace string, name string) {
 	mc.Package.Status.State = api.StateUninstalling
 }
 
-func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
+func (mc *ManagerContext) getImageRegistry(values map[string]interface{}) string {
 	if val, ok := values[sourceRegistry]; ok {
 		if val != "" {
 			return val.(string)
@@ -61,9 +61,6 @@ func (mc *ManagerContext) getRegistry(values map[string]interface{}) string {
 	}
 	if mc.PBC.Spec.PrivateRegistry != "" {
 		return mc.PBC.Spec.PrivateRegistry
-	}
-	if mc.Source.Registry != "" {
-		return mc.Source.Registry
 	}
 	return mc.PBC.GetDefaultImageRegistry()
 }
@@ -144,7 +141,7 @@ func processInstalling(mc *ManagerContext) bool {
 		mc.Log.Error(err, "Install failed")
 		return true
 	}
-	values[sourceRegistry] = mc.getRegistry(values)
+	values[sourceRegistry] = mc.getImageRegistry(values)
 	if mc.Source.Registry == "" {
 		mc.Source.Registry = mc.PBC.GetDefaultRegistry()
 	}
@@ -192,7 +189,7 @@ func processInstalled(mc *ManagerContext) bool {
 		return true
 	}
 
-	newValues[sourceRegistry] = mc.getRegistry(newValues)
+	newValues[sourceRegistry] = mc.getImageRegistry(newValues)
 	needs, err := mc.PackageDriver.IsConfigChanged(mc.Ctx, mc.Package.Name, newValues)
 	if err != nil {
 		mc.Log.Error(err, "checking necessity of reconfiguration")

--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -179,22 +179,14 @@ func TestManagerContext_getRegistry(t *testing.T) {
 		values := make(map[string]interface{})
 		values["sourceRegistry"] = "valuesRegistry"
 
-		assert.Equal(t, "valuesRegistry", sut.getRegistry(values))
+		assert.Equal(t, "valuesRegistry", sut.getImageRegistry(values))
 	})
 
 	t.Run("registry from privateRegistry", func(t *testing.T) {
 		sut, _ := givenMocks(t)
 		values := make(map[string]interface{})
 
-		assert.Equal(t, "privateRegistry", sut.getRegistry(values))
-	})
-
-	t.Run("registry from bundle package", func(t *testing.T) {
-		sut, _ := givenMocks(t)
-		values := make(map[string]interface{})
-		sut.PBC.Spec.PrivateRegistry = ""
-
-		assert.Equal(t, "public.ecr.aws/j0a1m4z9/", sut.getRegistry(values))
+		assert.Equal(t, "privateRegistry", sut.getImageRegistry(values))
 	})
 
 	t.Run("registry from default gated registry", func(t *testing.T) {
@@ -203,7 +195,7 @@ func TestManagerContext_getRegistry(t *testing.T) {
 		sut.PBC.Spec.PrivateRegistry = ""
 		sut.Source.Registry = ""
 
-		assert.Equal(t, "783794618700.dkr.ecr.us-west-2.amazonaws.com", sut.getRegistry(values))
+		assert.Equal(t, "783794618700.dkr.ecr.us-west-2.amazonaws.com", sut.getImageRegistry(values))
 	})
 }
 


### PR DESCRIPTION
Remove the use of manager.source.registry from getRegistry and rename it getImageRegistry. This was created before gating existed and doesn't support that case I guess.
