### PR TITLE
Allow metrics-server To Auto Update in Dev Bundle

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-21.yaml
+++ b/generatebundlefile/data/bundles_dev/1-21.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-21-19-latest
+            - name: 0.6.2-eks-1-21-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-22.yaml
+++ b/generatebundlefile/data/bundles_dev/1-22.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-22-11-latest
+            - name: 0.6.2-eks-1-22-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-23.yaml
+++ b/generatebundlefile/data/bundles_dev/1-23.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-23-6-latest
+            - name: 0.6.2-eks-1-23-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-24.yaml
+++ b/generatebundlefile/data/bundles_dev/1-24.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-24-1-latest
+            - name: 0.6.2-eks-1-24-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-25.yaml
+++ b/generatebundlefile/data/bundles_dev/1-25.yaml
@@ -44,7 +44,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.1-eks-1-25-1-latest
+            - name: 0.6.2-eks-1-25-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
Previously, because eks-d specified a release patch number and it was included in the promo data config file, charts would stop updating as soon as eks-d published a new patch.

Also starts pulling in charts using the 0.6.2 image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->