### PR TITLE
allow eksa-controller-manager management permissions

### DIFF
--- a/charts/eks-anywhere-packages/templates/clusterrolebinding.yaml
+++ b/charts/eks-anywhere-packages/templates/clusterrolebinding.yaml
@@ -17,6 +17,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: eksa-controller-manager
+    namespace: eksa-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/eks-anywhere-packages/templates/rolebinding.yaml
+++ b/charts/eks-anywhere-packages/templates/rolebinding.yaml
@@ -19,25 +19,3 @@ subjects:
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
 {{- end }}
-{{- if .Values.workloadOnly }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "eks-anywhere-packages.fullname" . }}-manager-rolebinding
-  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
-  labels:
-    {{- include "eks-anywhere-packages.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "eks-anywhere-packages.fullname" . }}-manager-role
-subjects:
-  - kind: ServiceAccount
-    name: eksa-controller-manager
-    namespace: eksa-system
-{{- end }}


### PR DESCRIPTION
With the addition of full cluster lifecycle, the eksa-controller needs to be able to install / remove packages installations in the workload clusters it creates.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
