### PR TITLE
Use the package-manager command everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ COPY config/ config/
 COPY pkg/ pkg/
 
 # Build
-RUN GOPROXY=direct CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN GOPROXY=direct CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o package-manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/package-manager .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/package-manager"]

--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -38,8 +38,9 @@ spec:
       containers:
         - name: controller
           command:
-          - /manager
+          - /package-manager
           args:
+          - server
           - --health-probe-bind-address=:8081
           - --metrics-bind-address=127.0.0.1:8080
           - --leader-elect


### PR DESCRIPTION
Missed the deployment `package-manager` command change until I functionally tested it
