### PR TITLE
Add createNamespace PBC setting

### DIFF
--- a/api/v1alpha1/packagebundlecontroller_types.go
+++ b/api/v1alpha1/packagebundlecontroller_types.go
@@ -85,6 +85,11 @@ type PackageBundleControllerSpec struct {
 	// Repository portion of an OCI address to the bundle
 	// +optional
 	BundleRepository string `json:"bundleRepository"`
+
+	// +kubebuilder:default:=false
+	// Allow target namespace creation by the controller
+	// +optional
+	CreateNamespace bool `json:"createNamespace"`
 }
 
 // +kubebuilder:validation:Enum=ignored;active;disconnected;upgrade available

--- a/charts/eks-anywhere-packages/crds/crd.yaml
+++ b/charts/eks-anywhere-packages/crds/crd.yaml
@@ -56,6 +56,10 @@ spec:
                 default: eks-anywhere-packages-bundles
                 description: Repository portion of an OCI address to the bundle
                 type: string
+              createNamespace:
+                default: false
+                description: Allow target namespace creation by the controller
+                type: boolean
               defaultImageRegistry:
                 default: 783794618700.dkr.ecr.us-west-2.amazonaws.com
                 description: DefaultImageRegistry for pulling images

--- a/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
+++ b/config/crd/bases/packages.eks.amazonaws.com_packagebundlecontrollers.yaml
@@ -58,6 +58,10 @@ spec:
                 default: eks-anywhere-packages-bundles
                 description: Repository portion of an OCI address to the bundle
                 type: string
+              createNamespace:
+                default: false
+                description: Allow target namespace creation by the controller
+                type: boolean
               defaultImageRegistry:
                 default: 783794618700.dkr.ecr.us-west-2.amazonaws.com
                 description: DefaultImageRegistry for pulling images

--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -70,12 +70,12 @@ func (d *helmDriver) Initialize(ctx context.Context, clusterName string) (err er
 }
 
 func (d *helmDriver) Install(ctx context.Context,
-	name string, namespace string, source api.PackageOCISource, values map[string]interface{}) error {
+	name string, namespace string, createNamespace bool, source api.PackageOCISource, values map[string]interface{}) error {
 	var err error
 	install := action.NewInstall(d.cfg)
 	install.Version = source.Version
 	install.ReleaseName = name
-	install.Namespace = namespace
+	install.CreateNamespace = createNamespace
 
 	helmChart, err := d.getChart(install, source)
 	if err != nil {
@@ -90,6 +90,7 @@ func (d *helmDriver) Install(ctx context.Context,
 			namespace = "default"
 		}
 	}
+	install.Namespace = namespace
 
 	// Update values with imagePullSecrets
 	// If no secret values we should still continue as it could be case of public registry or local registry

--- a/pkg/driver/mocks/packagedriver.go
+++ b/pkg/driver/mocks/packagedriver.go
@@ -50,17 +50,17 @@ func (mr *MockPackageDriverMockRecorder) Initialize(ctx, clusterName interface{}
 }
 
 // Install mocks base method.
-func (m *MockPackageDriver) Install(ctx context.Context, name, namespace string, source v1alpha1.PackageOCISource, values map[string]interface{}) error {
+func (m *MockPackageDriver) Install(ctx context.Context, name, namespace string, createNamespace bool, source v1alpha1.PackageOCISource, values map[string]interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", ctx, name, namespace, source, values)
+	ret := m.ctrl.Call(m, "Install", ctx, name, namespace, createNamespace, source, values)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Install indicates an expected call of Install.
-func (mr *MockPackageDriverMockRecorder) Install(ctx, name, namespace, source, values interface{}) *gomock.Call {
+func (mr *MockPackageDriverMockRecorder) Install(ctx, name, namespace, createNamespace, source, values interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockPackageDriver)(nil).Install), ctx, name, namespace, source, values)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockPackageDriver)(nil).Install), ctx, name, namespace, createNamespace, source, values)
 }
 
 // IsConfigChanged mocks base method.

--- a/pkg/driver/packagedriver.go
+++ b/pkg/driver/packagedriver.go
@@ -16,7 +16,7 @@ type PackageDriver interface {
 	Initialize(ctx context.Context, clusterName string) error
 
 	// Install or upgrade an package.
-	Install(ctx context.Context, name string, namespace string, source api.PackageOCISource, values map[string]interface{}) error
+	Install(ctx context.Context, name string, namespace string, createNamespace bool, source api.PackageOCISource, values map[string]interface{}) error
 
 	// Uninstall an package.
 	Uninstall(ctx context.Context, name string) error

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -150,7 +150,9 @@ func processInstalling(mc *ManagerContext) bool {
 		mc.Log.Error(err, "Initialization failed")
 		return true
 	}
-	if err := mc.PackageDriver.Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, values); err != nil {
+
+	createNamespace := mc.PBC.Spec.CreateNamespace
+	if err := mc.PackageDriver.Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, createNamespace, mc.Source, values); err != nil {
 		mc.Package.Status.Detail = err.Error()
 		mc.Log.Error(err, "Install failed")
 		return true

--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -305,7 +305,7 @@ func TestManagerLifecycle(t *testing.T) {
 		mc, mockDriver := givenMocks(t)
 		mc.Package.Status.State = api.StateInstalling
 		mockDriver.EXPECT().Initialize(mc.Ctx, clusterName).Return(nil)
-		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, gomock.Any()).Return(nil)
+		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, false, mc.Source, gomock.Any()).Return(nil)
 		result := sut.Process(mc)
 		assert.True(t, result)
 		thenManagerContext(t, mc, api.StateInstalled, expectedSource, 60*time.Second, "")
@@ -317,10 +317,21 @@ func TestManagerLifecycle(t *testing.T) {
 		mc.Package.Namespace = "eksa-packages"
 		t.Setenv("CLUSTER_NAME", "franky")
 		mockDriver.EXPECT().Initialize(mc.Ctx, "").Return(nil)
-		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, gomock.Any()).Return(nil)
+		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, false, mc.Source, gomock.Any()).Return(nil)
 		result := sut.Process(mc)
 		assert.True(t, result)
 		thenManagerContext(t, mc, api.StateInstalled, expectedSource, 60*time.Second, "Deprecated package namespace. Move to eksa-packages-franky")
+	})
+
+	t.Run("installing with namespace creation enabled creates the namespace", func(t *testing.T) {
+		mc, mockDriver := givenMocks(t)
+		mc.PBC.Spec.CreateNamespace = true
+		mc.Package.Status.State = api.StateInstalling
+		mockDriver.EXPECT().Initialize(mc.Ctx, clusterName).Return(nil)
+		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, true, mc.Source, gomock.Any()).Return(nil)
+		result := sut.Process(mc)
+		assert.True(t, result)
+		thenManagerContext(t, mc, api.StateInstalled, expectedSource, 60*time.Second, "")
 	})
 
 	t.Run("installing initialize fails", func(t *testing.T) {
@@ -336,7 +347,7 @@ func TestManagerLifecycle(t *testing.T) {
 		mc, mockDriver := givenMocks(t)
 		mc.Package.Status.State = api.StateInstalling
 		mockDriver.EXPECT().Initialize(mc.Ctx, clusterName).Return(nil)
-		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, mc.Source, gomock.Any()).Return(fmt.Errorf("boom"))
+		mockDriver.EXPECT().Install(mc.Ctx, mc.Package.Name, mc.Package.Spec.TargetNamespace, false, mc.Source, gomock.Any()).Return(fmt.Errorf("boom"))
 		result := sut.Process(mc)
 		assert.True(t, result)
 		thenManagerContext(t, mc, api.StateInstalling, expectedSource, 60*time.Second, "boom")


### PR DESCRIPTION
This PBC setting will tell the controller to create the namespace on the target cluster if it doesn't exist. This is disabled by default because the controller does not impersonate the user applying the package and will always have namespace creation permissions.

Fixes #601



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
