### PR TITLE
Fixing typo from source AccountID function

### DIFF
--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -274,7 +274,7 @@ func (c *SDKClients) CheckDestinationECR(images Image, version string) (bool, bo
 
 func (c *SDKClients) activeAccountID() string {
 	if c.stsClientRelease != nil && c.stsClient != nil {
-		return c.stsClientRelease.AccountID
+		return c.stsClient.AccountID
 	}
 	if c.stsClientRelease != nil {
 		return c.stsClientRelease.AccountID


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

Used the wrong client in the function I created last week for cross-account releases.
