### PR TITLE
Copying images over for packages dev chart for e2e

### DIFF
--- a/generatebundlefile/data/promote/eks-anywhere-packages/promote.yaml
+++ b/generatebundlefile/data/promote/eks-anywhere-packages/promote.yaml
@@ -20,5 +20,5 @@ packages:
         repository: eks-anywhere-packages
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: latest
+            - name: 0.0.0-latest # We want this to only promote the dev helm charts for e2e
 

--- a/generatebundlefile/hack/promote.sh
+++ b/generatebundlefile/hack/promote.sh
@@ -34,11 +34,14 @@ aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 h
 cd "${BASE_DIRECTORY}/generatebundlefile"
 
 if [[ -n "${PROMOTE_FILE}" ]]; then
-    ./bin/generatebundlefile  \
-        --promote ${HELM_REPO} --input ${PROMOTE_FILE}
-elif [[ -n "${PROMOTE_TAG}" ]]; then
-    ./bin/generatebundlefile  \
-        --promote ${HELM_REPO} --tag ${PROMOTE_TAG} --copy-images
+    if [[ "${HELM_REPO}" == "eks-anywhere-packages" ]]; then
+        # We need to copy the images for the packages helm chart, but no other packages.
+        ./bin/generatebundlefile  \
+            --promote ${HELM_REPO} --input ${PROMOTE_FILE} --copy-images
+    else
+        ./bin/generatebundlefile  \
+            --promote ${HELM_REPO} --input ${PROMOTE_FILE}
+    fi
 else
     ./bin/generatebundlefile  \
         --promote ${HELM_REPO}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When we added a promote file for the Package controller as a package, it didn't include the `copy-images` flag which is needed for the e2e dev chart to have it's image in the public ECR. Adding it back here.
