### PR TITLE
Add k1.27 support in dev

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-27.yaml
+++ b/generatebundlefile/data/bundles_dev/1-27.yaml
@@ -1,0 +1,101 @@
+# This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
+name: "v1-27-1001"
+kubernetesVersion: "1.27"
+minControllerVersion: "v0.3.2"
+packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: aws-observability
+    projects:
+      - name: adot
+        repository: adot/charts/aws-otel-collector
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: harbor
+    projects:
+      - name: harbor
+        repository: harbor/harbor-helm
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: kubernetes
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: 9.21.0-1.27-latest
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: 0.6.3-eks-1-27-latest
+  - org: metallb
+    projects:
+      - name: metallb
+        repository: metallb/metallb
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+      - name: metallb-crds
+        repository: metallb/crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: prometheus
+    projects:
+      - name: prometheus
+        repository: prometheus/charts/prometheus
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest

--- a/generatebundlefile/data/promote/autoscaler/promote.yaml
+++ b/generatebundlefile/data/promote/autoscaler/promote.yaml
@@ -8,6 +8,13 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
+            - name: 9.21.0-1.27-latest
+  - org: cluster-autoscaler
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
+        versions:
             - name: 9.21.0-1.26-latest
   - org: cluster-autoscaler
     projects:

--- a/generatebundlefile/data/promote/metrics-server/promote.yaml
+++ b/generatebundlefile/data/promote/metrics-server/promote.yaml
@@ -3,6 +3,13 @@ name: "v1-22-1001"
 kubernetesVersion: "1.22"
 packages:
   - org: metrics-server
+      projects:
+        - name: metrics-server
+          repository: metrics-server/charts/metrics-server
+          registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
+          versions:
+              - name: 0.6.3-eks-1-27-latest
+  - org: metrics-server
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -34,7 +34,7 @@ fi
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin
 
-for version in 1-22 1-23 1-24 1-25 1-26; do
+for version in 1-22 1-23 1-24 1-25 1-26 1-27; do
     generate ${version} "dev"
     push ${version}
 done


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add k1.27 support. Confirmed metrics-server and auto-scaler exists in the l0g8r8j6 account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
