### PR TITLE
Add 1-25 Dev Bundle Support

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-25.yaml
+++ b/generatebundlefile/data/bundles_dev/1-25.yaml
@@ -37,14 +37,14 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 9.21.0-1.24-latest
+            - name: 9.21.0-1.25-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-24-1-latest
+            - name: 0.6.1-eks-1-25-1-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
Removes duplicate autoscaler entry in 1-24 as well.


*Issue #, if available:*
Prep for 1.25 testing

*Description of changes:*
Adds support for 1.25 packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->