### PR TITLE
Remove deep copy from bundle

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -39,7 +39,6 @@ var _ Manager = (*bundleManager)(nil)
 func (m bundleManager) ProcessBundle(_ context.Context, newBundle *api.PackageBundle) (bool, error) {
 	if newBundle.Namespace != api.PackageNamespace {
 		if newBundle.Status.State != api.PackageBundleStateIgnored {
-			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 			newBundle.Status.State = api.PackageBundleStateIgnored
 			m.log.V(6).Info("update", "bundle", newBundle.Name, "state", newBundle.Status.State)
 			return true, nil
@@ -49,7 +48,6 @@ func (m bundleManager) ProcessBundle(_ context.Context, newBundle *api.PackageBu
 
 	if !newBundle.IsValidVersion() {
 		if newBundle.Status.State != api.PackageBundleStateInvalid {
-			newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 			newBundle.Status.State = api.PackageBundleStateInvalid
 			m.log.V(6).Info("update", "bundle", newBundle.Name, "state", newBundle.Status.State)
 			return true, nil
@@ -58,7 +56,6 @@ func (m bundleManager) ProcessBundle(_ context.Context, newBundle *api.PackageBu
 	}
 
 	if newBundle.Status.State != api.PackageBundleStateAvailable {
-		newBundle.Spec.DeepCopyInto(&newBundle.Status.Spec)
 		newBundle.Status.State = api.PackageBundleStateAvailable
 		m.log.V(6).Info("update", "bundle", newBundle.Name, "state", newBundle.Status.State)
 		return true, nil


### PR DESCRIPTION
The bundle is pretty much a static object because of the signature, so copying the entire thing is kind of a waste. We do nothing to reconcile any valid updates to the bundle anyway right now and we could add the copy back if we do. Either way, the package reconciliation should detect changes to the bundle if there were any. The relationship between the objects is that the bundle doesn't know about the others.