### PR TITLE
Update env var and public key for regional builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean: ## Clean up resources created by make targets
 ##@ Build
 
 build: go.sum generate ## Build package-manager binary.
-	$(GO) build -o $(BIN_DIR)/package-manager main.go
+	CGO_ENABLED=0 $(GO) build -o $(BIN_DIR)/package-manager main.go
 
 run: manifests generate vet ## Run a controller from your host.
 	$(GO) run ./main.go server --verbosity 9

--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -38,8 +38,8 @@ function generate () {
     local kms_key=signingPackagesKey
 
     file_name=${version}.yaml
-    new_build_mode=${NEW_BUILD_MODE:-}
-    if [ "$new_build_mode" == "true" ]; then
+    regional_build_mode=${REGIONAL_BUILD_MODE:-}
+    if [ "$regional_build_mode" == "true" ]; then
         file_name=${version}-regional.yaml
     fi
 

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -23,8 +23,8 @@ export LANG=C.UTF-8
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 . "${BASE_DIRECTORY}/generatebundlefile/hack/common.sh"
 
-new_build_mode=${NEW_BUILD_MODE:-}
-if [ "$new_build_mode" == "true" ]; then
+regional_build_mode=${REGIONAL_BUILD_MODE:-}
+if [ "$regional_build_mode" == "true" ]; then
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
     REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
 else

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -25,11 +25,11 @@ func main() {
 	opts := NewOptions()
 	opts.SetupLogger()
 
-	newBuildModeEnvvar := os.Getenv("NEW_BUILD_MODE")
-	if newBuildModeEnvvar == "true" {
-		opts.newBuildMode = true
+	regionalBuildModeEnvvar := os.Getenv("REGIONAL_BUILD_MODE")
+	if regionalBuildModeEnvvar == "true" {
+		opts.regionalBuildMode = true
 	} else {
-		opts.newBuildMode = false
+		opts.regionalBuildMode = false
 	}
 
 	if opts.generateSample {
@@ -127,7 +127,7 @@ func cmdPromote(opts *Options) error {
 		}
 	}
 
-	clients, err := GetSDKClients(opts.newBuildMode)
+	clients, err := GetSDKClients(opts.regionalBuildMode)
 	if err != nil {
 		return fmt.Errorf("getting SDK clients: %w", err)
 	}
@@ -138,7 +138,7 @@ func cmdPromote(opts *Options) error {
 		},
 	}
 
-	if !opts.newBuildMode {
+	if !opts.regionalBuildMode {
 		clients.ecrPublicClient.SourceRegistry, err = clients.ecrPublicClient.GetRegistryURI()
 		if err != nil {
 			return fmt.Errorf("getting registry URI: %w", err)
@@ -429,7 +429,7 @@ func cmdGenerate(opts *Options) error {
 		// push packages to private ECR.
 		if opts.publicProfile != "" {
 			BundleLog.Info("Starting release public ECR process....")
-			clients, err := GetSDKClients(opts.newBuildMode)
+			clients, err := GetSDKClients(opts.regionalBuildMode)
 			if err != nil {
 				BundleLog.Error(err, "getting sdk clients")
 				os.Exit(1)
@@ -495,7 +495,7 @@ func cmdGenerate(opts *Options) error {
 		// if o.publicProfile != "" && if o.privateProfile != "" {}
 		if opts.privateProfile != "" {
 			BundleLog.Info("Starting release to private ECR process....")
-			clients, err := GetSDKClients(opts.newBuildMode)
+			clients, err := GetSDKClients(opts.regionalBuildMode)
 			if err != nil {
 				BundleLog.Error(err, "getting SDK clients")
 				os.Exit(1)

--- a/generatebundlefile/options.go
+++ b/generatebundlefile/options.go
@@ -24,7 +24,7 @@ type Options struct {
 	privateProfile string
 	bundleFile     string
 	regionCheck    bool
-	newBuildMode   bool
+	regionalBuildMode   bool
 }
 
 func (o *Options) SetupLogger() {

--- a/generatebundlefile/promote.go
+++ b/generatebundlefile/promote.go
@@ -24,7 +24,7 @@ type SDKClients struct {
 }
 
 // GetSDKClients is used to handle the creation of different SDK clients.
-func GetSDKClients(newBuildMode bool) (*SDKClients, error) {
+func GetSDKClients(regionalBuildMode bool) (*SDKClients, error) {
 	clients := &SDKClients{}
 	var err error
 
@@ -45,11 +45,11 @@ func GetSDKClients(newBuildMode bool) (*SDKClients, error) {
 		return nil, fmt.Errorf("Unable to create SDK connection to ECR %s", err)
 	}
 
-	if newBuildMode {
+	if regionalBuildMode {
 		clients.stsClientRelease = clients.stsClient
 		clients.ecrClientRelease = clients.ecrClient
 	}
-	if !newBuildMode {
+	if !regionalBuildMode {
 		// ECR Public Connection with us-east-1 region
 		conf, err = config.LoadDefaultConfig(context.TODO(), config.WithRegion(ecrPublicRegion))
 		if err != nil {

--- a/pkg/signature/manifest.go
+++ b/pkg/signature/manifest.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"os"
 	"path"
 	"strings"
 	"text/template"
@@ -18,13 +19,22 @@ import (
 )
 
 const (
-	PublicKey           = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP0Yo+ZxzPUEfohcG3bbJ8987UT4f0tj+XVBjS/s35wkfjrxTKrVZQpz3ta3zi5ZlgXzd7a20B1U1Py/TtPsxw=="
 	DomainName          = "eksa.aws.com"
 	SignatureAnnotation = "signature"
 	ExcludesAnnotation  = "excludes"
 )
 
-var EksaDomain = Domain{Name: DomainName, Pubkey: PublicKey}
+var PublicKey string
+var EksaDomain Domain
+
+func init() {
+	if os.Getenv("REGIONAL_BUILD_MODE") == "true" {
+		PublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELSnBPQf4H/GFb6yl6smKB9wwuKnD4goGHQYwg9+yQ1YusQNqZPn/QkVZnWCzJbZ/pksmpkno6dSzb/Hq+dBAMA=="
+	} else {
+		PublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP0Yo+ZxzPUEfohcG3bbJ8987UT4f0tj+XVBjS/s35wkfjrxTKrVZQpz3ta3zi5ZlgXzd7a20B1U1Py/TtPsxw=="
+	}
+	EksaDomain = Domain{Name: DomainName, Pubkey: PublicKey}
+}
 
 type GojqParams struct {
 	Excludes []string


### PR DESCRIPTION
The regional builds use a different public key for signing verification, so we need to update that.
  Also renaming `NEW_BUILD_MODE` to `REGIONAL_BUILD_MODE` across the board.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
