### PR TITLE
Remove non-image artifacts from image index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOLANG_VERSION?="1.20"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
+ifeq (,$(shell $(GO) env GOBIN))
 GOBIN=$(shell $(GO) env GOPATH)/bin
 else
 GOBIN=$(shell $(GO) env GOBIN)
@@ -63,7 +63,7 @@ run-gofmt: ## Run gofmt against code.
 
 .PHONY: run-gci
 run-gci: $(GOBIN)/gci ## Run gci against code.
-	$(LS_FILES_CMD) | xargs $(GOBIN)/gci write --skip-generated -s standard,default -s "prefix($(shell go list -m))"
+	$(LS_FILES_CMD) | xargs $(GOBIN)/gci write --skip-generated -s standard,default -s "prefix($(shell $(GO) list -m))"
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint
@@ -181,7 +181,7 @@ endef
 
 ## Generate mocks
 mocks: mockgen controllers/mocks/client.go controllers/mocks/manager.go
-	PATH=$(BIN_DIR):$(PATH) go generate ./...
+	PATH=$(BIN_DIR):$(PATH) $(GO) generate ./...
 
 controllers/mocks/client.go: go.mod
 	PATH=$(shell $(GO) env GOROOT)/bin:$$PATH \

--- a/credentialproviderpackage/Makefile
+++ b/credentialproviderpackage/Makefile
@@ -7,10 +7,10 @@ GOLANG_VERSION?="1.19"
 GO ?= $(shell source $(REPO_ROOT)/scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+ifeq (,$(shell $(GO) env GOBIN))
+GOBIN=$(shell $(GO) env GOPATH)/bin
 else
-GOBIN=$(shell go env GOBIN)
+GOBIN=$(shell $(GO) env GOBIN)
 endif
 
 all: build

--- a/ecrtokenrefresher/Makefile
+++ b/ecrtokenrefresher/Makefile
@@ -6,10 +6,10 @@ GOLANG_VERSION?="1.19"
 GO ?= $(shell source $(REPO_ROOT)/scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+ifeq (,$(shell $(GO) env GOBIN))
+GOBIN=$(shell $(GO) env GOPATH)/bin
 else
-GOBIN=$(shell go env GOBIN)
+GOBIN=$(shell $(GO) env GOBIN)
 endif
 
 all: build

--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -22,10 +22,10 @@ endif
 IMG ?= controller:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+ifeq (,$(shell $(GO) env GOBIN))
+GOBIN=$(shell $(GO) env GOPATH)/bin
 else
-GOBIN=$(shell go env GOBIN)
+GOBIN=$(shell $(GO) env GOBIN)
 endif
 
 SHELL = /usr/bin/env bash -o pipefail

--- a/generatebundlefile/go.mod
+++ b/generatebundlefile/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/jinzhu/copier v0.3.5
 	github.com/pkg/errors v0.9.1
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.11.1
 	k8s.io/apimachinery v0.26.1

--- a/generatebundlefile/go.sum
+++ b/generatebundlefile/go.sum
@@ -684,6 +684,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/generatebundlefile/hack/policy.json
+++ b/generatebundlefile/hack/policy.json
@@ -6,6 +6,9 @@
                         "067575901363.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
                         "646717423341.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
                         "public.ecr.aws": [{"type": "insecureAcceptAnything"}]
+                },
+                "dir": {
+                        "": [{"type": "insecureAcceptAnything"}]
                 }
         }
 }


### PR DESCRIPTION
We pull ADOT images directly from public ECR in our builds and push to our ECR. In a recent release, ADOT maintainers added an SBOM artifact to their image manifest list (image index) which Skopeo doesn't support (https://github.com/containers/skopeo/issues/2174). So this PR adds the logic for modifying the manifest list to include only the amd64 and arm64 images for the project.

Tested this flow locally and confirmed skopeo copy of the modified manifest works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
