### PR TITLE
Moving region check call to correct spot

### DIFF
--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -72,12 +72,12 @@ fi
 
 for version in 1-20 1-21 1-22 1-23 1-24; do
     generate ${version} "staging"
+    export AWS_PROFILE=packages && regionCheck ${version}
 done
 
 export AWS_PROFILE=staging
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
 
 for version in 1-21 1-22 1-23 1-24; do
-    regionCheck ${version}
     push ${version}
 done


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

#658

*Description of changes:*

The last region check was calling on the staging account for helm charts, we need to move it earlier to query vs the Account which the images live in.