### PR TITLE
Update eks-anywhere-packages versions

### DIFF
--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -8,7 +8,7 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+            - name: v0.2.30-latest
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere


### PR DESCRIPTION
This versions.name value controls what eks-anywhere-packages images get copied over to the ECR image scanning account. In order to mirror prod images, we should copy over v0.x.xx-latest series. This version needs to match the latest release branch tag (i.e. https://github.com/aws/eks-anywhere-build-tooling/blob/release-0.14/projects/aws/eks-anywhere-packages/GIT_TAG).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
