### PR TITLE
Bump metrics-server tag to 0.7.0 for Kubernetes 1.29

### DIFF
--- a/generatebundlefile/README.md
+++ b/generatebundlefile/README.md
@@ -45,7 +45,7 @@ This will output a sample bundle file to ./output.
 ### Public Promotion to another Account
 
 ```sh
-generatebundlefile --private-profile "profile-name" --input data/sample_input.yaml
+generatebundlefile --public-profile "profile-name" --input data/sample_input.yaml
 ```
 
 This command will move **Only** the helm chart from the listed input files to the target **public** ECR in another account.

--- a/generatebundlefile/data/bundles_dev/1-29-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29-regional.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-29-latest
+            - name: 0.7.0-eks-1-29-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-            - name: 0.6.4-eks-1-29-latest
+            - name: 0.7.0-eks-1-29-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/promote/metrics-server/promote.yaml
+++ b/generatebundlefile/data/promote/metrics-server/promote.yaml
@@ -8,7 +8,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-29-latest
+            - name: 0.7.0-eks-1-29-latest
   - org: metrics-server
     projects:
       - name: metrics-server


### PR DESCRIPTION
Bump metrics-server tag to 0.7.0 for Kubernetes 1.29.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
