### PR TITLE
Add image pull secrets to migrations

### DIFF
--- a/charts/eks-anywhere-packages-migrations/templates/adopt-crds-awssecret.yaml
+++ b/charts/eks-anywhere-packages-migrations/templates/adopt-crds-awssecret.yaml
@@ -58,6 +58,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: patch-awssecret
         image: {{.Values.sourceRegistry}}{{ template "template.image" .Values.controller }}


### PR DESCRIPTION
*Description of changes:*
Add pull secret to migrations since the sourceRegistry set by the controller points to private ECR. This might change soon by passing values down to dependencies but having it available is still a good thing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
