### PR TITLE
Remove unused configmap

### DIFF
--- a/charts/eks-anywhere-packages/templates/configmap.yaml
+++ b/charts/eks-anywhere-packages/templates/configmap.yaml
@@ -23,19 +23,4 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: 6ef7a950.eks.amazonaws.com
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{.Values.nsconfigmap.name}}
-  namespace: {{ .Values.namespace }}
-  labels:
-    {{- include "eks-anywhere-packages.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-data:
-  {{ .Values.namespace }}: {{ include "eks-anywhere-packages.fullname" . }}
-  emissary-system: emissary-ingress
 {{- end }}

--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -111,9 +111,6 @@ cronjob:
   # -- ECR refresher digest
   digest: "{{ecr-token-refresher}}"
   suspend: false
-#  Additional Variables for Config Map for namespace
-nsconfigmap:
-  name: ns-secret-map
 # Secrets
 registryMirrorSecret:
   endpoint: ""


### PR DESCRIPTION
The `ns-secret-map` configMap in `eksa-packages` namespace is no longer needed as package controller is now responsible for creating that in the target namespace in form of `eksa-packages-[clusterName]` (https://github.com/aws/eks-anywhere-packages/blob/main/pkg/bundle/client.go#L162). We are no longer supporting for package installation in `eksa-packages` namespace.