### PR TITLE
Support cluster specific ca.crt and insecure

### DIFF
--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -69,11 +69,6 @@ spec:
               value: {{ .Values.clusterName | quote}}
             - name: HELM_CONFIG_HOME
               value: {{ .Values.helmConfigHome | quote}}
-            - name: REGISTRY_INSECURE
-              valueFrom:
-                secretKeyRef:
-                  name: registry-mirror-secret
-                  key: INSECURE
           ports:
             - name: webhook-server
               containerPort: 9443

--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"oras.land/oras-go/v2/registry/remote"
 

--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -2,21 +2,13 @@ package artifacts
 
 import (
 	"context"
-	"path/filepath"
-
-	"github.com/docker/cli/cli/config"
 	"github.com/go-logr/logr"
 	"oras.land/oras-go/v2/registry/remote"
 
 	"github.com/aws/eks-anywhere-packages/pkg/registry"
 )
 
-const configPath = "/tmp/config/registry"
-
-var certFile = filepath.Join(configPath, "ca.crt")
-
 // RegistryPuller handles pulling OCI artifacts from an OCI registry
-// (i.e. bundles)
 type RegistryPuller struct {
 	log logr.Logger
 }
@@ -36,12 +28,12 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string) ([]byte, error) {
 		return nil, err
 	}
 
-	certificates, err := registry.GetCertificates(certFile)
+	certificates, err := registry.GetManagementClusterCertificate()
 	if err != nil {
-		p.log.Info("problem getting certificate file", "filename", certFile, "error", err.Error())
+		p.log.Info("problem getting certificate file", "error", err.Error())
 	}
 
-	configFile, err := config.Load("")
+	configFile, err := registry.CredentialsConfigLoad()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/certificates.go
+++ b/pkg/registry/certificates.go
@@ -4,8 +4,43 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 )
+
+const (
+	registryConfigPath = "/tmp/config/registry"
+	certFile           = "ca.crt"
+	insecureFile       = "insecure"
+)
+
+func GetManagementClusterCertificate() (certificates *x509.CertPool, err error) {
+	return GetClusterCertificate(os.Getenv("CLUSTER_NAME"))
+}
+
+func GetRegistryInsecure(clusterName string) bool {
+	caFile := path.Join(registryConfigPath, clusterName, insecureFile)
+	if _, err := os.Stat(caFile); err != nil {
+		return false
+	}
+	return true
+}
+
+func GetClusterCertificateFileName(clusterName string) string {
+	caFile := path.Join(registryConfigPath, clusterName, certFile)
+	if _, err := os.Stat(caFile); err != nil {
+		return ""
+	}
+	return caFile
+}
+
+func GetClusterCertificate(clusterName string) (certificates *x509.CertPool, err error) {
+	caFile := GetClusterCertificateFileName(clusterName)
+	if caFile == "" {
+		return nil, nil
+	}
+	return GetCertificates(caFile)
+}
 
 // GetCertificates get X509 certificates.
 func GetCertificates(certFile string) (certificates *x509.CertPool, err error) {

--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -9,6 +10,11 @@ import (
 // DockerCredentialStore for Docker registry credentials, like ~/.docker/config.json.
 type DockerCredentialStore struct {
 	configFile *configfile.ConfigFile
+}
+
+// CredentialsConfigLoad load credentials from directory.
+func CredentialsConfigLoad() (*configfile.ConfigFile, error) {
+	return config.Load(registryConfigPath)
 }
 
 // NewDockerCredentialStore creates a DockerCredentialStore.


### PR DESCRIPTION
Add support for cluster specific configuration:
* cluster specific ca.crt file
* cluster specific insecure file
* cluster specific credentials config.json file

The existence of the insecure file indicates insecure mode.
