### PR TITLE
Control Plane Toleration and Bottlerocket version check

### DIFF
--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Function to figure out if to install cronjob, credential-package, or none
                         {{- printf "credential-package" -}}
                     {{- end -}}
                 {{- else -}}
-                    {{- if semverCompare "<=1.11" $v -}}
+                    {{- if semverCompare "<=1.13" $v -}}
                         {{- printf "cronjob" -}}
                     {{- else -}}
                         {{- printf "credential-package" -}}

--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -14,6 +14,13 @@ spec:
   packageName: credential-provider-package
   targetNamespace: eksa-packages
   config: |-
+    tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
     sourceRegistry: {{.Values.sourceRegistry}}
     credential:
       - matchImages:

--- a/credentialproviderpackage/go.mod
+++ b/credentialproviderpackage/go.mod
@@ -3,11 +3,11 @@ module github.com/aws/eks-anywhere-packages/credentialproviderpackage
 go 1.19
 
 require (
-	github.com/Masterminds/semver v1.5.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/mod v0.3.0
 	k8s.io/apimachinery v0.26.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/credentialproviderpackage/go.mod
+++ b/credentialproviderpackage/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/eks-anywhere-packages/credentialproviderpackage
 go 1.19
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/mitchellh/go-ps v1.0.0

--- a/credentialproviderpackage/go.sum
+++ b/credentialproviderpackage/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/credentialproviderpackage/go.sum
+++ b/credentialproviderpackage/go.sum
@@ -1,5 +1,3 @@
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -41,6 +39,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
+++ b/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
@@ -246,10 +246,6 @@ func (b *bottleRocket) isSupportedBRVersion() (bool, error) {
 	}
 
 	ver := "v" + osVersion.Os.VersionID
-
 	valid := semver.Compare(ver, allowedVersions)
-	if valid <= 0 {
-		return false, nil
-	}
-	return true, nil
+	return valid > 0, nil
 }


### PR DESCRIPTION
* Added CP toleration as default for credential package
* Add version check to configurator binary to prevent node breakage
* Defaulting to cronjob for BR regardless of k8s version for BR < 1.13 by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
