### PR TITLE
Do not generate deepcopy for generate bundle file

### DIFF
--- a/generatebundlefile/bundle_types.go
+++ b/generatebundlefile/bundle_types.go
@@ -58,6 +58,7 @@ func newSigningObjectMeta(meta *metav1.ObjectMeta) *SigningObjectMeta {
 
 // Types for input file format
 // +kubebuilder:object:root=true
+// +kubebuilder:object:generate=false
 // Input is the schema for the Input file
 type Input struct {
 	Packages          []Org  `json:"packages,omitempty"`


### PR DESCRIPTION
We don't generate deepcopy for any other resources except for this one for some reason. This stops generating the deepcopy for this resource.
