### PR TITLE
Bump metallb base image

### DIFF
--- a/generatebundlefile/data/bundles_prod/1-22.yaml
+++ b/generatebundlefile/data/bundles_prod/1-22.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-23.yaml
+++ b/generatebundlefile/data/bundles_prod/1-23.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-24.yaml
+++ b/generatebundlefile/data/bundles_prod/1-24.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_prod/1-25.yaml
+++ b/generatebundlefile/data/bundles_prod/1-25.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_prod/1-26.yaml
+++ b/generatebundlefile/data/bundles_prod/1-26.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_staging/1-22.yaml
+++ b/generatebundlefile/data/bundles_staging/1-22.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_staging/1-23.yaml
+++ b/generatebundlefile/data/bundles_staging/1-23.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_staging/1-24.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_staging/1-25.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -86,12 +86,12 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: prometheus
     projects:
       - name: prometheus

--- a/generatebundlefile/data/prod_artifact_move.yaml
+++ b/generatebundlefile/data/prod_artifact_move.yaml
@@ -67,14 +67,14 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -75,14 +75,14 @@ packages:
         repository: metallb/metallb
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.13.7-f6fa2d12ab0f0a3082eab915e4afdbd421d0e99d
+            - name: 0.13.7-a5ed31e0a9b3c06d35d72b4b261c16d7de931765
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
*Issue #, if available:* Bump the OS image to remove CVEs (even if we're not affected by it)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
