### PR TITLE
Updating helm chart to newer version

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-21.yaml
+++ b/generatebundlefile/data/bundles_staging/1-21.yaml
@@ -37,7 +37,7 @@ packages:
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 2.5.1-0d4e0476a740b48a232041597ded2031595d9409
+            - name: 2.5.1-ee7e5a6898b6c35668a1c5789aa0d654fad6c913	
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_staging/1-22.yaml
+++ b/generatebundlefile/data/bundles_staging/1-22.yaml
@@ -37,7 +37,7 @@ packages:
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 2.5.1-0d4e0476a740b48a232041597ded2031595d9409
+            - name: 2.5.1-ee7e5a6898b6c35668a1c5789aa0d654fad6c913	
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_staging/1-23.yaml
+++ b/generatebundlefile/data/bundles_staging/1-23.yaml
@@ -37,7 +37,7 @@ packages:
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 2.5.1-0d4e0476a740b48a232041597ded2031595d9409
+            - name: 2.5.1-ee7e5a6898b6c35668a1c5789aa0d654fad6c913	
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_staging/1-24.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24.yaml
@@ -42,7 +42,7 @@ packages:
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 2.5.1-0d4e0476a740b48a232041597ded2031595d9409
+            - name: 2.5.1-ee7e5a6898b6c35668a1c5789aa0d654fad6c913	
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -40,7 +40,7 @@ packages:
         repository: harbor/harbor-helm
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 2.5.1-0d4e0476a740b48a232041597ded2031595d9409
+            - name: 2.5.1-ee7e5a6898b6c35668a1c5789aa0d654fad6c913	
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

We have a newer version of harbor in production gallery, we should use that since the image replication has already occurred on this one. https://gallery.ecr.aws/eks-anywhere/harbor/harbor-helm


