### PR TITLE
Fix condition for running promote operation

### DIFF
--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -53,14 +53,13 @@ func main() {
 		return
 	}
 
-	if opts.promote != "" || opts.inputFile != "" {
+	// Run promotion operation if promote flag is provided or if running
+	// in regional build mode
+	if opts.promote != "" || opts.regionalBuildMode {
 		err := cmdPromote(opts)
 		if err != nil {
 			BundleLog.Error(err, "promoting curated package")
 			os.Exit(1)
-		}
-		if !opts.regionalBuildMode {
-			return
 		}
 	}
 


### PR DESCRIPTION
In regional builds, run promotions always. In non-regional builds, run promotion only if `promote` flag is specified.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
