### PR TITLE
Revert autoscaler version bump for release branch 1-24

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-24-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-24-regional.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.24-latest
+            - name: 9.21.0-1.24-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_dev/1-24.yaml
+++ b/generatebundlefile/data/bundles_dev/1-24.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 9.34.0-1.24-latest
+            - name: 9.21.0-1.24-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/promote/autoscaler/promote.yaml
+++ b/generatebundlefile/data/promote/autoscaler/promote.yaml
@@ -36,4 +36,4 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.24-latest
+            - name: 9.21.0-1.24-latest


### PR DESCRIPTION
*Issue #, if available:*
Revert Autoscaler version bump to latest 9.34 to previous version 9.21 as 1-24 release branch is deprecated and we do not build 1-24 Cluster-autoscaler with the latest version.
 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
