### PR TITLE
Add tag option for package controller dev promote pipeline

### DIFF
--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -106,7 +106,7 @@ func ImageTagFilter(details []ImageDetailsBothECR, version string) []ImageDetail
 	var filteredDetails []ImageDetailsBothECR
 	for _, detail := range details {
 		for _, tag := range detail.ImageTags {
-			if strings.Contains(tag, version) {
+			if strings.HasPrefix(tag, version) {
 				filteredDetails = append(filteredDetails, detail)
 			}
 		}

--- a/generatebundlefile/hack/promote.sh
+++ b/generatebundlefile/hack/promote.sh
@@ -33,11 +33,13 @@ aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 h
 
 cd "${BASE_DIRECTORY}/generatebundlefile"
 
-if [[ -z "${PROMOTE_FILE}" ]]; then
-    ./bin/generatebundlefile  \
-        --promote ${HELM_REPO}
-else
-    echo $PROMOTE_FILE
+if [[ -n "${PROMOTE_FILE}" ]]; then
     ./bin/generatebundlefile  \
         --promote ${HELM_REPO} --input ${PROMOTE_FILE}
+elif [[ -n "${PROMOTE_TAG}" ]]; then
+    ./bin/generatebundlefile  \
+        --promote ${HELM_REPO} --tag ${PROMOTE_TAG}
+else
+    ./bin/generatebundlefile  \
+        --promote ${HELM_REPO}
 fi

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -91,9 +91,13 @@ func cmdPromote(opts *Options) error {
 
 	promoteCharts := make(map[string][]string)
 
+	if opts.tag != "" {
+		opts.tag = "latest"
+	}
+
 	// If we are promoting an individual chart with the --promote flag like we do for most charts.
 	if opts.promote != "" {
-		promoteCharts[opts.promote] = append(promoteCharts[opts.promote], "latest")
+		promoteCharts[opts.promote] = append(promoteCharts[opts.promote], opts.tag)
 	}
 
 	// If we are promoting multiple chart with the --input file flag we override the struct with files inputs from the file.

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -91,7 +91,7 @@ func cmdPromote(opts *Options) error {
 
 	promoteCharts := make(map[string][]string)
 
-	if opts.tag != "" {
+	if opts.tag == "" {
 		opts.tag = "latest"
 	}
 

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -142,9 +142,14 @@ func cmdPromote(opts *Options) error {
 	if dockerAuth.Authfile == "" {
 		return fmt.Errorf("no authfile generated")
 	}
+	clients.helmDriver, err = NewHelm(BundleLog, dockerAuth.Authfile)
+	if err != nil {
+		BundleLog.Error(err, "Unable to create Helm driver")
+		os.Exit(1)
+	}
 	for repoName, versions := range promoteCharts {
 		for _, version := range versions {
-			err = clients.PromoteHelmChart(repoName, dockerAuth.Authfile, version, false)
+			err = clients.PromoteHelmChart(repoName, dockerAuth.Authfile, version, opts.copyImages)
 			if err != nil {
 				return fmt.Errorf("promoting Helm chart: %w", err)
 			}
@@ -433,6 +438,11 @@ func cmdGenerate(opts *Options) error {
 				BundleLog.Error(err, "Unable create AuthFile")
 				os.Exit(1)
 			}
+			clients.helmDriver, err = NewHelm(BundleLog, dockerAuth.Authfile)
+			if err != nil {
+				BundleLog.Error(err, "Unable to create Helm driver")
+				os.Exit(1)
+			}
 			for _, charts := range addOnBundleSpec.Packages {
 				for _, versions := range charts.Source.Versions {
 					err = clients.PromoteHelmChart(charts.Source.Repository, dockerAuth.Authfile, versions.Name, false)
@@ -481,6 +491,11 @@ func cmdGenerate(opts *Options) error {
 			dockerAuth, err = NewAuthFile(dockerReleaseStruct)
 			if err != nil {
 				BundleLog.Error(err, "Unable create AuthFile")
+				os.Exit(1)
+			}
+			clients.helmDriver, err = NewHelm(BundleLog, dockerAuth.Authfile)
+			if err != nil {
+				BundleLog.Error(err, "Unable to create Helm driver")
 				os.Exit(1)
 			}
 			for _, charts := range addOnBundleSpec.Packages {

--- a/generatebundlefile/options.go
+++ b/generatebundlefile/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	generateSample bool
 	promote        string
 	tag            string
+	copyImages     bool
 	key            string
 	publicProfile  string
 	privateProfile string
@@ -79,6 +80,7 @@ func NewOptions() *Options {
 	fs.StringVar(&o.outputFolder, "output", "output", "The path where to write the output bundle files")
 	fs.StringVar(&o.promote, "promote", "", "The Helm chart private ECR OCI uri to pull and promote")
 	fs.StringVar(&o.tag, "tag", "", "The tag of the helm chart used with promote flag")
+	fs.BoolVar(&o.copyImages, "copy-images", false, "Whether to copy images during a helm promotion, the default is to Not copy.")
 	fs.StringVar(&o.key, "key", "k", "The key to sign with")
 	fs.StringVar(&o.publicProfile, "public-profile", "", "The AWS Public Profile to release the prod bundle into")
 	fs.StringVar(&o.privateProfile, "private-profile", "", "The AWS Private Profile to release all packages into")

--- a/generatebundlefile/options.go
+++ b/generatebundlefile/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	outputFolder   string
 	generateSample bool
 	promote        string
+	tag            string
 	key            string
 	publicProfile  string
 	privateProfile string
@@ -77,6 +78,7 @@ func NewOptions() *Options {
 	fs.StringVar(&o.inputFile, "input", "", "The path where the input bundle generation file lives")
 	fs.StringVar(&o.outputFolder, "output", "output", "The path where to write the output bundle files")
 	fs.StringVar(&o.promote, "promote", "", "The Helm chart private ECR OCI uri to pull and promote")
+	fs.StringVar(&o.tag, "tag", "", "The tag of the helm chart used with promote flag")
 	fs.StringVar(&o.key, "key", "k", "The key to sign with")
 	fs.StringVar(&o.publicProfile, "public-profile", "", "The AWS Public Profile to release the prod bundle into")
 	fs.StringVar(&o.privateProfile, "private-profile", "", "The AWS Private Profile to release all packages into")


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

Why this needs to exist is because there is two sets of dev build being produced, one by the EKS-A pipeline using Git Tag, and another by the new dev pipeline. The current logic just defaults to latest, so adding a tag option allows us to always promote our dev builds for e2e purposes to always use dev chart.
