### PR TITLE
Rename bundle client to manager client

### DIFF
--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -87,7 +87,7 @@ func RegisterPackageReconciler(mgr ctrl.Manager) (err error) {
 
 	puller := artifacts.NewRegistryPuller()
 	registryClient := bundle.NewRegistryClient(puller)
-	bundleClient := bundle.NewPackageBundleClient(mgr.GetClient())
+	bundleClient := bundle.NewManagerClient(mgr.GetClient())
 	packageClient := packages.NewPackageClient(mgr.GetClient())
 	bundleManager := bundle.NewBundleManager(log, registryClient, bundleClient, tcc, config.GetGlobalConfig())
 	reconciler := NewPackageReconciler(

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -64,7 +64,7 @@ func NewPackageBundleReconciler(client client.Client, scheme *runtime.Scheme,
 
 func RegisterPackageBundleReconciler(mgr ctrl.Manager) error {
 	log := ctrl.Log.WithName(packageBundleName)
-	bundleClient := bundle.NewPackageBundleClient(mgr.GetClient())
+	bundleClient := bundle.NewManagerClient(mgr.GetClient())
 	tcc := authenticator.NewTargetClusterClient(mgr.GetConfig(), mgr.GetClient())
 	puller := artifacts.NewRegistryPuller()
 	registryClient := bundle.NewRegistryClient(puller)

--- a/controllers/packagebundlecontroller_controller.go
+++ b/controllers/packagebundlecontroller_controller.go
@@ -64,7 +64,7 @@ func NewPackageBundleControllerReconciler(client client.Client,
 func RegisterPackageBundleControllerReconciler(mgr ctrl.Manager) error {
 	log := ctrl.Log.WithName(packageBundleControllerName)
 
-	bundleClient := bundle.NewPackageBundleClient(mgr.GetClient())
+	bundleClient := bundle.NewManagerClient(mgr.GetClient())
 	tcc := authenticator.NewTargetClusterClient(mgr.GetConfig(), mgr.GetClient())
 	puller := artifacts.NewRegistryPuller()
 	registryClient := bundle.NewRegistryClient(puller)

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -44,23 +44,23 @@ type Client interface {
 	Save(ctx context.Context, object client.Object) error
 }
 
-type bundleClient struct {
+type managerClient struct {
 	client.Client
 }
 
-func NewPackageBundleClient(client client.Client) *bundleClient {
-	return &(bundleClient{
+func NewManagerClient(client client.Client) *managerClient {
+	return &(managerClient{
 		Client: client,
 	})
 }
 
-var _ Client = (*bundleClient)(nil)
+var _ Client = (*managerClient)(nil)
 
 // GetActiveBundle retrieves the bundle from which package are installed.
 //
 // It retrieves the name of the active bundle from the PackageBundleController,
 // then uses the K8s API to retrieve and return the active bundle.
-func (bc *bundleClient) GetActiveBundle(ctx context.Context, clusterName string) (activeBundle *api.PackageBundle, err error) {
+func (bc *managerClient) GetActiveBundle(ctx context.Context, clusterName string) (activeBundle *api.PackageBundle, err error) {
 	pbc, err := bc.GetPackageBundleController(ctx, clusterName)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (bc *bundleClient) GetActiveBundle(ctx context.Context, clusterName string)
 	return activeBundle, nil
 }
 
-func (bc *bundleClient) GetPackageBundleController(ctx context.Context, clusterName string) (*api.PackageBundleController, error) {
+func (bc *managerClient) GetPackageBundleController(ctx context.Context, clusterName string) (*api.PackageBundleController, error) {
 	if clusterName == "" {
 		clusterName = os.Getenv("CLUSTER_NAME")
 	}
@@ -99,7 +99,7 @@ func (bc *bundleClient) GetPackageBundleController(ctx context.Context, clusterN
 	return &pbc, nil
 }
 
-func (bc *bundleClient) GetBundle(ctx context.Context, name string) (namedBundle *api.PackageBundle, err error) {
+func (bc *managerClient) GetBundle(ctx context.Context, name string) (namedBundle *api.PackageBundle, err error) {
 	nn := types.NamespacedName{
 		Namespace: api.PackageNamespace,
 		Name:      name,
@@ -116,7 +116,7 @@ func (bc *bundleClient) GetBundle(ctx context.Context, name string) (namedBundle
 	return namedBundle, nil
 }
 
-func (bc *bundleClient) GetBundleList(ctx context.Context) (bundles []api.PackageBundle, err error) {
+func (bc *managerClient) GetBundleList(ctx context.Context) (bundles []api.PackageBundle, err error) {
 	var allBundles = &api.PackageBundleList{}
 	err = bc.Client.List(ctx, allBundles, &client.ListOptions{Namespace: api.PackageNamespace})
 	if err != nil {
@@ -126,7 +126,7 @@ func (bc *bundleClient) GetBundleList(ctx context.Context) (bundles []api.Packag
 	return allBundles.Items, nil
 }
 
-func (bc *bundleClient) CreateClusterNamespace(ctx context.Context, clusterName string) error {
+func (bc *managerClient) CreateClusterNamespace(ctx context.Context, clusterName string) error {
 	name := api.PackageNamespace + "-" + clusterName
 	key := types.NamespacedName{
 		Name: name,
@@ -149,7 +149,7 @@ func (bc *bundleClient) CreateClusterNamespace(ctx context.Context, clusterName 
 	return nil
 }
 
-func (bc *bundleClient) CreateClusterConfigMap(ctx context.Context, clusterName string) error {
+func (bc *managerClient) CreateClusterConfigMap(ctx context.Context, clusterName string) error {
 	name := auth.ConfigMapName
 	namespace := api.PackageNamespace + "-" + clusterName
 	key := types.NamespacedName{
@@ -185,7 +185,7 @@ func (bc *bundleClient) CreateClusterConfigMap(ctx context.Context, clusterName 
 	return nil
 }
 
-func (bc *bundleClient) CreateBundle(ctx context.Context, bundle *api.PackageBundle) error {
+func (bc *managerClient) CreateBundle(ctx context.Context, bundle *api.PackageBundle) error {
 	err := bc.Client.Create(ctx, bundle)
 	if err != nil {
 		return fmt.Errorf("creating new package bundle: %s", err)
@@ -193,10 +193,10 @@ func (bc *bundleClient) CreateBundle(ctx context.Context, bundle *api.PackageBun
 	return nil
 }
 
-func (bc *bundleClient) SaveStatus(ctx context.Context, object client.Object) error {
+func (bc *managerClient) SaveStatus(ctx context.Context, object client.Object) error {
 	return bc.Client.Status().Update(ctx, object, &client.UpdateOptions{})
 }
 
-func (bc *bundleClient) Save(ctx context.Context, object client.Object) error {
+func (bc *managerClient) Save(ctx context.Context, object client.Object) error {
 	return bc.Client.Update(ctx, object, &client.UpdateOptions{})
 }

--- a/pkg/bundle/client_test.go
+++ b/pkg/bundle/client_test.go
@@ -77,7 +77,7 @@ func TestNewPackageBundleClient(t *testing.T) {
 		t.Parallel()
 
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 
 		assert.NotNil(t, bundleClient)
 	})
@@ -91,7 +91,7 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 
 	t.Run("golden path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		testBundle := givenBundle()
 
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
@@ -108,7 +108,7 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 	t.Run("no active bundle", func(t *testing.T) {
 		pbc := givenPackageBundleController()
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		pbc.Spec.ActiveBundle = ""
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
 
@@ -120,7 +120,7 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 
 	t.Run("error path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("oops"))
 
 		_, err := bundleClient.GetActiveBundle(ctx, "billy")
@@ -130,7 +130,7 @@ func TestBundleClient_GetActiveBundle(t *testing.T) {
 
 	t.Run("other error path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(pbc)).SetArg(2, *pbc)
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("oops"))
 
@@ -165,7 +165,7 @@ func TestBundleClient_GetBundle(t *testing.T) {
 
 	t.Run("already exists", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.Any()).DoAndReturn(doAndReturnBundle)
 
 		actualBundle, err := bundleClient.GetBundle(ctx, "v1-21-1003")
@@ -176,7 +176,7 @@ func TestBundleClient_GetBundle(t *testing.T) {
 
 	t.Run("already exists error", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(namedBundle)).Return(fmt.Errorf("boom"))
 
 		actualBundle, err := bundleClient.GetBundle(ctx, "v1-21-1003")
@@ -187,7 +187,7 @@ func TestBundleClient_GetBundle(t *testing.T) {
 
 	t.Run("returns nil when bundle does not", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		groupResource := schema.GroupResource{
 			Group:    key.Name,
 			Resource: "Namespace",
@@ -208,7 +208,7 @@ func TestBundleClient_GetBundleList(t *testing.T) {
 
 	t.Run("golden path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		testBundleList := &api.PackageBundleList{
 			Items: []api.PackageBundle{
 				{
@@ -241,7 +241,7 @@ func TestBundleClient_GetBundleList(t *testing.T) {
 
 	t.Run("error scenario", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		actualList := &api.PackageBundleList{}
 		mockClient.EXPECT().List(ctx, actualList, &client.ListOptions{Namespace: api.PackageNamespace}).Return(fmt.Errorf("oops"))
 
@@ -259,7 +259,7 @@ func TestBundleClient_CreateBundle(t *testing.T) {
 
 	t.Run("golden path", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		actualBundle := &api.PackageBundle{}
 		mockClient.EXPECT().Create(ctx, actualBundle).Return(nil)
 
@@ -270,7 +270,7 @@ func TestBundleClient_CreateBundle(t *testing.T) {
 
 	t.Run("error scenario", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		actualBundle := &api.PackageBundle{}
 		mockClient.EXPECT().Create(ctx, actualBundle).Return(fmt.Errorf("oops"))
 
@@ -292,7 +292,7 @@ func TestBundleClient_CreateClusterNamespace(t *testing.T) {
 
 	t.Run("already exists", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(ns)).Return(nil)
 
 		err := bundleClient.CreateClusterNamespace(ctx, "bobby")
@@ -302,7 +302,7 @@ func TestBundleClient_CreateClusterNamespace(t *testing.T) {
 
 	t.Run("get error", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(ns)).Return(fmt.Errorf("boom"))
 
 		err := bundleClient.CreateClusterNamespace(ctx, "bobby")
@@ -312,7 +312,7 @@ func TestBundleClient_CreateClusterNamespace(t *testing.T) {
 
 	t.Run("create namespace", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		groupResource := schema.GroupResource{
 			Group:    key.Name,
 			Resource: "Namespace",
@@ -328,7 +328,7 @@ func TestBundleClient_CreateClusterNamespace(t *testing.T) {
 
 	t.Run("create namespace error", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		groupResource := schema.GroupResource{
 			Group:    key.Name,
 			Resource: "Namespace",
@@ -366,7 +366,7 @@ func TestBundleClient_CreateClusterConfigMap(t *testing.T) {
 
 	t.Run("already exists", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(nil)
 
 		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
@@ -376,7 +376,7 @@ func TestBundleClient_CreateClusterConfigMap(t *testing.T) {
 
 	t.Run("get error", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		mockClient.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(cm)).Return(fmt.Errorf("boom"))
 
 		err := bundleClient.CreateClusterConfigMap(ctx, "bobby")
@@ -386,7 +386,7 @@ func TestBundleClient_CreateClusterConfigMap(t *testing.T) {
 
 	t.Run("create configmap", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		groupResource := schema.GroupResource{
 			Group:    key.Name,
 			Resource: "Namespace",
@@ -402,7 +402,7 @@ func TestBundleClient_CreateClusterConfigMap(t *testing.T) {
 
 	t.Run("create configmap error", func(t *testing.T) {
 		mockClient := givenMockClient(t)
-		bundleClient := NewPackageBundleClient(mockClient)
+		bundleClient := NewManagerClient(mockClient)
 		groupResource := schema.GroupResource{
 			Group:    key.Name,
 			Resource: "Namespace",

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -45,7 +45,7 @@ func InitPackageValidator(mgr ctrl.Manager) error {
 		Register("/validate-packages-eks-amazonaws-com-v1alpha1-package",
 			&webhook.Admission{Handler: &packageValidator{
 				Client:       mgr.GetClient(),
-				BundleClient: bundle.NewPackageBundleClient(mgr.GetClient()),
+				BundleClient: bundle.NewManagerClient(mgr.GetClient()),
 			}})
 	return nil
 }

--- a/pkg/webhook/packagebundle_webhook.go
+++ b/pkg/webhook/packagebundle_webhook.go
@@ -49,7 +49,7 @@ func NewPackageBundleValidator(mgr ctrl.Manager) packageBundleValidator {
 	client := mgr.GetClient()
 	return packageBundleValidator{
 		Client:       client,
-		BundleClient: bundle.NewPackageBundleClient(client),
+		BundleClient: bundle.NewManagerClient(client),
 		log:          mgr.GetLogger().WithName("webhook"),
 	}
 }


### PR DESCRIPTION
This is a simple rename of bundleClient to managerClient. This was talked about a while back that our two main clients would be the TargetClusterClient and ManagerClient depending on who you needed to talk to.
