### PR TITLE
Allowing tags to contain latest in the middle and still work

### DIFF
--- a/generatebundlefile/bundle_test.go
+++ b/generatebundlefile/bundle_test.go
@@ -138,6 +138,31 @@ func TestNewPackageFromInput(t *testing.T) {
 				},
 			},
 		},
+		{
+			testname: "Test '-latest' in the middle of tag",
+			testproject: Project{
+				Name:       "hello-eks-anywhere",
+				Repository: "hello-eks-anywhere",
+				Registry:   "public.ecr.aws/eks-anywhere",
+				Versions: []Tag{
+					{Name: "test-latest-helm"},
+				},
+			},
+			wantErr: false,
+			wantBundle: &api.BundlePackage{
+				Name: "hello-eks-anywhere",
+				Source: api.BundlePackageSource{
+					Repository: "hello-eks-anywhere",
+					Registry:   "public.ecr.aws/eks-anywhere",
+					Versions: []api.SourceVersion{
+						{
+							Name:   "test-latest-helm",
+							Digest: testShaBundle,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.testname, func(tt *testing.T) {

--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -73,7 +73,7 @@ func (c *ecrClient) Describe(describeInput *ecr.DescribeImagesInput) ([]ecrtypes
 func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error) {
 	sourceVersion := []api.SourceVersion{}
 	for _, tag := range project.Versions {
-		if !strings.Contains(tag.Name, "latest") {
+		if !strings.HasSuffix(tag.Name, "latest") {
 			var imagelookup []ecrtypes.ImageIdentifier
 			imagelookup = append(imagelookup, ecrtypes.ImageIdentifier{ImageTag: &tag.Name})
 			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{

--- a/generatebundlefile/ecr_public.go
+++ b/generatebundlefile/ecr_public.go
@@ -63,7 +63,7 @@ func (c *ecrPublicClient) DescribePublic(describeInput *ecrpublic.DescribeImages
 func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVersion, error) {
 	sourceVersion := []api.SourceVersion{}
 	for _, tag := range project.Versions {
-		if !strings.Contains(tag.Name, "latest") {
+		if !strings.HasSuffix(tag.Name, "latest") {
 			var imagelookup []ecrpublictypes.ImageIdentifier
 			imagelookup = append(imagelookup, ecrpublictypes.ImageIdentifier{ImageTag: &tag.Name})
 			ImageDetails, err := c.DescribePublic(&ecrpublic.DescribeImagesInput{


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

The tag 

`9.21.0-1.21-56810429df35d3ec6ddd5b83ce409f1f33d76c1b-latest-helm`

Was breaking the logic since it contained "latest", but didn't end in latest. Fixed the statement, and added a test to check for tags like this going forward.