### PR TITLE
Add cert manager to release bundle

### DIFF
--- a/generatebundlefile/data/input_120_prod.yaml
+++ b/generatebundlefile/data/input_120_prod.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_121_prod.yaml
+++ b/generatebundlefile/data/input_121_prod.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_122_prod.yaml
+++ b/generatebundlefile/data/input_122_prod.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_123_prod.yaml
+++ b/generatebundlefile/data/input_123_prod.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/eks-anywhere
         versions:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/input_release.yaml
+++ b/generatebundlefile/data/input_release.yaml
@@ -16,6 +16,14 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
+  - org: cert-manager
+    projects:
+        - name: cert-manager
+          workloadonly: true
+          repository: cert-manager/cert-manager
+          registry: public.ecr.aws/l0g8r8j6
+          versions:
+            - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/input_release.yaml
+++ b/generatebundlefile/data/input_release.yaml
@@ -18,12 +18,12 @@ packages:
             - name: 0.21.1-971c31238aeea5f1bda6ec95caaf24993b304157
   - org: cert-manager
     projects:
-        - name: cert-manager
-          workloadonly: true
-          repository: cert-manager/cert-manager
-          registry: public.ecr.aws/l0g8r8j6
-          versions:
-            - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 1.9.1-dc0c845b5f71bea6869efccd3ca3f2dd11b5c95f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler


### PR DESCRIPTION
*Description of changes:*
- Add cert-manager to release bundle
- Copy cert-manager to prod account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
