### PR TITLE
Add metrics-server Charts to Prod Bundle

### DIFF
--- a/generatebundlefile/data/input_121_prod.yaml
+++ b/generatebundlefile/data/input_121_prod.yaml
@@ -43,6 +43,13 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.13.5-0c9bc01066c2b8e8006c60d09f55015501ad2fc2
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.6.1-eks-1-21-18-c94ed410f56421659f554f13b4af7a877da72bc1
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/input_122_prod.yaml
+++ b/generatebundlefile/data/input_122_prod.yaml
@@ -43,6 +43,13 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.13.5-0c9bc01066c2b8e8006c60d09f55015501ad2fc2
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.6.1-eks-1-22-11-c94ed410f56421659f554f13b4af7a877da72bc1
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/input_123_prod.yaml
+++ b/generatebundlefile/data/input_123_prod.yaml
@@ -43,6 +43,13 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.13.5-0c9bc01066c2b8e8006c60d09f55015501ad2fc2
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+            - name: 0.6.1-eks-1-23-6-c94ed410f56421659f554f13b4af7a877da72bc1
   - org: emissary
     projects:
       - name: emissary


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3187
Ticket: https://github.com/aws/eks-anywhere/issues/3727

*Description of changes:*
Adds metrics-server to production bundle.

I've generated bundles locally using the charts published to `eks-anywhere/metrics-server/charts/metrics-server` and verified they install and run correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->