### PR TITLE
Stop flow after promotion in case of non-regional build mode

### DIFF
--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -61,6 +61,9 @@ func main() {
 			BundleLog.Error(err, "promoting curated package")
 			os.Exit(1)
 		}
+		if !opts.regionalBuildMode {
+			return
+		}
 	}
 
 	if opts.regionCheck {


### PR DESCRIPTION
Stop flow after promotion in case of non-regional build mode. This is how it was previously, until one of the subsequent PRs removed it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
