### PR TITLE
Change secret to not be reapply on management cluster. Update BR versions

### DIFF
--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -127,7 +127,7 @@ Function to figure out if to install cronjob, credential-package, or none
             {{- if eq $os "bottlerocket" -}}
                 {{- $v := include "template.getBRVersion" . -}}
                 {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
-                    {{- if semverCompare "<=1.12" $v -}}
+                    {{- if semverCompare "<=1.13" $v -}}
                         {{- printf "cronjob" -}}
                     {{- else -}}
                         {{- printf "credential-package" -}}

--- a/pkg/authenticator/target_cluster_client.go
+++ b/pkg/authenticator/target_cluster_client.go
@@ -246,9 +246,8 @@ func (tcc *targetClusterClient) ApplySecret(ctx context.Context, secret *corev1.
 
 	newSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        secret.ObjectMeta.Name,
-			Namespace:   secret.ObjectMeta.Namespace,
-			Annotations: secret.ObjectMeta.Annotations,
+			Name:      secret.ObjectMeta.Name,
+			Namespace: secret.ObjectMeta.Namespace,
 		},
 		Data: secret.Data,
 	}

--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -166,15 +166,17 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 			return fmt.Errorf("creating workload cluster namespace eksa-packages for %s: %s", pbc.Name, err)
 		}
 
-		secret, err := m.bundleClient.GetSecret(ctx, "aws-secret")
-		if err != nil {
-			return fmt.Errorf("getting aws secret eksa-packages:%s", err)
-		}
-
-		if secret != nil {
-			err = m.targetClient.ApplySecret(ctx, secret)
+		if pbc.GetName() != os.Getenv("CLUSTER_NAME") {
+			secret, err := m.bundleClient.GetSecret(ctx, "aws-secret")
 			if err != nil {
-				return fmt.Errorf("creating workload cluster secret aws-secret:%s", err)
+				return fmt.Errorf("getting aws secret eksa-packages:%s", err)
+			}
+
+			if secret != nil {
+				err = m.targetClient.ApplySecret(ctx, secret)
+				if err != nil {
+					return fmt.Errorf("creating workload cluster secret aws-secret:%s", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
BR v1.13 was released and does not include the fix needed for credential package to work so logic was updated.

Removing the need to copy annotations for secret over as secret is no longer reapplied on management cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
