### PR TITLE
Chart.yaml version for image tag

### DIFF
--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -87,3 +87,17 @@ Create image name
 {{- printf "/%s:%s" .repository .tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Template Controller image from Chart version
+*/}}
+{{- define "controller.image" -}}
+{{- printf "/%s:v%s" .Values.controller.repository .Chart.Version -}}
+{{- end -}}
+
+{{/*
+Template Cronjob image from Chart version
+*/}}
+{{- define "cronjob.image" -}}
+{{- printf "/%s:v%s" .Values.cronjob.repository .Chart.Version -}}
+{{- end -}}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: {{ include "eks-anywhere-packages.serviceAccountName" . }}
           containers:
             - name: {{.Values.cronjob.name}}
-              image: {{.Values.sourceRegistry}}{{ template "template.image" .Values.cronjob }}
+              image: {{.Values.sourceRegistry}}{{ template "cronjob.image" . }}
               imagePullPolicy: {{ .Values.imagePullPolicy }}
               env:
                 - name: ECR_TOKEN_SECRET_NAME

--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: {{.Values.sourceRegistry}}{{ template "template.image" .Values.controller }}
+          image: {{.Values.sourceRegistry}}{{ template "controller.image" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: ENABLE_WEBHOOKS


### PR DESCRIPTION
Changing template for controller/cronjob to use chart.yaml version value to create image url

Addresses issue where image tag doesn't exist. Currently release process updates the version in chart.yaml. This PR changes the chart to use that version to build the image url.

This should be a short-term fix until a different solution is developed to handle pulling by tag and promotion.
