### PR TITLE
Moving to dev tag for packages image move

### DIFF
--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -8,7 +8,7 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.2.30-release-0.14-helm
+            - name: 0.0.0-latest
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere


### PR DESCRIPTION
*Description of changes:*

The function is looking for images in the Private ECR, but the chart in the Public ECR since it's mimicking the behavior of our other packages. Due to this we can't use the Core teams tags since those are only written into public, but not in Private ECR.

