### PR TITLE
Don't export AWS_PROFILE env var during login

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -35,7 +35,6 @@ function orasLogin () {
     else
         profile=${PROFILE:-}
     fi
-    export AWS_PROFILE=$profile
 
     aws "$awsCmd" "$region" --profile=$profile get-login-password | "$ORAS_BIN" login "$repo" --username AWS --password-stdin
 }


### PR DESCRIPTION
Don't export AWS_PROFILE env var during login as it leads to errors like
```
The config profile () could not be found
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
