### PR TITLE
Fixing the bundle diff check removing unique metadata fields

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -31,3 +31,9 @@ function awsAuth () {
 
     aws "$awsCmd" "$region" "--profile=${PROFILE:-}" get-login-password
 }
+
+function removeBundleMetadata () {
+    local bundle=${1?:no bundle specified}
+    yq 'del(.metadata.name)' ${bundle} > ${bundle}.strippedname
+    yq 'del(.metadata.annotations)' ${bundle}.strippedname > ${bundle}.stripped
+}

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -47,7 +47,9 @@ function push () {
     cd "${BASE_DIRECTORY}/generatebundlefile/output"
     awsAuth "$REPO" | "$ORAS_BIN" login "$REPO" --username AWS --password-stdin
     "$ORAS_BIN" pull "${REPO}:v${version}-latest" -o ${version}
-    if (git diff --no-index --quiet -- ${version}/bundle.yaml bundle.yaml) then
+    removeBundleMetadata ${version}/bundle.yaml
+    removeBundleMetadata bundle.yaml
+    if (git diff --no-index --quiet -- ${version}/bundle.yaml.stripped bundle.yaml.stripped) then
         echo "bundle contents are identical skipping bundle push for ${version}"
     else
         "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml

--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -85,7 +85,9 @@ function push () {
     cd "${BASE_DIRECTORY}/generatebundlefile/output-${version}"
     awsAuth "$REPO" | "$ORAS_BIN" login "$REPO" --username AWS --password-stdin
     "$ORAS_BIN" pull "${REPO}:v${version}-latest" -o ${version}
-    if (git diff --no-index --quiet -- ${version}/bundle.yaml bundle.yaml) then
+    removeBundleMetadata ${version}/bundle.yaml
+    removeBundleMetadata bundle.yaml
+    if (git diff --no-index --quiet -- ${version}/bundle.yaml.stripped bundle.yaml.stripped) then
         echo "bundle contents are identical skipping bundle push for ${version}"
     else
         "$ORAS_BIN" push "${REPO}:v${version}-${CODEBUILD_BUILD_NUMBER}" bundle.yaml


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Remove the metadata.Annotations and metadata.Name field before doing the diff check on the bundle files.

Tested locally using a builder-base image, and works. Applying change to Dev and Staging first to verify.
