### PR TITLE
Removes inaccurate comment.

### DIFF
--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -20,9 +20,6 @@ type RegistryPuller struct {
 var _ Puller = (*RegistryPuller)(nil)
 
 // NewRegistryPuller creates and initializes a RegistryPuller.
-//
-// It assumes AWS ECR, and uses a password that exists in the ECR_PASSWORD
-// environment variable.
 func NewRegistryPuller(logger logr.Logger) *RegistryPuller {
 	return &RegistryPuller{
 		log: logger,


### PR DESCRIPTION
This used to be true, but at some point the RegistryPuller became a general purpose registry puller.
