### PR TITLE
Fix eks-anywhere-packages versions for image scanning

### DIFF
--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -8,7 +8,7 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: v0.2.30-latest
+            - name: 0.2.30-latest
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere


### PR DESCRIPTION
*Issue #, if available:*
We should use the helm tag, instead of the image tag. Verified this helm tag exists in the dev repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
