### PR TITLE
Add release clients for new build flow

### DIFF
--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -38,17 +38,17 @@ func GetSDKClients(newBuildMode bool) (*SDKClients, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create SDK connection to STS %s", err)
 	}
-	// ECR Private Connection with us-west-2 region
-	conf, err = config.LoadDefaultConfig(context.TODO(), config.WithRegion(ecrRegion))
-	if err != nil {
-		return nil, fmt.Errorf("loading default AWS config: %w", err)
-	}
+
 	ecrClient := ecr.NewFromConfig(conf)
 	clients.ecrClient, err = NewECRClient(ecrClient, true)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create SDK connection to ECR %s", err)
 	}
 
+	if newBuildMode {
+		clients.stsClientRelease = clients.stsClient
+		clients.ecrClientRelease = clients.ecrClient
+	}
 	if !newBuildMode {
 		// ECR Public Connection with us-east-1 region
 		conf, err = config.LoadDefaultConfig(context.TODO(), config.WithRegion(ecrPublicRegion))


### PR DESCRIPTION
* Make client creation flow use shared config
* ECR and STS clients are created to perform private ECR operations. In the new build flow, both source and release endpoints are private ECR, so we need these release clients too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
