### PR TITLE
Rework SetURI into ParseArtifactFromURI

### DIFF
--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -30,8 +30,7 @@ func NewRegistryPuller(logger logr.Logger) *RegistryPuller {
 }
 
 func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
-	var art registry.Artifact
-	err := art.SetURI(ref)
+	art, err := registry.ParseArtifactFromURI(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -55,5 +54,5 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
 		return nil, err
 	}
 
-	return registry.PullBytes(ctx, p.storageClient, art)
+	return registry.PullBytes(ctx, p.storageClient, *art)
 }

--- a/pkg/registry/artifact.go
+++ b/pkg/registry/artifact.go
@@ -23,11 +23,11 @@ func NewArtifact(registry, repository, tag, digest string) Artifact {
 	}
 }
 
-// SetURI value for artifact.
-func (art *Artifact) SetURI(uri string) error {
+// ParseArtifactFromURI parses the URI into a new Artifact object.
+func ParseArtifactFromURI(uri string) (*Artifact, error) {
 	elements := strings.SplitN(uri, "/", 2)
 	if len(elements) != 2 {
-		return fmt.Errorf("registry not found")
+		return nil, fmt.Errorf("registry not found")
 	}
 	registry := elements[0]
 	rol := elements[1]
@@ -38,22 +38,23 @@ func (art *Artifact) SetURI(uri string) error {
 	if len(elements) != 2 {
 		elements = strings.SplitN(rol, ":", 2)
 		if len(elements) != 2 {
-			return fmt.Errorf("tag or digest not found")
+			return nil, fmt.Errorf("tag or digest not found")
 		}
 		tag = elements[1]
 	} else {
 		digest = elements[1]
 	}
 	repository := elements[0]
-	art.Registry = registry
-	art.Repository = repository
-	art.Tag = tag
-	art.Digest = digest
-	return nil
+	return &Artifact{
+		Registry:   registry,
+		Repository: repository,
+		Tag:        tag,
+		Digest:     digest,
+	}, nil
 }
 
 // Version returns tag or digest.
-func (art *Artifact) Version() string {
+func (art Artifact) Version() string {
 	if art.Digest != "" {
 		return "@" + art.Digest
 	}
@@ -61,7 +62,7 @@ func (art *Artifact) Version() string {
 }
 
 // VersionedImage returns full URI for image.
-func (art *Artifact) VersionedImage() string {
+func (art Artifact) VersionedImage() string {
 	version := art.Version()
 	return art.Registry + "/" + art.Repository + version
 }

--- a/pkg/registry/artifact_test.go
+++ b/pkg/registry/artifact_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aws/eks-anywhere-packages/pkg/registry"
 )
@@ -18,4 +19,14 @@ func TestArtifact_VersionDigest(t *testing.T) {
 	artifact := registry.NewArtifact("localhost:8443", "owner/repo", "", "sha256:0db6a")
 	assert.Equal(t, "@sha256:0db6a", artifact.Version())
 	assert.Equal(t, "localhost:8443/owner/repo@sha256:0db6a", artifact.VersionedImage())
+}
+
+func TestParseArtifactFromURI_VersionedImageMatchesURI(t *testing.T) {
+	artifact, err := registry.ParseArtifactFromURI("localhost:8443/owner/repo@sha256:0db6a")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:8443/owner/repo@sha256:0db6a", artifact.VersionedImage())
+
+	artifact, err = registry.ParseArtifactFromURI("localhost:8443/owner/repo:sometag")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:8443/owner/repo:sometag", artifact.VersionedImage())
 }


### PR DESCRIPTION
By moving SetURI to ParseArtifactFromURI we re-use commonly used terminology and semantics around the term "Parse", which implies that the process can fail (returning nil and an error), as opposed to the SetURI, which left it up to the caller to initialize the Artifact, and abort if the SetURI call failed.

Also adds some tests for the parsing algorithm, and changes methods to remove the pointer receiver which better communicates that the methods are read-only.
