### PR TITLE
Revert emissary to 3.6.0

### DIFF
--- a/generatebundlefile/data/promote/emissary/promote.yaml
+++ b/generatebundlefile/data/promote/emissary/promote.yaml
@@ -8,9 +8,9 @@ packages:
         repository: emissary-ingress/emissary
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-latest
+            - name: 3.6.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-latest
+            - name: 3.6.0-latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert Emissary package back down to 3.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

