### PR TITLE
Add logging for ECR Public lookup

### DIFF
--- a/generatebundlefile/ecr_public.go
+++ b/generatebundlefile/ecr_public.go
@@ -61,6 +61,7 @@ func (c *ecrPublicClient) DescribePublic(describeInput *ecrpublic.DescribeImages
 
 // GetShaForPublicInputs returns a list of an images version/sha for given inputs to lookup
 func (c *SDKClients) GetShaForPublicInputs(project Project) ([]api.SourceVersion, error) {
+	BundleLog.Info("Looking up ECR Public for image SHA", "Repository", project.Repository)
 	sourceVersion := []api.SourceVersion{}
 	for _, tag := range project.Versions {
 		if !strings.HasSuffix(tag.Name, "latest") {


### PR DESCRIPTION
Add logging for ECR Public image SHA lookup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
