### PR TITLE
Allow reconciler retry downloading bundle

### DIFF
--- a/pkg/bundle/manager.go
+++ b/pkg/bundle/manager.go
@@ -134,7 +134,7 @@ func (m *bundleManager) ProcessBundleController(ctx context.Context, pbc *api.Pa
 				return fmt.Errorf("updating %s status to %s: %s", pbc.Name, pbc.Status.State, err)
 			}
 		}
-		return nil
+		return err
 	}
 
 	allBundles, err := m.bundleClient.GetBundleList(ctx)

--- a/pkg/bundle/manager_test.go
+++ b/pkg/bundle/manager_test.go
@@ -302,7 +302,7 @@ func TestBundleManager_ProcessBundleController(t *testing.T) {
 
 		err := bm.ProcessBundleController(ctx, pbc)
 
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, api.BundleControllerStateDisconnected, pbc.Status.State)
 	})
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Allow reconciler to be rescheduled, when the secrets is being injected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
