### PR TITLE
Lift configfile

### DIFF
--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -16,8 +16,7 @@ var certFile = filepath.Join(configPath, "ca.crt")
 // RegistryPuller handles pulling OCI artifacts from an OCI registry
 // (i.e. bundles)
 type RegistryPuller struct {
-	storageClient registry.StorageClient
-	log           logr.Logger
+	log logr.Logger
 }
 
 var _ Puller = (*RegistryPuller)(nil)
@@ -48,11 +47,11 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
 	}
 
 	sc := registry.NewStorageContext(art.Registry, credentialStore, certificates, false)
-	p.storageClient = registry.NewOCIRegistry(sc)
-	err = p.storageClient.Init()
+	client := registry.NewOCIRegistry(sc)
+	err = client.Init()
 	if err != nil {
 		return nil, err
 	}
 
-	return registry.PullBytes(ctx, p.storageClient, *art)
+	return registry.PullBytes(ctx, client, *art)
 }

--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/docker/cli/cli/config"
 	"github.com/go-logr/logr"
 
 	"github.com/aws/eks-anywhere-packages/pkg/registry"
@@ -39,14 +40,13 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
 		p.log.Error(err, "problem getting certificate file", "filename", certFile)
 	}
 
-	credentialStore := registry.NewCredentialStore()
-	credentialStore.SetDirectory(configPath)
-	err = credentialStore.Init()
+	configFile, err := config.Load("")
 	if err != nil {
 		return nil, err
 	}
+	store := registry.NewDockerCredentialStore(configFile)
 
-	sc := registry.NewStorageContext(art.Registry, credentialStore, certificates, false)
+	sc := registry.NewStorageContext(art.Registry, store, certificates, false)
 	client := registry.NewOCIRegistry(sc)
 	err = client.Init()
 	if err != nil {

--- a/pkg/registry/credentials_test.go
+++ b/pkg/registry/credentials_test.go
@@ -3,53 +3,54 @@ package registry_test
 import (
 	"testing"
 
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"github.com/aws/eks-anywhere-packages/pkg/registry"
 )
 
-func TestCredentialStore_Init(t *testing.T) {
-	credentialStore := registry.NewCredentialStore()
-	credentialStore.SetDirectory("testdata")
-
-	err := credentialStore.Init()
-	assert.NoError(t, err)
+func TestDockerCredentialStore(t *testing.T) {
+	configFile := newConfigFile(t, "testdata")
+	credentialStore := registry.NewDockerCredentialStore(configFile)
 
 	result, err := credentialStore.Credential("localhost")
-	assert.NoError(t, err)
-	assert.Equal(t, "user", result.Username)
-	assert.Equal(t, "pass", result.Password)
-	assert.Equal(t, "", result.AccessToken)
-	assert.Equal(t, "", result.RefreshToken)
+	require.NoError(t, err)
+	assertAuthEqual(t, auth.Credential{Username: "user", Password: "pass"}, result)
 
 	result, err = credentialStore.Credential("harbor.eksa.demo:30003")
-	assert.NoError(t, err)
-	assert.Equal(t, "captain", result.Username)
-	assert.Equal(t, "haddock", result.Password)
-	assert.Equal(t, "", result.AccessToken)
-	assert.Equal(t, "", result.RefreshToken)
+	require.NoError(t, err)
+	assertAuthEqual(t, auth.Credential{Username: "captain", Password: "haddock"}, result)
 
 	result, err = credentialStore.Credential("bogus")
-	assert.NoError(t, err)
-	assert.Equal(t, "", result.Username)
-	assert.Equal(t, "", result.Password)
-	assert.Equal(t, "", result.AccessToken)
-	assert.Equal(t, "", result.RefreshToken)
+	require.NoError(t, err)
+	assertAuthEqual(t, auth.EmptyCredential, result)
 
 	result, err = credentialStore.Credential("5551212.dkr.ecr.us-west-2.amazonaws.com")
 	// This is a generic error, so using errors.Is won't work, and this is as
 	// much of the string as we can reliably match against in a cross-platform
 	// fashion. Until they change it, then everything will break.
-	assert.ErrorContains(t, err, "error getting credentials - err")
-	assert.Equal(t, "", result.Username)
-	assert.Equal(t, "", result.Password)
-	assert.Equal(t, "", result.AccessToken)
-	assert.Equal(t, "", result.RefreshToken)
+	require.ErrorContains(t, err, "error getting credentials - err")
+	assertAuthEqual(t, auth.EmptyCredential, result)
 }
 
 func TestCredentialStore_InitEmpty(t *testing.T) {
-	credentialStore := registry.NewCredentialStore()
-	credentialStore.SetDirectory("testdata/empty")
-	err := credentialStore.Init()
-	assert.NoError(t, err)
+	registry.NewDockerCredentialStore(newConfigFile(t, "testdata/empty"))
+}
+
+func newConfigFile(t *testing.T, dir string) *configfile.ConfigFile {
+	t.Helper()
+	configFile, err := config.Load(dir)
+	require.NoError(t, err)
+	return configFile
+}
+
+func assertAuthEqual(t *testing.T, expected, got auth.Credential) {
+	t.Helper()
+	assert.Equal(t, expected.Username, got.Username)
+	assert.Equal(t, expected.Password, got.Password)
+	assert.Equal(t, expected.AccessToken, got.AccessToken)
+	assert.Equal(t, expected.RefreshToken, got.RefreshToken)
 }

--- a/pkg/registry/storage.go
+++ b/pkg/registry/storage.go
@@ -12,13 +12,13 @@ import (
 type StorageContext struct {
 	host            string
 	project         string
-	credentialStore *CredentialStore
+	credentialStore *DockerCredentialStore
 	certificates    *x509.CertPool
 	insecure        bool
 }
 
 // NewStorageContext create registry context.
-func NewStorageContext(host string, credentialStore *CredentialStore, certificates *x509.CertPool, insecure bool) StorageContext {
+func NewStorageContext(host string, credentialStore *DockerCredentialStore, certificates *x509.CertPool, insecure bool) StorageContext {
 	return StorageContext{
 		host:            host,
 		credentialStore: credentialStore,


### PR DESCRIPTION
Two smallish changes:

    Lift configfile.ConfigFile out of CredentialsStore
    
    Rather than assuming that users of CredentialStore will know to call Init
    after instantiation, the CredentialStore's dependency on a Docker *ConfigFile
    is made explicit by requiring it to be passed to the constructor. Now we need
    never worry that a user will forget to call Init, and it removes the awkward
    pattern of New-then-Init.
 

and:

    Don't store the RegistryPuller's StorageClient
    
    There's no point in storing it, as it's never reused.