### PR TITLE
Updating staging bundles in prep for 0.15 release.

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-22.yaml
+++ b/generatebundlefile/data/bundles_dev/1-22.yaml
@@ -3,30 +3,32 @@ name: "v1-22-1001"
 kubernetesVersion: "1.22"
 minControllerVersion: "v0.3.2"
 packages:
-  - org: aws-containers
+  - org: aws
     projects:
-      - name: hello-eks-anywhere
-        repository: hello-eks-anywhere
-        registry: public.ecr.aws/l0g8r8j6
-        versions:
-            - name: latest
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: credential-provider-package
         repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest

--- a/generatebundlefile/data/bundles_dev/1-23.yaml
+++ b/generatebundlefile/data/bundles_dev/1-23.yaml
@@ -3,30 +3,32 @@ name: "v1-23-1001"
 kubernetesVersion: "1.23"
 minControllerVersion: "v0.3.2"
 packages:
-  - org: aws-containers
+  - org: aws
     projects:
-      - name: hello-eks-anywhere
-        repository: hello-eks-anywhere
-        registry: public.ecr.aws/l0g8r8j6
-        versions:
-            - name: latest
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: credential-provider-package
         repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest

--- a/generatebundlefile/data/bundles_dev/1-24.yaml
+++ b/generatebundlefile/data/bundles_dev/1-24.yaml
@@ -3,30 +3,32 @@ name: "v1-24-1001"
 kubernetesVersion: "1.24"
 minControllerVersion: "v0.3.2"
 packages:
-  - org: aws-containers
+  - org: aws
     projects:
-      - name: hello-eks-anywhere
-        repository: hello-eks-anywhere
-        registry: public.ecr.aws/l0g8r8j6
-        versions:
-            - name: latest
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: credential-provider-package
         repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest

--- a/generatebundlefile/data/bundles_dev/1-25.yaml
+++ b/generatebundlefile/data/bundles_dev/1-25.yaml
@@ -3,30 +3,32 @@ name: "v1-25-1001"
 kubernetesVersion: "1.25"
 minControllerVersion: "v0.3.2"
 packages:
-  - org: aws-containers
+  - org: aws
     projects:
-      - name: hello-eks-anywhere
-        repository: hello-eks-anywhere
-        registry: public.ecr.aws/l0g8r8j6
-        versions:
-            - name: latest
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: credential-provider-package
         repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest

--- a/generatebundlefile/data/bundles_dev/1-26.yaml
+++ b/generatebundlefile/data/bundles_dev/1-26.yaml
@@ -3,30 +3,32 @@ name: "v1-26-1001"
 kubernetesVersion: "1.26"
 minControllerVersion: "v0.3.2"
 packages:
-  - org: aws-containers
+  - org: aws
     projects:
-      - name: hello-eks-anywhere
-        repository: hello-eks-anywhere
-        registry: public.ecr.aws/l0g8r8j6
-        versions:
-            - name: latest
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+          - name: 0.0.0-latest
       - name: credential-provider-package
         repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: latest

--- a/generatebundlefile/data/bundles_staging/1-22.yaml
+++ b/generatebundlefile/data/bundles_staging/1-22.yaml
@@ -3,6 +3,28 @@ name: "v1-22-1001"
 kubernetesVersion: "1.22"
 minControllerVersion: "v0.3.2"
 packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-23.yaml
+++ b/generatebundlefile/data/bundles_staging/1-23.yaml
@@ -3,6 +3,28 @@ name: "v1-23-1001"
 kubernetesVersion: "1.23"
 minControllerVersion: "v0.3.2"
 packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-24.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24.yaml
@@ -3,6 +3,28 @@ name: "v1-24-1001"
 kubernetesVersion: "1.24"
 minControllerVersion: "v0.3.2"
 packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-25.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25.yaml
@@ -3,6 +3,28 @@ name: "v1-25-1001"
 kubernetesVersion: "1.25"
 minControllerVersion: "v0.3.2"
 packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -3,6 +3,28 @@ name: "v1-26-1001"
 kubernetesVersion: "1.26"
 minControllerVersion: "v0.3.2"
 packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/w9m0f3l5
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -8,7 +8,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.0.0-latest
+            - name: 0.3.9-eks-a-v0.0.0-dev-build.6630
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.3.9-latest-helm
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.3.9-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere


### PR DESCRIPTION
* Moved packages,crds,migrations, and credential package under aws org for dev
* Updated staging move with latest helm chart
* Added packages,crd,migrations, and credential package to staging bundle.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
