### PR TITLE
Use common public key for signing artifacts

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -35,7 +35,7 @@ function awsAuth () {
 function generate () {
     local version=$1
     local stage=$2
-    local kms_key=signingPackagesKey
+    local kms_key="arn:aws:kms:us-west-2:857151390494:alias/signingPackagesKey"
 
     file_name=${version}.yaml
     regional_build_mode=${REGIONAL_BUILD_MODE:-}
@@ -45,7 +45,7 @@ function generate () {
 
     cd "${BASE_DIRECTORY}/generatebundlefile"
     ./bin/generatebundlefile --input "./data/bundles_${stage}/$file_name" \
-                 --key alias/${kms_key} \
+                 --key ${kms_key} \
                  --output "output-${version}"
 }
 


### PR DESCRIPTION
This PR changes the bundle generation script to use a common public key for signing artifacts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
