### PR TITLE
Changing module credential-provider to github.com/aws/eks-anywhere-packages/credentialproviderpackage

### DIFF
--- a/credentialproviderpackage/cmd/aws-credential-provider/main.go
+++ b/credentialproviderpackage/cmd/aws-credential-provider/main.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
-	cfg "credential-provider/pkg/configurator"
-	"credential-provider/pkg/configurator/bottlerocket"
-	"credential-provider/pkg/configurator/linux"
-	"credential-provider/pkg/constants"
-	"credential-provider/pkg/log"
+	cfg "github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/configurator"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/configurator/bottlerocket"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/configurator/linux"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/log"
 )
 
 const (

--- a/credentialproviderpackage/go.mod
+++ b/credentialproviderpackage/go.mod
@@ -1,4 +1,4 @@
-module credential-provider
+module github.com/aws/eks-anywhere-packages/credentialproviderpackage
 
 go 1.19
 

--- a/credentialproviderpackage/internal/test/files.go
+++ b/credentialproviderpackage/internal/test/files.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"testing"
 
-	"credential-provider/pkg/filewriter"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/filewriter"
 )
 
 var UpdateGoldenFiles = flag.Bool("update", false, "update golden files")

--- a/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
+++ b/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 	"os"
 
-	"credential-provider/pkg/configurator"
-	"credential-provider/pkg/constants"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/configurator"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
 )
 
 type bottleRocket struct {

--- a/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket_test.go
+++ b/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"credential-provider/pkg/constants"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
 )
 
 type response struct {

--- a/credentialproviderpackage/pkg/configurator/configurator.go
+++ b/credentialproviderpackage/pkg/configurator/configurator.go
@@ -1,6 +1,6 @@
 package configurator
 
-import "credential-provider/pkg/constants"
+import "github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
 
 type Configurator interface {
 	// Initialize Handles node specific configuration depending on OS

--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -11,10 +11,10 @@ import (
 
 	ps "github.com/mitchellh/go-ps"
 
-	"credential-provider/pkg/configurator"
-	"credential-provider/pkg/constants"
-	"credential-provider/pkg/log"
-	"credential-provider/pkg/templater"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/configurator"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/log"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/templater"
 )
 
 //go:embed templates/credential-provider-config.yaml

--- a/credentialproviderpackage/pkg/configurator/linux/linux_test.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"credential-provider/internal/test"
-	"credential-provider/pkg/constants"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/internal/test"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/constants"
 )
 
 func Test_linuxOS_updateKubeletArguments(t *testing.T) {

--- a/credentialproviderpackage/pkg/filewriter/tmp_writer_test.go
+++ b/credentialproviderpackage/pkg/filewriter/tmp_writer_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"credential-provider/pkg/filewriter"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/filewriter"
 )
 
 func TestTmpWriterWriteValid(t *testing.T) {

--- a/credentialproviderpackage/pkg/filewriter/writer_test.go
+++ b/credentialproviderpackage/pkg/filewriter/writer_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"credential-provider/internal/test"
-	"credential-provider/pkg/filewriter"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/internal/test"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/filewriter"
 )
 
 func TestWriterWriteValid(t *testing.T) {

--- a/credentialproviderpackage/pkg/templater/partialyaml_test.go
+++ b/credentialproviderpackage/pkg/templater/partialyaml_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"credential-provider/internal/test"
-	"credential-provider/pkg/templater"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/internal/test"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/templater"
 )
 
 func TestPartialYamlAddIfNotZero(t *testing.T) {

--- a/credentialproviderpackage/pkg/templater/templater.go
+++ b/credentialproviderpackage/pkg/templater/templater.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"text/template"
 
-	"credential-provider/pkg/filewriter"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/filewriter"
 )
 
 type Templater struct {

--- a/credentialproviderpackage/pkg/templater/templater_test.go
+++ b/credentialproviderpackage/pkg/templater/templater_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"credential-provider/internal/test"
-	"credential-provider/pkg/filewriter"
-	"credential-provider/pkg/templater"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/internal/test"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/filewriter"
+	"github.com/aws/eks-anywhere-packages/credentialproviderpackage/pkg/templater"
 )
 
 func TestTemplaterWriteToFileSuccess(t *testing.T) {


### PR DESCRIPTION
Changing the module to match rest of repository. Also needed for build-tooling to properly generate the license
