### PR TITLE
Adding webhook ignore

### DIFF
--- a/api/testdata/package_webhook_invalid_type_with_skip_annotation_false.yaml
+++ b/api/testdata/package_webhook_invalid_type_with_skip_annotation_false.yaml
@@ -1,0 +1,12 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: my-hello-eks-anywhere
+  namespace: eksa-packages-cluster01
+  annotations:
+    "skip-webhook-validation": "false"
+spec:
+  packageName: hello-eks-anywhere
+  config: |
+    sourceRegistry: "public.ecr.aws/dev"
+    title: 5

--- a/api/testdata/package_webhook_invalid_type_with_skip_annotation_true.yaml
+++ b/api/testdata/package_webhook_invalid_type_with_skip_annotation_true.yaml
@@ -1,0 +1,12 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: my-hello-eks-anywhere
+  namespace: eksa-packages-cluster01
+  annotations:
+    "skip-webhook-validation": "true"
+spec:
+  packageName: hello-eks-anywhere
+  config: |
+    sourceRegistry: "public.ecr.aws/dev"
+    title: 5

--- a/api/testdata/package_webhook_valid_config_skip_webhook_annotation.yaml
+++ b/api/testdata/package_webhook_valid_config_skip_webhook_annotation.yaml
@@ -1,0 +1,13 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: my-hello-eks-anywhere
+  namespace: eksa-packages-cluster01
+  annotations:
+    "skip-webhook-validation": "true"
+spec:
+  packageName: hello-eks-anywhere
+  config: |
+    sourceRegistry: "public.ecr.aws/dev"
+    title: "Amazon EKS Anywhere"
+    subtitle: "Run EKS in your datacenter"

--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: eksa-packages-{{.Values.clusterName}}
   annotations:
     "helm.sh/resource-policy": keep
+    "skip-webhook-validation": "true"
 spec:
   packageName: credential-provider-package
   targetNamespace: eksa-packages

--- a/pkg/authenticator/target_cluster_client.go
+++ b/pkg/authenticator/target_cluster_client.go
@@ -262,5 +262,5 @@ func (tcc *targetClusterClient) ApplySecret(ctx context.Context, secret *corev1.
 		}
 	}
 
-	return err
+	return nil
 }

--- a/pkg/authenticator/target_cluster_client.go
+++ b/pkg/authenticator/target_cluster_client.go
@@ -258,7 +258,7 @@ func (tcc *targetClusterClient) ApplySecret(ctx context.Context, secret *corev1.
 		}
 		err := k8sClient.Update(ctx, &newSecret)
 		if err != nil {
-			return fmt.Errorf("create secret for workload cluster %s", err)
+			return fmt.Errorf("updating secret for workload cluster %s", err)
 		}
 	}
 

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -133,9 +133,9 @@ func (bc *managerClient) GetSecret(ctx context.Context, name string) (secret *v1
 	err = bc.Get(ctx, nn, secret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, nil
+			return nil, fmt.Errorf("aws-secret not found")
 		}
-		return nil, err
+		return nil, fmt.Errorf("aws-secret error:%v", err)
 	}
 
 	return secret, nil

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -89,8 +89,7 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 }
 
 func (v *packageValidator) isPackageValid(p *v1alpha1.Package, activeBundle *v1alpha1.PackageBundle) (bool, error) {
-	skipAnnotation := p.Annotations["skip-webhook-validation"]
-	if skipAnnotation == "true" {
+	if p.Annotations["skip-webhook-validation"] == "true" {
 		return true, nil
 	}
 

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -58,6 +58,10 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 			fmt.Errorf("decoding request: %w", err))
 	}
 
+	if p.Annotations["skip-webhook-validation"] == "true" {
+		return admission.Response{AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true}}
+	}
+
 	clusterName := p.GetClusterName()
 	if clusterName == "" {
 		clusterName = os.Getenv("CLUSTER_NAME")
@@ -89,10 +93,6 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 }
 
 func (v *packageValidator) isPackageValid(p *v1alpha1.Package, activeBundle *v1alpha1.PackageBundle) (bool, error) {
-	if p.Annotations["skip-webhook-validation"] == "true" {
-		return true, nil
-	}
-
 	packageInBundle, err := activeBundle.FindPackage(p.Spec.PackageName)
 	if err != nil {
 		return false, err

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -89,6 +89,11 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 }
 
 func (v *packageValidator) isPackageValid(p *v1alpha1.Package, activeBundle *v1alpha1.PackageBundle) (bool, error) {
+	skipAnnotation := p.Annotations["skip-webhook-validation"]
+	if skipAnnotation == "true" {
+		return true, nil
+	}
+
 	packageInBundle, err := activeBundle.FindPackage(p.Spec.PackageName)
 	if err != nil {
 		return false, err

--- a/pkg/webhook/package_webhook_test.go
+++ b/pkg/webhook/package_webhook_test.go
@@ -94,4 +94,43 @@ func TestPackageValidate(t *testing.T) {
 		assert.False(t, result)
 		assert.EqualError(t, err, "package my-hello-eks-anywhere targetNamespace is immutable")
 	})
+
+	t.Run("valid package with webhook ignore", func(t *testing.T) {
+		activeBundle, err := testutil.GivenPackageBundle("../../api/testdata/bundle_one.yaml")
+		require.Nil(t, err)
+		myPackage, err := testutil.GivenPackage("../../api/testdata/package_webhook_valid_config_skip_webhook_annotation.yaml")
+		require.Nil(t, err)
+		validator := packageValidator{}
+
+		result, err := validator.isPackageValid(myPackage, activeBundle)
+
+		assert.True(t, result)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid package with webhook ignore", func(t *testing.T) {
+		activeBundle, err := testutil.GivenPackageBundle("../../api/testdata/bundle_one.yaml")
+		require.Nil(t, err)
+		myPackage, err := testutil.GivenPackage("../../api/testdata/package_webhook_valid_config_skip_webhook_annotation.yaml")
+		require.Nil(t, err)
+		validator := packageValidator{}
+
+		result, err := validator.isPackageValid(myPackage, activeBundle)
+
+		assert.True(t, result)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid package config type with skip annotation false", func(t *testing.T) {
+		activeBundle, err := testutil.GivenPackageBundle("../../api/testdata/bundle_one.yaml")
+		require.Nil(t, err)
+		myPackage, err := testutil.GivenPackage("../../api/testdata/package_webhook_invalid_type.yaml")
+		require.Nil(t, err)
+		validator := packageValidator{}
+
+		result, err := validator.isPackageValid(myPackage, activeBundle)
+
+		assert.False(t, result)
+		assert.EqualError(t, err, "error validating configurations - title: Invalid type. Expected: string, given: integer\n")
+	})
 }


### PR DESCRIPTION
Adding the ability for packages to bypass the validation. This will be used by the credential package when it is installed on the workload cluster to apply the package before there is an active bundle


<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
