### PR TITLE
ns create

### DIFF
--- a/api/v1alpha1/packagebundle.go
+++ b/api/v1alpha1/packagebundle.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"strconv"
 	"strings"
@@ -212,7 +212,7 @@ func (bp *BundlePackage) GetJsonSchema(pkgVersion *SourceVersion) ([]byte, error
 		return nil, fmt.Errorf("error when uncompressing configurations %v", err)
 	}
 
-	output, err := ioutil.ReadAll(gzreader)
+	output, err := io.ReadAll(gzreader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading configurations %v", err)
 	}

--- a/controllers/package_controller.go
+++ b/controllers/package_controller.go
@@ -80,7 +80,7 @@ func RegisterPackageReconciler(mgr ctrl.Manager) (err error) {
 		return err
 	}
 
-	tcc := auth.NewTargetClusterClient(cfg, mgr.GetClient())
+	tcc := auth.NewTargetClusterClient(log, cfg, mgr.GetClient())
 	helmDriver := driver.NewHelm(log, secretAuth, tcc)
 
 	puller := artifacts.NewRegistryPuller(log)

--- a/controllers/packagebundle_controller.go
+++ b/controllers/packagebundle_controller.go
@@ -65,7 +65,7 @@ func NewPackageBundleReconciler(client client.Client, scheme *runtime.Scheme,
 func RegisterPackageBundleReconciler(mgr ctrl.Manager) error {
 	log := ctrl.Log.WithName(packageBundleName)
 	bundleClient := bundle.NewManagerClient(mgr.GetClient())
-	tcc := authenticator.NewTargetClusterClient(mgr.GetConfig(), mgr.GetClient())
+	tcc := authenticator.NewTargetClusterClient(mgr.GetLogger(), mgr.GetConfig(), mgr.GetClient())
 	puller := artifacts.NewRegistryPuller(log)
 	registryClient := bundle.NewRegistryClient(puller)
 	bundleManager := bundle.NewBundleManager(log, registryClient, bundleClient, tcc, config.GetGlobalConfig())

--- a/controllers/packagebundlecontroller_controller.go
+++ b/controllers/packagebundlecontroller_controller.go
@@ -67,7 +67,7 @@ func RegisterPackageBundleControllerReconciler(mgr ctrl.Manager) error {
 	log := ctrl.Log.WithName(packageBundleControllerName)
 
 	bundleClient := bundle.NewManagerClient(mgr.GetClient())
-	tcc := authenticator.NewTargetClusterClient(mgr.GetConfig(), mgr.GetClient())
+	tcc := authenticator.NewTargetClusterClient(log, mgr.GetConfig(), mgr.GetClient())
 	puller := artifacts.NewRegistryPuller(log)
 	registryClient := bundle.NewRegistryClient(puller)
 	bm := bundle.NewBundleManager(log, registryClient, bundleClient, tcc, config.GetGlobalConfig())

--- a/pkg/authenticator/mocks/target_cluster_client.go
+++ b/pkg/authenticator/mocks/target_cluster_client.go
@@ -39,6 +39,20 @@ func (m *MockTargetClusterClient) EXPECT() *MockTargetClusterClientMockRecorder 
 	return m.recorder
 }
 
+// CheckNamespace mocks base method.
+func (m *MockTargetClusterClient) CheckNamespace(ctx context.Context, namespace string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckNamespace", ctx, namespace)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CheckNamespace indicates an expected call of CheckNamespace.
+func (mr *MockTargetClusterClientMockRecorder) CheckNamespace(ctx, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckNamespace", reflect.TypeOf((*MockTargetClusterClient)(nil).CheckNamespace), ctx, namespace)
+}
+
 // CreateClusterNamespace mocks base method.
 func (m *MockTargetClusterClient) CreateClusterNamespace(ctx context.Context, clusterName string) error {
 	m.ctrl.T.Helper()

--- a/pkg/authenticator/target_cluster_client_test.go
+++ b/pkg/authenticator/target_cluster_client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -45,8 +46,9 @@ func TestTargetClusterClient_Init(t *testing.T) {
 	}
 
 	t.Run("get kubeconfig success", func(t *testing.T) {
+		logger := testr.New(t)
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		sut := NewTargetClusterClient(nil, mockClient)
+		sut := NewTargetClusterClient(logger, nil, mockClient)
 		var kubeconfigSecret corev1.Secret
 		kubeconfigSecret.Data = make(map[string][]byte)
 		kubeconfigSecret.Data["value"] = []byte(actualData)
@@ -62,8 +64,9 @@ func TestTargetClusterClient_Init(t *testing.T) {
 	})
 
 	t.Run("get kubeconfig CLUSTER_NAME success", func(t *testing.T) {
+		logger := testr.New(t)
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		sut := NewTargetClusterClient(nil, mockClient)
+		sut := NewTargetClusterClient(logger, nil, mockClient)
 		t.Setenv("CLUSTER_NAME", "billy")
 
 		err := sut.Initialize(ctx, "billy")
@@ -71,8 +74,9 @@ func TestTargetClusterClient_Init(t *testing.T) {
 	})
 
 	t.Run("get kubeconfig failure", func(t *testing.T) {
+		logger := testr.New(t)
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		sut := NewTargetClusterClient(nil, mockClient)
+		sut := NewTargetClusterClient(logger, nil, mockClient)
 		nn := types.NamespacedName{
 			Namespace: "eksa-system",
 			Name:      "billy-kubeconfig",
@@ -85,8 +89,9 @@ func TestTargetClusterClient_Init(t *testing.T) {
 	})
 
 	t.Run("get kubeconfig no cluster", func(t *testing.T) {
+		logger := testr.New(t)
 		mockClient := mocks.NewMockClient(gomock.NewController(t))
-		sut := NewTargetClusterClient(nil, mockClient)
+		sut := NewTargetClusterClient(logger, nil, mockClient)
 
 		// TODO do we need to support this case?
 		err := sut.Initialize(ctx, "")

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -161,6 +161,11 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("creating configmap for %s: %s", pbc.Name, err)
 		}
 
+		err = m.targetClient.CreateClusterNamespace(ctx, pbc.GetName())
+		if err != nil {
+			return fmt.Errorf("creating workload cluster namespace eksa-packages for %s: %s", pbc.Name, err)
+		}
+
 		if len(pbc.Spec.ActiveBundle) > 0 {
 			if !m.hasBundleNamed(allBundles, pbc.Spec.ActiveBundle) {
 

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,12 +40,14 @@ func GivenBundle(state api.PackageBundleStateEnum) *api.PackageBundle {
 }
 
 func givenBundleManager(t *testing.T) (*mocks.MockTargetClusterClient, *bundleMocks.MockRegistryClient, *bundleMocks.MockClient, *bundleManager) {
-	tcc := mocks.NewMockTargetClusterClient(gomock.NewController(t))
-	rc := bundleMocks.NewMockRegistryClient(gomock.NewController(t))
-	bc := bundleMocks.NewMockClient(gomock.NewController(t))
+	logger := testr.New(t)
+	ctrl := gomock.NewController(t)
+	tcc := mocks.NewMockTargetClusterClient(ctrl)
+	rc := bundleMocks.NewMockRegistryClient(ctrl)
+	bc := bundleMocks.NewMockClient(ctrl)
 	cfg := config.GetConfig()
 	cfg.BuildInfo.Version = "v2.2.2"
-	bm := NewBundleManager(logr.Discard(), rc, bc, tcc, cfg)
+	bm := NewBundleManager(logger, rc, bc, tcc, cfg)
 	return tcc, rc, bc, bm
 }
 
@@ -169,6 +171,8 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
+
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
@@ -187,6 +191,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
@@ -208,6 +213,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
@@ -227,6 +233,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateClusterConfigMap(ctx, pbc.Name).Return(nil)
@@ -313,6 +320,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.GetName()).Return(nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
@@ -351,6 +359,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.Name).Return(nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
@@ -523,6 +532,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
 		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
+		tcc.EXPECT().CreateClusterNamespace(ctx, pbc.GetName()).Return(nil).AnyTimes()
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
 		bc.EXPECT().CreateBundle(ctx, latestBundle).Return(nil)
@@ -561,7 +571,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		pbc.Status.State = ""
 		latestBundle := givenBundle()
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
-		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
+		tcc.EXPECT().Initialize(ctx, gomock.Any()).AnyTimes().Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)
@@ -581,7 +591,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 		latestBundle := givenBundle()
 		latestBundle.Name = testNextBundleName
 		tcc.EXPECT().GetServerVersion(ctx, pbc.Name).Return(&info, nil)
-		tcc.EXPECT().Initialize(ctx, gomock.Any()).Return(nil)
+		tcc.EXPECT().Initialize(ctx, gomock.Any()).AnyTimes().Return(nil)
 		tcc.EXPECT().ToRESTConfig().Return(&rest.Config{}, nil)
 		rc.EXPECT().LatestBundle(ctx, testBundleRegistry+"/eks-anywhere-packages-bundles", testKubeMajor, testKubeMinor, pbc.Name).Return(latestBundle, nil)
 		bc.EXPECT().GetBundleList(ctx).Return(allBundles, nil)

--- a/pkg/webhook/packagebundlecontroller_webhook.go
+++ b/pkg/webhook/packagebundlecontroller_webhook.go
@@ -39,7 +39,7 @@ type activeBundleValidator struct {
 }
 
 func InitPackageBundleControllerValidator(mgr ctrl.Manager) error {
-	tcc := authenticator.NewTargetClusterClient(mgr.GetConfig(), mgr.GetClient())
+	tcc := authenticator.NewTargetClusterClient(mgr.GetLogger(), mgr.GetConfig(), mgr.GetClient())
 	mgr.GetWebhookServer().
 		Register("/validate-packages-eks-amazonaws-com-v1alpha1-packagebundlecontroller",
 			&webhook.Admission{Handler: &activeBundleValidator{


### PR DESCRIPTION
This is created on all clusters. The namespace will store Helm release resources, even for workload clusters.

The namespace is created when a bundle is activated.

The namespace shouldn't be created via Helm chart because that would break full cluster lifecycle installations as they run helm with the permissions of the eksa-controller-manager service account, which doesn't have permission to create namespaces.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
