### PR TITLE
Fix Kubelet Args for 1.28

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,3 +11,4 @@ approvers:
 - lewisdiamond
 - TerryHowe
 - vincentni
+- tatlat

--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -217,8 +217,11 @@ func (c *linuxOS) createConfig() (string, error) {
 
 func (c *linuxOS) updateKubeletArguments(line string) string {
 	args := ""
-	if !strings.Contains(line, "KubeletCredentialProviders") {
-		args += " --feature-gates=KubeletCredentialProviders=true"
+	k8sVersion := os.Getenv("K8S_VERSION")
+	if semver.Compare(k8sVersion, "v1.26") < 0 {
+		if !strings.Contains(line, "KubeletCredentialProviders") {
+			args += " --feature-gates=KubeletCredentialProviders=true"
+		}
 	}
 
 	val, err := c.createConfig()


### PR DESCRIPTION
*Issue #, if available:*
KubeletCredentialProviders was GA'd in 1.26 and removed as a feature flag in 1.28. Adding the feature flag caused the kubelet to exit on startup when upgrading to a 1.28 cluster. 

*Description of changes:*
The KubeletCredentialProviders is now only added when k8s version is less than v1.26. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
