### PR TITLE
Support for Ubuntu 22.04 in credential package

### DIFF
--- a/credentialproviderpackage/charts/credential-provider-package/templates/_helpers.tpl
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/_helpers.tpl
@@ -75,14 +75,16 @@ Create image name
 {{/*
 Function to figure out os name
 */}}
-{{- define "template.getOSName" -}}
+{{- define "template.getOSType" -}}
 {{- with first ((lookup "v1" "Node" "" "").items) -}}
 {{- if contains "Bottlerocket" .status.nodeInfo.osImage -}}
 {{- printf "bottlerocket" -}}
 {{- else if contains "Amazon Linux" .status.nodeInfo.osImage -}}
-{{- printf "amazonlinux" -}}
+{{- printf "default" -}}
+{{- else if contains "Ubuntu 22.04" .status.nodeInfo.osImage -}}
+{{- printf "default" -}}
 {{- else -}}
-{{- printf "other" -}}
+{{- printf "sysconfig" -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
           volumeMounts:
             - name: aws-creds
               mountPath: /secrets/aws-creds
-            {{ $os := include "template.getOSName" .}}
+            {{ $os := include "template.getOSType" .}}
             {{- if eq $os "bottlerocket" }}
             - mountPath: /run/api.sock
               name: socket
@@ -67,7 +67,7 @@ spec:
         - name: socket
           hostPath:
             path: /run/api.sock
-        {{- else if eq $os "amazonlinux"}}
+        {{- else if eq $os "default"}}
         - name: kubelet-extra-args
           hostPath:
             path: /etc/default/kubelet


### PR DESCRIPTION
*Issue # *
Adding support for ubuntu 22.04 in credential package.

*Description of changes:*
Ubuntu changed from using /etc/sysconfig/kubelet to /etc/default/kubelet in 22.04. Updating volume mounts on credential package to support this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
