### PR TITLE
Update credential vs cronjob semverCompare logic

### DIFF
--- a/charts/eks-anywhere-packages/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages/templates/_helpers.tpl
@@ -127,13 +127,13 @@ Function to figure out if to install cronjob, credential-package, or none
             {{- if eq $os "bottlerocket" -}}
                 {{- $v := include "template.getBRVersion" . -}}
                 {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
-                    {{- if semverCompare "<=1.13" $v -}}
+                    {{- if semverCompare "<=1.13.1" $v -}}
                         {{- printf "cronjob" -}}
                     {{- else -}}
                         {{- printf "credential-package" -}}
                     {{- end -}}
                 {{- else -}}
-                    {{- if semverCompare "<=1.13" $v -}}
+                    {{- if semverCompare "<=1.13.1" $v -}}
                         {{- printf "cronjob" -}}
                     {{- else -}}
                         {{- printf "credential-package" -}}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
It appears that customer with BR 1.13.1 is still using CronJob. This change makes BR 1.13.1 use cronJob, and move to credential package on 1.13.2. Currently the logic for k1.25 and other versions are the same, but it's still kept as separate logic  in case we foresee further issues on BR with k1.25.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
