### PR TITLE
Avoid one hour wait for pbc

### DIFF
--- a/controllers/packagebundlecontroller_controller.go
+++ b/controllers/packagebundlecontroller_controller.go
@@ -17,7 +17,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -127,8 +126,7 @@ func (r *PackageBundleControllerReconciler) Reconcile(ctx context.Context, req c
 
 	err = r.bundleManager.ProcessBundleController(ctx, pbc)
 	if err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") &&
-			!r.webhookInitialized {
+		if !r.webhookInitialized {
 			r.Log.Info("delaying reconciliation until webhook is initialized")
 			result.RequeueAfter = webhookInitializationRequeueInterval
 			return result, nil


### PR DESCRIPTION
Several errors happened during start-up and none of them matched the "connection refused", but they did result in a one hour timer for the PBC.