### PR TITLE
Stop promotion of Kubernetes v1.22 and v1.23 related artifacts

### DIFF
--- a/generatebundlefile/data/promote/autoscaler/promote.yaml
+++ b/generatebundlefile/data/promote/autoscaler/promote.yaml
@@ -37,17 +37,3 @@ packages:
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 9.21.0-1.24-latest
-  - org: cluster-autoscaler
-    projects:
-      - name: cluster-autoscaler
-        repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 9.21.0-1.23-latest
-  - org: cluster-autoscaler
-    projects:
-      - name: cluster-autoscaler
-        repository: cluster-autoscaler/charts/cluster-autoscaler
-        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 9.21.0-1.22-latest

--- a/generatebundlefile/data/promote/metrics-server/promote.yaml
+++ b/generatebundlefile/data/promote/metrics-server/promote.yaml
@@ -37,17 +37,3 @@ packages:
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.6.2-eks-1-24-latest
-  - org: metrics-server
-    projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
-        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 0.6.2-eks-1-23-latest
-  - org: metrics-server
-    projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
-        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 0.6.2-eks-1-22-latest


### PR DESCRIPTION
Stop promotion of Kubernetes v1.22 and v1.23 related artifacts for metrics-server and autoscaler since these versions are no longer supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
