### PR TITLE
Bump Metrics Server on Dev

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-25-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-25-regional.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-25-latest
+            - name: 0.6.4-eks-1-25-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-25.yaml
+++ b/generatebundlefile/data/bundles_dev/1-25.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.2-eks-1-25-latest
+            - name: 0.6.4-eks-1-25-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-26-regional.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.2-eks-1-26-latest
+            - name: 0.6.4-eks-1-26-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-26.yaml
+++ b/generatebundlefile/data/bundles_dev/1-26.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.2-eks-1-26-latest
+            - name: 0.6.4-eks-1-26-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-27-regional.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.3-eks-1-27-latest
+            - name: 0.6.4-eks-1-27-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-27.yaml
+++ b/generatebundlefile/data/bundles_dev/1-27.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.3-eks-1-27-latest
+            - name: 0.6.4-eks-1-27-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
Promote new metrics-server chart to dev.


*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2042

*Description of changes:*
Promotes new metrics-server version we are building to the dev packages bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->