### PR TITLE
Adding skip-webhook-validation before checking bundle is active. 

### DIFF
--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: eksa-packages-{{.Values.clusterName}}
   annotations:
     "helm.sh/resource-policy": keep
+    "skip-webhook-validation": "true"
 spec:
   packageName: credential-provider-package
   targetNamespace: eksa-packages

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -135,7 +135,7 @@ func (bc *managerClient) GetSecret(ctx context.Context, name string) (secret *v1
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("aws-secret error:%v", err)
 	}
 
 	return secret, nil

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -171,9 +171,11 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("getting aws secret eksa-packages:%s", err)
 		}
 
-		err = m.targetClient.ApplySecret(ctx, secret)
-		if err != nil {
-			return fmt.Errorf("creating workload cluster secret aws-secret:%s", err)
+		if secret != nil {
+			err = m.targetClient.ApplySecret(ctx, secret)
+			if err != nil {
+				return fmt.Errorf("creating workload cluster secret aws-secret:%s", err)
+			}
 		}
 
 		if len(pbc.Spec.ActiveBundle) > 0 {

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -58,6 +58,10 @@ func (v *packageValidator) Handle(ctx context.Context, request admission.Request
 			fmt.Errorf("decoding request: %w", err))
 	}
 
+	if p.Annotations["skip-webhook-validation"] == "true" {
+		return admission.Response{AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true}}
+	}
+
 	clusterName := p.GetClusterName()
 	if clusterName == "" {
 		clusterName = os.Getenv("CLUSTER_NAME")


### PR DESCRIPTION
Fixing situations where aws-secret doesn't exist and causes controller to crash


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
