### PR TITLE
Add support for rendering just a package

### DIFF
--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -147,3 +147,18 @@ Function to figure out if to install cronjob, credential-package, or none
         {{- printf "none" -}}
     {{- end -}}
 {{- end -}}
+
+
+{{/*
+RenderType returns the type of output we need to render, either controller, workload or package.
+*/}}
+{{- define "eks-anywhere-packages.rendertype" -}}
+    {{- if and (not .Values.workloadOnly) (not .Values.workloadPackageOnly) -}}
+        {{- printf "controller" -}}
+    {{- else if .Values.workloadPackageOnly -}}
+        {{- printf "package" -}}
+    {{- else -}}
+        {{- printf "workload" -}}
+    {{- end -}}
+{{- end -}}
+

--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -153,12 +153,12 @@ Function to figure out if to install cronjob, credential-package, or none
 RenderType returns the type of output we need to render, either controller, workload or package.
 */}}
 {{- define "eks-anywhere-packages.rendertype" -}}
-    {{- if and (not .Values.workloadOnly) (not .Values.workloadPackageOnly) -}}
-        {{- printf "controller" -}}
-    {{- else if .Values.workloadPackageOnly -}}
+    {{- if .Values.workloadPackageOnly -}}
         {{- printf "package" -}}
-    {{- else -}}
+    {{- else if .Values.workloadOnly -}}
         {{- printf "workload" -}}
+    {{- else -}}
+        {{- printf "controller" -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/eks-anywhere-packages/templates/awssecret.yaml
+++ b/charts/eks-anywhere-packages/templates/awssecret.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 {{- if not (lookup "v1" "Secret" "eksa-packages" "aws-secret") -}}
 apiVersion: v1
 kind: Secret

--- a/charts/eks-anywhere-packages/templates/certs.yaml
+++ b/charts/eks-anywhere-packages/templates/certs.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/eks-anywhere-packages/templates/clusterrole.yaml
+++ b/charts/eks-anywhere-packages/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/eks-anywhere-packages/templates/clusterrolebinding.yaml
+++ b/charts/eks-anywhere-packages/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/eks-anywhere-packages/templates/configmap.yaml
+++ b/charts/eks-anywhere-packages/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -1,4 +1,6 @@
 {{ $credtype := include "lookup-credential.method" . }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if or (eq $render "controller") (eq $render "workload") }}
 {{ if (eq $credtype "credential-package" ) }}
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: Package
@@ -19,4 +21,5 @@ spec:
         profile: "default"
         secretName: aws-secret
         defaultCacheDuration: "5h"
+{{- end }}
 {{- end }}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -1,3 +1,5 @@
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if or (eq $render "controller") (eq $render "workload") }}
 {{ $credtype := include "lookup-credential.method" . }}
 {{- if (eq $credtype "cronjob" ) -}}
 {{- if not (lookup "batch/v1" "CronJob" "eksa-packages" "cron-ecr-renew") -}}
@@ -73,5 +75,6 @@ spec:
                   value: {{ .Values.proxy.HTTPS_PROXY | quote}}
                 - name: NO_PROXY
                   value: {{ .Values.proxy.NO_PROXY | quote}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/eks-anywhere-packages/templates/namespace.yaml
+++ b/charts/eks-anywhere-packages/templates/namespace.yaml
@@ -1,6 +1,7 @@
-# If workloadOnly is true, the eksa-packages namespace isn't used and already
+# If not seeding the controller, the eksa-packages namespace isn't used and already
 # exists.
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 {{ $namespace := "eksa-packages" }}
 # If the release namespace is set, it is expected that either --create-namespace
 # is specified or the namespace exists
@@ -27,6 +28,7 @@ metadata:
 {{- end }}
 {{- end }}
 
+{{- if not (eq $render "package") }}
 {{ $pkgnamespace := (printf "%s-%s" "eksa-packages" .Values.clusterName) }}
 {{- if not (lookup "v1" "Namespace" "" $pkgnamespace ) -}}
 apiVersion: v1
@@ -35,4 +37,5 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   name: {{ $pkgnamespace }}
+{{- end }}
 {{- end }}

--- a/charts/eks-anywhere-packages/templates/network-policy.yaml
+++ b/charts/eks-anywhere-packages/templates/network-policy.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/eks-anywhere-packages/templates/package.yaml
+++ b/charts/eks-anywhere-packages/templates/package.yaml
@@ -1,6 +1,8 @@
-{{- if not .Values.workloadOnly }}
-{{-  $namespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
-{{- if not (lookup "packages.eks.amazonaws.com/v1alpha1" "Package" "eksa-packages-main" "eks-anywhere-packages") }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- $namespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
+{{- $mgmtNamespace := printf "%s-%s" "eksa-packages" .Values.managementClusterName -}}
+{{- if eq $render "controller" }}
+{{- if not (lookup "packages.eks.amazonaws.com/v1alpha1" "Package" $namespace "eks-anywhere-packages") }}
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: Package
 metadata:
@@ -19,4 +21,22 @@ spec:
     {{- toYaml $newValues | nindent 4 }}
     {{- end }}
 {{- end }}
+{{ else if eq $render "package" }}
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: eks-anywhere-packages-{{ .Values.clusterName }}
+  namespace: {{ $mgmtNamespace }}
+spec:
+  packageName: eks-anywhere-packages
+  targetNamespace: {{ $namespace }}
+  config: |
+    workloadOnly: true
+    clusterName: {{ .Values.clusterName }}
+    sourceRegistry: {{ .Values.sourceRegistry }}
+    defaultRegistry: {{ .Values.defaultRegistry }}
+    defaultImageRegistry: {{ .Values.defaultImageRegistry }} 
 {{- end }}
+

--- a/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
+++ b/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
@@ -1,3 +1,5 @@
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if not (eq $render "package") }}
 {{ if .Capabilities.APIVersions.Has "packagecontrollers.packages.eks.amazonaws.com/v1alpha1/{{.Values.clusterName}}" -}}
 {{- else -}}
 apiVersion: packages.eks.amazonaws.com/v1alpha1
@@ -11,4 +13,5 @@ spec:
   defaultRegistry: {{.Values.defaultRegistry}}
   defaultImageRegistry: {{.Values.defaultImageRegistry}}
   privateRegistry: {{.Values.privateRegistry}}
+{{- end -}}
 {{- end -}}

--- a/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
+++ b/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
@@ -1,10 +1,12 @@
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if or (eq $render "controller") (eq $render "workload") }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: registry-mirror-secret
-  {{- if not .Values.workloadOnly }}
+  {{- if eq $render "controller" }}
   namespace: {{ .Values.namespace }}
-  {{- else }}
+  {{- else if eq $render "workload" }}
   namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
   {{- end }}
 data:
@@ -16,3 +18,4 @@ data:
   INSECURE: "{{ .insecure }}"
   {{- end }}
 type: Opaque
+{{- end }}

--- a/charts/eks-anywhere-packages/templates/role.yaml
+++ b/charts/eks-anywhere-packages/templates/role.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 ---
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
@@ -44,8 +45,6 @@ rules:
   verbs:
   - create
   - patch
-{{- end }}
-{{- if .Values.workloadOnly }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/eks-anywhere-packages/templates/rolebinding.yaml
+++ b/charts/eks-anywhere-packages/templates/rolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -18,8 +19,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
-{{- end }}
-{{- if .Values.workloadOnly }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/eks-anywhere-packages/templates/service.yaml
+++ b/charts/eks-anywhere-packages/templates/service.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/eks-anywhere-packages/templates/serviceaccount.yaml
+++ b/charts/eks-anywhere-packages/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/eks-anywhere-packages/templates/servicemonitor.yaml
+++ b/charts/eks-anywhere-packages/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 {{- if.Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/eks-anywhere-packages/templates/webhook.yaml
+++ b/charts/eks-anywhere-packages/templates/webhook.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.workloadOnly }}
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- if eq $render "controller" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -22,6 +22,7 @@ defaultImageRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
 privateRegistry: ""
 # -- clusterName managed by a particular PBC
 clusterName: bundle-controller
+managementClusterName: ""
 # -- Image pull policy for Docker images.
 imagePullPolicy: IfNotPresent
 helmConfigHome: /tmp/config


### PR DESCRIPTION
*Description of changes:* Add support for only rendering a package resource as a temporary workaround until that's generated by the eksa controller.

/hold until I review it tomorrow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
