### PR TITLE
Reduce path for controller-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./api/v1alpha1" output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."


### PR DESCRIPTION
The generatebundle command causes controller-gen to generate the file `config/crd/bases/_.yaml` since the generate bundle uses  kubebuilder style structs. This stops the generation of that useless file.
