### PR TITLE
Fix installed package problem

### DIFF
--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -228,7 +228,8 @@ func (d *helmDriver) IsConfigChanged(_ context.Context, name string, values map[
 	get := action.NewGet(d.cfg)
 	rel, err := get.Run(name)
 	if err != nil {
-		return false, fmt.Errorf("installation not found %q: %w", name, err)
+		d.log.Info("Installation not found %q: %w", name, err)
+		return true, nil
 	}
 
 	// Check imagePullSecret not defined in config

--- a/pkg/driver/helmdriver_test.go
+++ b/pkg/driver/helmdriver_test.go
@@ -60,9 +60,10 @@ func TestIsConfigChanged(t *testing.T) {
 		require.NoError(t, err)
 		helm.cfg.KubeClient = newMockKube(fmt.Errorf("blah"))
 
-		_, err = helm.IsConfigChanged(ctx, "name-does-not-exist", values)
+		changed, err := helm.IsConfigChanged(ctx, "name-does-not-exist", values)
 
-		assert.EqualError(t, err, "installation not found \"name-does-not-exist\": IsReachable test error blah")
+		assert.NoError(t, err)
+		assert.True(t, changed)
 	})
 
 	t.Run("golden path returning true", func(t *testing.T) {


### PR DESCRIPTION
The helm chart was installed and the helm secret was in eksa-packages namespace. When that namespace was deleted, it lost the helm state, but the chart resources are still there. When I reinstalled the package, I get:
```
eksa-packages-billy   package.packages.eks.amazonaws.com/my-other-hello   hello-eks-anywhere   23h   installed   0.1.2-latest-helm   0.1.2-latest-helm (latest)   installation not found "my-other-hello": release: not found
```

Closes: https://github.com/aws/eks-anywhere-packages/issues/621