### PR TITLE
Template credential-provider-config api version

### DIFF
--- a/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
@@ -55,6 +55,8 @@ spec:
               value: '{{ join "," (index .Values.credential 0).matchImages }}'
             - name: DEFAULT_CACHE_DURATION
               value: {{(index .Values.credential 0).defaultCacheDuration}}
+            - name: K8S_VERSION
+              value: "v{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}"
       volumes:
         # Currently only one secret (aws-secret) is supported at this time
         - name: aws-creds

--- a/credentialproviderpackage/pkg/configurator/linux/linux_test.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux_test.go
@@ -163,11 +163,8 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 				basePath:      tt.fields.basePath,
 				config:        tt.fields.config,
 			}
-			err := os.Setenv("K8S_VERSION", tt.k8sVersion)
-			if err != nil {
-				t.Errorf("updateKubeletArguments failed to set K8S_VERSION")
-			}
-			defer os.Unsetenv("K8S_VERSION")
+			t.Setenv("K8S_VERSION", tt.k8sVersion)
+
 			if got := c.updateKubeletArguments(tt.args.line); got != tt.want {
 				t.Errorf("updateKubeletArguments() = %v, want %v", got, tt.want)
 			}

--- a/credentialproviderpackage/pkg/configurator/linux/templates/credential-provider-config.yaml
+++ b/credentialproviderpackage/pkg/configurator/linux/templates/credential-provider-config.yaml
@@ -1,11 +1,11 @@
-apiVersion: kubelet.config.k8s.io/v1alpha1
+apiVersion: kubelet.config.k8s.io/{{.apiVersion}}
 kind: CredentialProviderConfig
 providers:
   - name: ecr-credential-provider
     matchImages:{{range $val := .imagePattern}}
       - "{{$val}}"{{end}}
     defaultCacheDuration: "{{.cacheDuration}}"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/{{.apiVersion}}
     env:
       - name: AWS_PROFILE
         value: {{.profile}}

--- a/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config-alpha.yaml
+++ b/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config-alpha.yaml
@@ -1,12 +1,11 @@
-apiVersion: kubelet.config.k8s.io/v1
+apiVersion: kubelet.config.k8s.io/v1alpha1
 kind: CredentialProviderConfig
 providers:
   - name: ecr-credential-provider
     matchImages:
-      - "1234567.dkr.ecr.us-east-1.amazonaws.com"
-      - "7654321.dkr.ecr.us-west-2.amazonaws.com"
+      - "*.dkr.ecr.*.amazonaws.com"
     defaultCacheDuration: "30m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
     env:
       - name: AWS_PROFILE
         value: eksa-packages

--- a/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config-beta.yaml
+++ b/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config-beta.yaml
@@ -1,12 +1,11 @@
-apiVersion: kubelet.config.k8s.io/v1
+apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:
   - name: ecr-credential-provider
     matchImages:
-      - "1234567.dkr.ecr.us-east-1.amazonaws.com"
-      - "7654321.dkr.ecr.us-west-2.amazonaws.com"
+      - "*.dkr.ecr.*.amazonaws.com"
     defaultCacheDuration: "30m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
     env:
       - name: AWS_PROFILE
         value: eksa-packages

--- a/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config.yaml
+++ b/credentialproviderpackage/pkg/configurator/linux/testdata/expected-config.yaml
@@ -1,11 +1,11 @@
-apiVersion: kubelet.config.k8s.io/v1alpha1
+apiVersion: kubelet.config.k8s.io/v1
 kind: CredentialProviderConfig
 providers:
   - name: ecr-credential-provider
     matchImages:
       - "*.dkr.ecr.*.amazonaws.com"
     defaultCacheDuration: "30m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
     env:
       - name: AWS_PROFILE
         value: eksa-packages


### PR DESCRIPTION
Have credential-provider-config api version be dynamically generated based on kubernetes version.
Kubernetes added v1 support for kubelet.config.k8s.io and credentialprovider.kubelet.k8s.io in v1.26 and will be removing v1alpha1 in future versions. Adding support now before v1.27

Currently this is setup to bump the api version one version after the release supported. For example even though v1 was added to v1.26 we will still use v1beta1. This is because there are cases during an upgrade for example of a rolling upgrade of v1.25 -> v1.26 cluster that the node the helm chart installs on might be v1.26 and try to run the deamonset on the 1.25 nodes with an unsupported api. Since we don't allow a two version jump of k8s version at once this should be fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
