### PR TITLE
Promote Newest 1.21.18 metrics-server Chart

### DIFF
--- a/generatebundlefile/data/metrics-server/input_promote.yaml
+++ b/generatebundlefile/data/metrics-server/input_promote.yaml
@@ -29,4 +29,4 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.1-eks-1-21-19-latest
+            - name: 0.6.1-eks-1-21-18-latest


### PR DESCRIPTION
*Description of changes:*
Because we reverted EKS-D 1.21 images from 1.21.19 to 1.21.18 we are failing to promote the *newer* 1.21.18 charts into the public ECR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.