### PR TITLE
Allow eksa-controller-manager to remove package bundle controllers

### DIFF
--- a/charts/eks-anywhere-packages/templates/role.yaml
+++ b/charts/eks-anywhere-packages/templates/role.yaml
@@ -45,3 +45,25 @@ rules:
   - create
   - patch
 {{- end }}
+{{- if .Values.workloadOnly }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "eks-anywhere-packages.fullname" . }}-manager-role
+  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
+  labels:
+    {{- include "eks-anywhere-packages.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - delete
+{{- end }}

--- a/charts/eks-anywhere-packages/templates/rolebinding.yaml
+++ b/charts/eks-anywhere-packages/templates/rolebinding.yaml
@@ -19,3 +19,25 @@ subjects:
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
 {{- end }}
+{{- if .Values.workloadOnly }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "eks-anywhere-packages.fullname" . }}-manager-rolebinding
+  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
+  labels:
+    {{- include "eks-anywhere-packages.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "eks-anywhere-packages.fullname" . }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: eksa-controller-manager
+    namespace: eksa-system
+{{- end }}


### PR DESCRIPTION
These permissions will allow the eksa-controller to delete package bundle controller helm installations completely, and without error.

The namespace in question is the workload clusters, e.g. eksa-packages-my-workload-cluster.

The secret in question is the registry-mirror-secret that is created for workload clusters (regardless of whether or registry mirror is in use).

Part of https://github.com/aws/eks-anywhere-packages/issues/807.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
