### PR TITLE
Add input files for regional staging package bundle generation

### DIFF
--- a/generatebundlefile/bundle_test.go
+++ b/generatebundlefile/bundle_test.go
@@ -64,12 +64,14 @@ func TestNewBundleGenerate(t *testing.T) {
 	}
 }
 
-var testTagBundle string = "0.1.0_c4e25cb42e9bb88d2b8c2abfbde9f10ade39b214"
-var testShaBundle string = "sha256:d5467083c4d175e7e9bba823e95570d28fff86a2fbccb03f5ec3093db6f039be"
-var testImageMediaType string = "application/vnd.oci.image.manifest.v1+json"
-var testRegistryId string = "public.ecr.aws/eks-anywhere"
-var testRepositoryName string = "hello-eks-anywhere"
-var testAccountID string = "123456702424"
+var (
+	testTagBundle      string = "0.1.0_c4e25cb42e9bb88d2b8c2abfbde9f10ade39b214"
+	testShaBundle      string = "sha256:d5467083c4d175e7e9bba823e95570d28fff86a2fbccb03f5ec3093db6f039be"
+	testImageMediaType string = "application/vnd.oci.image.manifest.v1+json"
+	testRegistryId     string = "public.ecr.aws/eks-anywhere"
+	testRepositoryName string = "hello-eks-anywhere"
+	testAccountID      string = "123456702424"
+)
 
 func TestNewPackageFromInput(t *testing.T) {
 	client := newMockPublicRegistryClientBundle(nil)

--- a/generatebundlefile/data/bundles_staging/1-24-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24-regional.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
+name: "v1-24-1001"
+kubernetesVersion: "1.24"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.12-latest-helm
+          - name: 0.3.13-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
@@ -29,14 +29,14 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
   - org: cert-manager
@@ -44,59 +44,59 @@ packages:
       - name: cert-manager
         workloadonly: true
         repository: cert-manager/cert-manager
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
           - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
       - name: emissary-crds
         repository: emissary-ingress/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.7.1-3f95205edb1b6e80c9d424b12abd2d8ecbb57f54
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
+            - name: 9.21.0-1.24-f9017a890ac64959308c86f341b72cdc2c3a67a4
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
+            - name: 0.6.2-eks-1-24-13-da99883b9791fb9e8a6e135513f49b636583e40a
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
       - name: metallb-crds
         repository: metallb/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
 

--- a/generatebundlefile/data/bundles_staging/1-24.yaml
+++ b/generatebundlefile/data/bundles_staging/1-24.yaml
@@ -9,12 +9,12 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
@@ -24,7 +24,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-25-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25-regional.yaml
@@ -29,14 +29,14 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
   - org: cert-manager
@@ -44,59 +44,59 @@ packages:
       - name: cert-manager
         workloadonly: true
         repository: cert-manager/cert-manager
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
           - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
       - name: emissary-crds
         repository: emissary-ingress/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.7.1-3f95205edb1b6e80c9d424b12abd2d8ecbb57f54
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
       - name: metallb-crds
         repository: metallb/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
 

--- a/generatebundlefile/data/bundles_staging/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26-regional.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
+name: "v1-26-1001"
+kubernetesVersion: "1.26"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -29,14 +29,14 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
   - org: cert-manager
@@ -44,59 +44,59 @@ packages:
       - name: cert-manager
         workloadonly: true
         repository: cert-manager/cert-manager
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
           - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
       - name: emissary-crds
         repository: emissary-ingress/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.7.1-3f95205edb1b6e80c9d424b12abd2d8ecbb57f54
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
+            - name: 9.21.0-1.26-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
+            - name: 0.6.2-eks-1-26-5-da99883b9791fb9e8a6e135513f49b636583e40a
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
       - name: metallb-crds
         repository: metallb/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
 

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -9,12 +9,12 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
@@ -24,7 +24,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27-regional.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
+name: "v1-27-1001"
+kubernetesVersion: "1.27"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -29,14 +29,14 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
   - org: cert-manager
@@ -44,59 +44,59 @@ packages:
       - name: cert-manager
         workloadonly: true
         repository: cert-manager/cert-manager
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
           - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
       - name: emissary-crds
         repository: emissary-ingress/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.7.1-3f95205edb1b6e80c9d424b12abd2d8ecbb57f54
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
+            - name: 9.21.0-1.27-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
+            - name: 0.6.3-eks-1-27-4-21c206156e2f173a9471a992637eb43bf5147170
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
       - name: metallb-crds
         repository: metallb/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
 

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -9,12 +9,12 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
@@ -24,7 +24,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-28-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28-regional.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
+name: "v1-28-1001"
+kubernetesVersion: "1.28"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -29,14 +29,14 @@ packages:
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
   - org: cert-manager
@@ -44,59 +44,59 @@ packages:
       - name: cert-manager
         workloadonly: true
         repository: cert-manager/cert-manager
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
           - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
       - name: emissary-crds
         repository: emissary-ingress/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.7.1-3f95205edb1b6e80c9d424b12abd2d8ecbb57f54
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
+            - name: 9.21.0-1.28-f70bcf2d1cd0d76011744ac3bf6e757c0fe8fe37
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
+            - name: 0.6.4-eks-1-28-5-f2dc3c9bf04f185c4d14d443688c88418aa33dfc
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
       - name: metallb-crds
         repository: metallb/crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
-        registry: public.ecr.aws/w9m0f3l5
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
 

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -9,12 +9,12 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
@@ -24,7 +24,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -10,12 +10,12 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
             - name: 0.0.0-latest  # This is only used to move images for scanning, keep as 0.0.0-latest
-            - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+            - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
@@ -27,7 +27,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-3e751a8a3109bc790361d1b1032e6b432037155b
+          - name: 0.3.13-fc2d4466124ac722ec3bc83b00645c80476640ac
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -118,7 +118,7 @@ func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error
 		//
 		if strings.HasSuffix(tag.Name, "-latest") {
 			regex := regexp.MustCompile(`-latest`)
-			splitVersion := regex.Split(tag.Name, -1) //extract out the version without the latest
+			splitVersion := regex.Split(tag.Name, -1) // extract out the version without the latest
 			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
 			})
@@ -257,7 +257,7 @@ func (c *SDKClients) getNameAndVersion(repoName, tag, accountID string) (string,
 		// If tag contains -latest we do timestamp lookup of any tags matching a regexp of the specified tag.
 		if strings.Contains(tag, "-latest") {
 			regex := regexp.MustCompile(`-latest`)
-			splitVersion := regex.Split(tag, -1) //extract out the version without the latest
+			splitVersion := regex.Split(tag, -1) // extract out the version without the latest
 			ImageDetails, err := c.ecrClient.Describe(&ecr.DescribeImagesInput{
 				RepositoryName: aws.String(repoName),
 			})

--- a/generatebundlefile/ecr_public.go
+++ b/generatebundlefile/ecr_public.go
@@ -108,7 +108,7 @@ func (c *SDKClients) GetShaForPublicInputs(project Project) ([]api.SourceVersion
 		//
 		if strings.HasSuffix(tag.Name, "-latest") {
 			regex := regexp.MustCompile(`-latest`)
-			splitVersion := regex.Split(tag.Name, -1) //extract out the version without the latest
+			splitVersion := regex.Split(tag.Name, -1) // extract out the version without the latest
 			ImageDetails, err := c.ecrPublicClient.DescribePublic(&ecrpublic.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
 			})

--- a/generatebundlefile/ecr_test.go
+++ b/generatebundlefile/ecr_test.go
@@ -79,16 +79,16 @@ func TestSplitECRName(t *testing.T) {
 }
 
 func TestUnTarHelmChart(t *testing.T) {
-	//Construct a Valid temp Helm Chart and Targz it.
+	// Construct a Valid temp Helm Chart and Targz it.
 	var tarGZ string = "test.tgz"
-	err := os.Mkdir("hello-eks-anywhere", 0750)
+	err := os.Mkdir("hello-eks-anywhere", 0o750)
 	if err != nil {
 		t.Fatal("Error creating test dir:", err)
 	}
 	defer os.RemoveAll("hello-eks-anywhere")
 	f, err := os.Create("hello-eks-anywhere/Chart.yaml")
 	content := []byte("apiVersion: v2\nversion: 0.1.0\nappVersion: 0.1.0\nname: hello-eks-anywhere\n")
-	err = os.WriteFile("hello-eks-anywhere/Chart.yaml", content, 0644)
+	err = os.WriteFile("hello-eks-anywhere/Chart.yaml", content, 0o644)
 	if err != nil {
 		t.Fatal("Error creating test files:", err)
 	}
@@ -231,7 +231,7 @@ func TestTagFromSha(t *testing.T) {
 			wantErr:          false,
 		},
 	}
-	//images.Digest, err = ecrClient.tagFromSha(images.Repository, images.Digest)
+	// images.Digest, err = ecrClient.tagFromSha(images.Repository, images.Digest)
 	for _, tc := range tests {
 		t.Run(tc.testName, func(tt *testing.T) {
 			clients := &SDKClients{
@@ -250,7 +250,7 @@ func TestTagFromSha(t *testing.T) {
 	}
 }
 
-//Helper funcions
+// Helper funcions
 // to create the mocks "impl 'r *mockRegistryClient' registryClient"
 
 type mockPublicRegistryClient struct {
@@ -298,8 +298,10 @@ func newMockRegistryClient(err error) *mockRegistryClient {
 	}
 }
 
-var testTag1 string = "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660"
-var testTag2 string = "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea661"
+var (
+	testTag1 string = "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea660"
+	testTag2 string = "v0.1.1-baa4ef89fe91d65d3501336d95b680f8ae2ea661"
+)
 
 func (r *mockRegistryClient) DescribeImages(ctx context.Context, params *ecr.DescribeImagesInput, optFns ...func(*ecr.Options)) (*ecr.DescribeImagesOutput, error) {
 	if r.err != nil {

--- a/generatebundlefile/hack/policy.json
+++ b/generatebundlefile/hack/policy.json
@@ -3,6 +3,7 @@
         "transports": {
                 "docker": {
                         "857151390494.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
+                        "067575901363.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
                         "646717423341.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
                         "public.ecr.aws": [{"type": "insecureAcceptAnything"}]
                 }

--- a/generatebundlefile/helm.go
+++ b/generatebundlefile/helm.go
@@ -75,7 +75,7 @@ func UnTarHelmChart(chartRef, chartPath, dest string) error {
 	_, err := os.Stat(dest)
 	if os.IsNotExist(err) {
 		if _, err := os.Stat(chartPath); err != nil {
-			if err := os.MkdirAll(chartPath, 0755); err != nil {
+			if err := os.MkdirAll(chartPath, 0o755); err != nil {
 				return errors.Wrap(err, "failed to untar (mkdir)")
 			}
 		} else {

--- a/generatebundlefile/options.go
+++ b/generatebundlefile/options.go
@@ -13,18 +13,18 @@ import (
 
 // Options represents the flag for the current plugin
 type Options struct {
-	inputFile      string
-	outputFolder   string
-	generateSample bool
-	promote        string
-	tag            string
-	copyImages     bool
-	key            string
-	publicProfile  string
-	privateProfile string
-	bundleFile     string
-	regionCheck    bool
-	regionalBuildMode   bool
+	inputFile         string
+	outputFolder      string
+	generateSample    bool
+	promote           string
+	tag               string
+	copyImages        bool
+	key               string
+	publicProfile     string
+	privateProfile    string
+	bundleFile        string
+	regionCheck       bool
+	regionalBuildMode bool
 }
 
 func (o *Options) SetupLogger() {


### PR DESCRIPTION
* Add input files for regional staging package bundle generation 
* Promote `eks-anywhere-packages` (and related artifacts), `ecr-token-refresher`, `credential-provider-package` to public ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
