### PR TITLE
Determining cluster compatability with credential package

### DIFF
--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.cronjob.suspend }}
+{{ $credtype := include "lookup-credential.method" . }}
+{{ if (eq $credtype "credential-package" ) }}
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: Package
 metadata:

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,4 +1,6 @@
-{{- if not .Values.workloadOnly }}
+{{ $credtype := include "lookup-credential.method" . }}
+{{- if (eq $credtype "cronjob" ) -}}
+{{- if not (lookup "batch/v1" "CronJob" "eksa-packages" "cron-ecr-renew") -}}
 {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1
 {{- else }}
@@ -69,4 +71,5 @@ spec:
                   value: {{ .Values.proxy.HTTPS_PROXY | quote}}
                 - name: NO_PROXY
                   value: {{ .Values.proxy.NO_PROXY | quote}}
+{{- end }}
 {{- end }}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -10,6 +10,8 @@ kind: CronJob
 metadata:
   namespace: {{ .Values.namespace }}
   name: cron-ecr-renew
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   schedule: "0 */5 * * *"
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Currently there is a bug where Bottlerocket 1.25 k8s versions (as of BR version 0.12.0) and greater inaccurately renders the KubeletCredentialProvider causing the node to crash. Adding the ability for the helm chart to revert back to the cronjob in cases where the credential-package will not work.

* In cases where the aws-secret does not exist and the values are not set in the chart, neither the credential-package or cronjob will be enabled
* In the case where the workload cluster is not compatible the chart will check if the cronjob is already enabled if not it will re-enable even if mgmt cluster users credential package.
* Also versions of BR < 1.11.0 does not expose the necessary APIs for the credential package thus the cronjob will be enabled.
* If cronjob.suspend is set to false then the cronjob will be used and the credential-package will not be installed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
