### PR TITLE
Decrease wait time when pulling bundle failed

### DIFF
--- a/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
+++ b/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: eksa-packages
 spec:
   upgradeCheckInterval: 24h
-  upgradeCheckShortInterval: 5m
+  upgradeCheckShortInterval: 10s
   defaultRegistry: {{.Values.defaultRegistry}}
   defaultImageRegistry: {{.Values.defaultImageRegistry}}
   privateRegistry: {{.Values.privateRegistry}}


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* When EKSA create cluster, the cli command waits until the package bundle is available. However, when regional curated packages registry is used, the credential would not be available when the first reconciling is run, but it will be available shortly afterward as the credential injector finished its work. So this waiting period needs to be reduced from 1h to 10s, to make "create cluster" successful.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
