### PR TITLE
Credentials are not for Docker only

### DIFF
--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -45,7 +45,7 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	store := registry.NewDockerCredentialStore(configFile)
+	store := registry.NewCredentialStore(configFile)
 
 	sc := registry.NewStorageContext(art.Registry, store, certificates, false)
 	remoteRegistry, err := remote.NewRegistry(art.Registry)

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -52,7 +52,7 @@ func TestOCIRegistryClient_GetStorage(t *testing.T) {
 func newStorageContext(t *testing.T, dir string) registry.StorageContext {
 	configFile, err := config.Load(dir)
 	require.NoError(t, err)
-	store := registry.NewDockerCredentialStore(configFile)
+	store := registry.NewCredentialStore(configFile)
 	return registry.NewStorageContext("localhost", store, certificates, false)
 }
 

--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -6,23 +6,23 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
-// DockerCredentialStore for Docker registry credentials, like ~/.docker/config.json.
-type DockerCredentialStore struct {
+// CredentialStore for registry credentials, like ~/.docker/config.json.
+type CredentialStore struct {
 	configFile *configfile.ConfigFile
 }
 
-// NewDockerCredentialStore creates a DockerCredentialStore.
-func NewDockerCredentialStore(configFile *configfile.ConfigFile) *DockerCredentialStore {
+// NewCredentialStore creates a CredentialStore.
+func NewCredentialStore(configFile *configfile.ConfigFile) *CredentialStore {
 	if !configFile.ContainsAuth() {
 		configFile.CredentialsStore = credentials.DetectDefaultStore(configFile.CredentialsStore)
 	}
-	return &DockerCredentialStore{
+	return &CredentialStore{
 		configFile: configFile,
 	}
 }
 
 // Credential get an authentication credential for a given registry.
-func (cs *DockerCredentialStore) Credential(registry string) (auth.Credential, error) {
+func (cs *CredentialStore) Credential(registry string) (auth.Credential, error) {
 	authConf, err := cs.configFile.GetCredentialsStore(registry).Get(registry)
 	if err != nil {
 		return auth.EmptyCredential, err

--- a/pkg/registry/credentials_test.go
+++ b/pkg/registry/credentials_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aws/eks-anywhere-packages/pkg/registry"
 )
 
-func TestDockerCredentialStore(t *testing.T) {
+func TestCredentialStore(t *testing.T) {
 	configFile := newConfigFile(t, "testdata")
-	credentialStore := registry.NewDockerCredentialStore(configFile)
+	credentialStore := registry.NewCredentialStore(configFile)
 
 	result, err := credentialStore.Credential("localhost")
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestDockerCredentialStore(t *testing.T) {
 }
 
 func TestCredentialStore_InitEmpty(t *testing.T) {
-	registry.NewDockerCredentialStore(newConfigFile(t, "testdata/empty"))
+	registry.NewCredentialStore(newConfigFile(t, "testdata/empty"))
 }
 
 func newConfigFile(t *testing.T, dir string) *configfile.ConfigFile {

--- a/pkg/registry/storage.go
+++ b/pkg/registry/storage.go
@@ -12,13 +12,13 @@ import (
 type StorageContext struct {
 	host            string
 	project         string
-	credentialStore *DockerCredentialStore
+	credentialStore *CredentialStore
 	certificates    *x509.CertPool
 	insecure        bool
 }
 
 // NewStorageContext create registry context.
-func NewStorageContext(host string, credentialStore *DockerCredentialStore, certificates *x509.CertPool, insecure bool) StorageContext {
+func NewStorageContext(host string, credentialStore *CredentialStore, certificates *x509.CertPool, insecure bool) StorageContext {
 	return StorageContext{
 		host:            host,
 		credentialStore: credentialStore,


### PR DESCRIPTION
This credential store was not meant only for docker registries and the name exposes implementation. This implementation will likely change and that would be confusing.