### PR TITLE
Remove -latest From CA & MS Tags

### DIFF
--- a/generatebundlefile/data/input_release.yaml
+++ b/generatebundlefile/data/input_release.yaml
@@ -23,8 +23,8 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: 9.21.0-1.21-c94ed410f56421659f554f13b4af7a877da72bc1
-            - name: 9.21.0-1.22-c94ed410f56421659f554f13b4af7a877da72bc1-latest-helm
-            - name: 9.21.0-1.23-c94ed410f56421659f554f13b4af7a877da72bc1-latest-helm
+            - name: 9.21.0-1.22-c94ed410f56421659f554f13b4af7a877da72bc1
+            - name: 9.21.0-1.23-c94ed410f56421659f554f13b4af7a877da72bc1
             - name: 9.21.0-1.24-c94ed410f56421659f554f13b4af7a877da72bc1
   - org: harbor
     projects:
@@ -54,7 +54,7 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: 0.6.1-eks-1-21-18-c94ed410f56421659f554f13b4af7a877da72bc1
-            - name: 0.6.1-eks-1-22-11-c94ed410f56421659f554f13b4af7a877da72bc1-latest-helm
+            - name: 0.6.1-eks-1-22-11-c94ed410f56421659f554f13b4af7a877da72bc1
             - name: 0.6.1-eks-1-23-6-c94ed410f56421659f554f13b4af7a877da72bc1
             - name: 0.6.1-eks-1-24-1-c94ed410f56421659f554f13b4af7a877da72bc1
   - org: emissary


### PR DESCRIPTION
*Description of changes:*
Try removing latest from tags to get image promo job running.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.