### PR TITLE
Fix to use the correct env var in release pipelines on region check

### DIFF
--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -177,12 +177,19 @@ func cmdRegion(opts *Options) error {
 	//STS and ECR Client to get Account Number
 	BundleLog.Info("Creating SDK connections to Region Check")
 	clients := &SDKClients{}
-	clients, err = clients.GetProfileSDKConnection("ecr", "default", ecrRegion)
+
+	Profile := "default"
+	val, ok := os.LookupEnv("AWS_PROFILE")
+	if ok {
+		Profile = val
+	}
+
+	clients, err = clients.GetProfileSDKConnection("ecr", Profile, ecrRegion)
 	if err != nil {
 		BundleLog.Error(err, "getting SDK connection")
 		os.Exit(1)
 	}
-	clients, err = clients.GetProfileSDKConnection("sts", "default", ecrRegion)
+	clients, err = clients.GetProfileSDKConnection("sts", Profile, ecrRegion)
 	if err != nil {
 		BundleLog.Error(err, "getting profile SDK connection")
 		os.Exit(1)
@@ -190,7 +197,7 @@ func cmdRegion(opts *Options) error {
 	var imagesNotFound []string
 	for _, region := range RegionList {
 		BundleLog.Info("Starting Check for", "Region", region)
-		clients, err = clients.GetProfileSDKConnection("ecr", "default", region)
+		clients, err = clients.GetProfileSDKConnection("ecr", Profile, region)
 		if err != nil {
 			BundleLog.Error(err, "getting ECR SDK connection")
 			os.Exit(1)


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
