### PR TITLE
Fixing Ecr public lookup not use default accountID registry

### DIFF
--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -74,7 +74,7 @@ func (c *SDKClients) NewPackageFromInput(project Project) (*api.BundlePackage, e
 	var err error
 	// Check bundle Input registry for ECR Public Registry
 	if strings.Contains(project.Registry, "public.ecr.aws") {
-		versionList, err = c.ecrPublicClient.GetShaForPublicInputs(project)
+		versionList, err = c.GetShaForPublicInputs(project)
 		if err != nil {
 			return nil, err
 		}

--- a/generatebundlefile/ecr_public.go
+++ b/generatebundlefile/ecr_public.go
@@ -60,15 +60,16 @@ func (c *ecrPublicClient) DescribePublic(describeInput *ecrpublic.DescribeImages
 }
 
 // GetShaForPublicInputs returns a list of an images version/sha for given inputs to lookup
-func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVersion, error) {
+func (c *SDKClients) GetShaForPublicInputs(project Project) ([]api.SourceVersion, error) {
 	sourceVersion := []api.SourceVersion{}
 	for _, tag := range project.Versions {
 		if !strings.HasSuffix(tag.Name, "latest") {
 			var imagelookup []ecrpublictypes.ImageIdentifier
 			imagelookup = append(imagelookup, ecrpublictypes.ImageIdentifier{ImageTag: &tag.Name})
-			ImageDetails, err := c.DescribePublic(&ecrpublic.DescribeImagesInput{
+			ImageDetails, err := c.ecrPublicClient.DescribePublic(&ecrpublic.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
 				ImageIds:       imagelookup,
+				RegistryId:     &c.stsClientRelease.AccountID,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error: Unable to complete DescribeImagesRequest to ECR public. %s", err)
@@ -86,7 +87,7 @@ func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVe
 		}
 		//
 		if tag.Name == "latest" {
-			ImageDetails, err := c.DescribePublic(&ecrpublic.DescribeImagesInput{
+			ImageDetails, err := c.ecrPublicClient.DescribePublic(&ecrpublic.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
 			})
 			if err != nil {
@@ -108,7 +109,7 @@ func (c *ecrPublicClient) GetShaForPublicInputs(project Project) ([]api.SourceVe
 		if strings.HasSuffix(tag.Name, "-latest") {
 			regex := regexp.MustCompile(`-latest`)
 			splitVersion := regex.Split(tag.Name, -1) //extract out the version without the latest
-			ImageDetails, err := c.DescribePublic(&ecrpublic.DescribeImagesInput{
+			ImageDetails, err := c.ecrPublicClient.DescribePublic(&ecrpublic.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
 			})
 			if err != nil {

--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -70,10 +70,6 @@ if [ ! -x "${ORAS_BIN}" ]; then
     make oras-install
 fi
 
-for version in 1-22 1-23 1-24 1-25 1-26; do
-    generate ${version} "staging"
-done
-
 export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/configfile
 export AWS_PROFILE=packages
 
@@ -81,8 +77,13 @@ for version in 1-22 1-23 1-24 1-25 1-26; do
     regionCheck ${version}
 done
 
-export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/stagingconfigfile
 export AWS_PROFILE=staging
+export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/stagingconfigfile
+for version in 1-22 1-23 1-24 1-25 1-26; do
+    generate ${version} "staging"
+done
+
+
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
 
 for version in 1-22 1-23 1-24 1-25 1-26; do

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -309,6 +309,18 @@ func cmdGenerate(opts *Options) error {
 		BundleLog.Error(err, "creating ECR client")
 		os.Exit(1)
 	}
+	// Creating AWS Clients with profile
+	Profile := "default"
+	val, ok := os.LookupEnv("AWS_PROFILE")
+	if ok {
+		Profile = val
+	}
+	BundleLog.Info("Using Env", "AWS_PROFILE", Profile)
+	clients, err = clients.GetProfileSDKConnection("sts", Profile, ecrRegion)
+	if err != nil {
+		BundleLog.Error(err, "getting profile SDK connection")
+		os.Exit(1)
+	}
 	for _, f := range files {
 		Inputs, err := ValidateInputConfig(f)
 		if err != nil {
@@ -362,6 +374,7 @@ func cmdGenerate(opts *Options) error {
 			}
 			// Check for requires.yaml in the unpacked helm chart
 			helmDest := filepath.Join(pwd, chartName, helmname)
+			defer os.RemoveAll(helmDest)
 			f, err := hasRequires(helmDest)
 			if err != nil {
 				BundleLog.Error(err, "Helm chart doesn't have requires.yaml inside")

--- a/generatebundlefile/sts.go
+++ b/generatebundlefile/sts.go
@@ -8,14 +8,18 @@ import (
 )
 
 type stsClient struct {
-	*sts.Client
+	stsClientInterface
 	AccountID string
 }
 
-func NewStsClient(stsclient *sts.Client, account bool) (*stsClient, error) {
-	stsClient := &stsClient{Client: stsclient}
+type stsClientInterface interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+func NewStsClient(client stsClientInterface, account bool) (*stsClient, error) {
+	stsClient := &stsClient{stsClientInterface: client}
 	if account {
-		stslookup, err := stsClient.Client.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
+		stslookup, err := stsClient.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

on the ECR Public `DescribeImagesInput` function there was this note.

```
	// The AWS account ID associated with the public registry that contains the
	// repository in which to describe images. If you do not specify a registry, the
	// default public registry is assumed.
	RegistryId *string
```

What this effectively doing was looking up the bundle source of the helm charts in the source ECR public account to find the image sha. We hadn't noticed this issue previously since the images tags were identical between dev and staging, but we see the issue now on the EKS-A tagged artifacts since the tag is not the same between dev/staging.

This fix will source the correct Destination accountID when looking up artifacts for the bundle.
