### PR TITLE
Pull eks-anywhere-packages-migrations images by sha256

### DIFF
--- a/charts/eks-anywhere-packages-migrations/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages-migrations/templates/_helpers.tpl
@@ -2,9 +2,5 @@
 Create image name
 */}}
 {{- define "template.image" -}}
-{{- if eq (substr 0 7 .tag) "sha256:" -}}
-{{- printf "/%s@%s" .repository .tag -}}
-{{- else -}}
-{{- printf "/%s:%s" .repository .tag -}}
-{{- end -}}
+{{- printf "/%s@%s" .repository .digest -}}
 {{- end -}}


### PR DESCRIPTION
*Issue #, if available:* After "copy packages" to a registry mirror, images doesn't exist in the registry mirror with tags. 

*Description of changes:* Pull eks-anywhere-packages-migrations images by sha256 instead of tag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
