### PR TITLE
Adding priority to tag substring promote cmd

### DIFF
--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -143,7 +143,7 @@ func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error
 }
 
 // tagFromSha Looks up the Tag of an ECR artifact from a sha
-func (c *ecrClient) tagFromSha(repository, sha string) (string, error) {
+func (c *ecrClient) tagFromSha(repository, sha, substringTag string) (string, error) {
 	if repository == "" || sha == "" {
 		return "", fmt.Errorf("Emtpy repository, or sha passed to the function")
 	}
@@ -164,6 +164,11 @@ func (c *ecrClient) tagFromSha(repository, sha string) (string, error) {
 		// We can return the first tag for an image, if it has multiple tags
 		if len(detail.ImageTags) > 0 {
 			detail.ImageTags = removeStringSlice(detail.ImageTags, "latest")
+			for j, tag := range detail.ImageTags {
+				if strings.HasSuffix(tag, substringTag) {
+					return detail.ImageTags[j], nil
+				}
+			}
 			return detail.ImageTags[0], nil
 		}
 	}

--- a/generatebundlefile/ecr_test.go
+++ b/generatebundlefile/ecr_test.go
@@ -192,31 +192,43 @@ func TestShaExistsInRepository(t *testing.T) {
 func TestTagFromSha(t *testing.T) {
 	client := newMockRegistryClient(nil)
 	tests := []struct {
-		client         *mockRegistryClient
-		testName       string
-		testRepository string
-		testDigest     string
-		checkVersion   string
-		wantErr        bool
+		client           *mockRegistryClient
+		testName         string
+		testRepository   string
+		testDigest       string
+		testSubstringTag string
+		checkVersion     string
+		wantErr          bool
 	}{
 		{
-			testName:       "Test empty Repository",
-			testRepository: "",
-			testDigest:     "sha256:0526725a65691944e831add6b247b25a93b8eeb1033dddadeaa089e95b021172",
-			wantErr:        true,
+			testName:         "Test empty Repository",
+			testRepository:   "",
+			testDigest:       "sha256:0526725a65691944e831add6b247b25a93b8eeb1033dddadeaa089e95b021172",
+			testSubstringTag: "",
+			wantErr:          true,
 		},
 		{
-			testName:       "Test empty Version",
-			testRepository: "hello-eks-anywhere",
-			testDigest:     "",
-			wantErr:        true,
+			testName:         "Test empty Version",
+			testRepository:   "hello-eks-anywhere",
+			testDigest:       "",
+			testSubstringTag: "",
+			wantErr:          true,
 		},
 		{
-			testName:       "Test valid Repository and Version",
-			testRepository: "hello-eks-anywhere",
-			testDigest:     "sha256:0526725a65691944e831add6b247b25a93b8eeb1033dddadeaa089e95b021172",
-			checkVersion:   "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660",
-			wantErr:        false,
+			testName:         "Test valid Repository and Version",
+			testRepository:   "hello-eks-anywhere",
+			testDigest:       "sha256:0526725a65691944e831add6b247b25a93b8eeb1033dddadeaa089e95b021172",
+			testSubstringTag: "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660",
+			checkVersion:     "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660",
+			wantErr:          false,
+		},
+		{
+			testName:         "Test valid Repository and substring Version",
+			testRepository:   "hello-eks-anywhere",
+			testDigest:       "sha256:0526725a65691944e831add6b247b25a93b8eeb1033dddadeaa089e95b021172",
+			testSubstringTag: "v0.1.1",
+			checkVersion:     "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660",
+			wantErr:          false,
 		},
 	}
 	//images.Digest, err = ecrClient.tagFromSha(images.Repository, images.Digest)
@@ -227,7 +239,7 @@ func TestTagFromSha(t *testing.T) {
 					registryClient: client,
 				},
 			}
-			got, err := clients.ecrClient.tagFromSha(tc.testRepository, tc.testDigest)
+			got, err := clients.ecrClient.tagFromSha(tc.testRepository, tc.testDigest, tc.checkVersion)
 			if (err != nil) != tc.wantErr {
 				tt.Fatalf("tagFromSha() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -184,7 +184,7 @@ func (c *SDKClients) PromoteHelmChart(repository, authFile, tag string, copyImag
 				BundleLog.Info("Image Digest, and Tag dont exist in destination location...... copy to", "Location", fmt.Sprintf("%s/%s sha:%s", images.Repository, images.Tag, images.Digest))
 				// We have cases with tag mismatch where the SHA is accurate, but the tag in the destination repo is not synced, this will sync it.
 				if images.Tag == "" {
-					images.Tag, err = c.ecrClient.tagFromSha(images.Repository, images.Digest)
+					images.Tag, err = c.ecrClient.tagFromSha(images.Repository, images.Digest, tag)
 				}
 				if err != nil {
 					BundleLog.Error(err, "Unable to find Tag from Digest")


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

When promoting images, some images are doubletagged, and this will help ensure it preserves the correct tag during the copy command that was specified by the promote command.

ecr-token-refresher has tags `0.0.0-abc` and `release-0.14`.

If we use promote with substring match for `0.0.0` we want to return that tag back to the copy command, and not the `release-0.14` one since both get returned by the sdk query.