### PR TITLE
Adjust eks-anywhere-packages tags to sha256 format

### DIFF
--- a/charts/eks-anywhere-packages-migrations/templates/_helpers.tpl
+++ b/charts/eks-anywhere-packages-migrations/templates/_helpers.tpl
@@ -2,5 +2,9 @@
 Create image name
 */}}
 {{- define "template.image" -}}
-{{- printf "/%s@%s" .repository .digest -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "/%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "/%s:%s" .repository .tag -}}
+{{- end -}}
 {{- end -}}

--- a/charts/eks-anywhere-packages-migrations/values.yaml
+++ b/charts/eks-anywhere-packages-migrations/values.yaml
@@ -7,6 +7,6 @@ controller:
   # -- Controller repository name.
   repository: "eks-anywhere-packages"
   # -- Controller image tag
-  tag: "{{eks-anywhere-packages-tag}}"
+  tag: "{{eks-anywhere-packages}}"
   # -- Controller image digest
   digest: "{{eks-anywhere-packages}}"

--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -80,7 +80,7 @@ controller:
   # -- Controller repository name.
   repository: "eks-anywhere-packages"
   # -- Controller image tag
-  tag: "{{eks-anywhere-packages-tag}}"
+  tag: "{{eks-anywhere-packages}}"
   # -- Controller image digest
   digest: "{{eks-anywhere-packages}}"
   # -- Whether to turn on Webhooks for the controller image
@@ -108,7 +108,7 @@ cronjob:
   # -- ECR refresher repository name.
   repository: "ecr-token-refresher"
   # -- ECR refresher tag
-  tag: "{{ecr-token-refresher-tag}}"
+  tag: "{{ecr-token-refresher}}"
   # -- ECR refresher digest
   digest: "{{ecr-token-refresher}}"
   suspend: true


### PR DESCRIPTION
*Issue #, if available:* In airgapped environment, registry-mirror needs to host curated packages images. Those images' urls can only be fetched from packageBundle. But packageBundle doesn't store tags information. So registry-mirror will not have tag info as well.

*Description of changes:* eks-anywhere-package helm chart and its dependencies switch to sha256 tag so it can pull images from registry-mirror


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
