### PR TITLE
Using the actual tags for metallb from public ECR

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-22.yaml
+++ b/generatebundlefile/data/bundles_staging/1-22.yaml
@@ -45,12 +45,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_staging/1-23.yaml
+++ b/generatebundlefile/data/bundles_staging/1-23.yaml
@@ -45,12 +45,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_staging/1-24.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24.yaml
@@ -64,12 +64,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_staging/1-25.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25.yaml
@@ -64,12 +64,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -64,12 +64,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -55,14 +55,14 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-5bd8573a49109a567953b3825e29601d617fe9d5
+            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The tags used in the staging bundles were not the ones from Public ECR so it was failing staging pipeline.