### PR TITLE
Use real tag in eks-anywhere-packages

### DIFF
--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -80,7 +80,7 @@ controller:
   # -- Controller repository name.
   repository: "eks-anywhere-packages"
   # -- Controller image tag
-  tag: "{{eks-anywhere-packages}}"
+  tag: "{{eks-anywhere-packages-tag}}"
   # -- Controller image digest
   digest: "{{eks-anywhere-packages}}"
   # -- Whether to turn on Webhooks for the controller image
@@ -108,7 +108,7 @@ cronjob:
   # -- ECR refresher repository name.
   repository: "ecr-token-refresher"
   # -- ECR refresher tag
-  tag: "{{ecr-token-refresher}}"
+  tag: "{{ecr-token-refresher-tag}}"
   # -- ECR refresher digest
   digest: "{{ecr-token-refresher}}"
   suspend: true


### PR DESCRIPTION
*Issue #, if available:* we need to use real tag inside eks-anywhere-packages because some hack during release process depends on it.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
