### PR TITLE
Add Kubernetes 1.29 prod packages bundle files, deprecate 1.24 prod packages

### DIFF
--- a/generatebundlefile/data/bundles_prod/1-25-regional.yaml
+++ b/generatebundlefile/data/bundles_prod/1-25-regional.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,59 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.25-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: kubernetes-sigs
+            - name: 9.34.0-1.25-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-25-25-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
 

--- a/generatebundlefile/data/bundles_prod/1-25.yaml
+++ b/generatebundlefile/data/bundles_prod/1-25.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
-  - org: kubernetes-sigs
+          - name: 9.34.0-1.25-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9-latest-helm
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/bundles_prod/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_prod/1-26-regional.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.26-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: kubernetes-sigs
+            - name: 9.34.0-1.26-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-26-21-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325

--- a/generatebundlefile/data/bundles_prod/1-26.yaml
+++ b/generatebundlefile/data/bundles_prod/1-26.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 9.21.0-1.26-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
-  - org: kubernetes-sigs
+          - name: 9.34.0-1.26-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.6.2-eks-1-26-5-da99883b9791fb9e8a6e135513f49b636583e40a
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/bundles_prod/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_prod/1-27-regional.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.27-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: kubernetes-sigs
+            - name: 9.34.0-1.27-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-27-15-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325

--- a/generatebundlefile/data/bundles_prod/1-27.yaml
+++ b/generatebundlefile/data/bundles_prod/1-27.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 9.21.0-1.27-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
-  - org: kubernetes-sigs
+          - name: 9.34.0-1.27-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.6.3-eks-1-27-4-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/bundles_prod/1-28-regional.yaml
+++ b/generatebundlefile/data/bundles_prod/1-28-regional.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.28-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: kubernetes-sigs
+            - name: 9.34.0-1.28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-28-8-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325

--- a/generatebundlefile/data/bundles_prod/1-28.yaml
+++ b/generatebundlefile/data/bundles_prod/1-28.yaml
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,62 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 9.21.0-1.28-f70bcf2d1cd0d76011744ac3bf6e757c0fe8fe37
-  - org: kubernetes-sigs
+          - name: 9.34.0-1.28-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.6.4-eks-1-28-5-f2dc3c9bf04f185c4d14d443688c88418aa33dfc
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9-latest-helm
+          - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/bundles_prod/1-29-regional.yaml
+++ b/generatebundlefile/data/bundles_prod/1-29-regional.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-24-1001"
-kubernetesVersion: "1.24"
+name: "v1-29-1001"
+kubernetesVersion: "1.29"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
-        versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.24-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-  - org: kubernetes-sigs
+            - name: 9.34.0-1.29-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-24-29-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325

--- a/generatebundlefile/data/bundles_prod/1-29.yaml
+++ b/generatebundlefile/data/bundles_prod/1-29.yaml
@@ -1,6 +1,6 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-24-1001"
-kubernetesVersion: "1.24"
+name: "v1-29-1001"
+kubernetesVersion: "1.29"
 minControllerVersion: "v0.3.2"
 packages:
   - org: aws
@@ -9,36 +9,36 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
-  - org: emissary
-    projects:
-      - name: emissary
-        repository: emissary-ingress/emissary
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-      - name: emissary-crds
-        repository: emissary-ingress/crds
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
-  - org: harbor
-    projects:
-      - name: harbor
-        repository: harbor/harbor-helm
-        registry: public.ecr.aws/eks-anywhere
-        versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 9.21.0-1.24-f9017a890ac64959308c86f341b72cdc2c3a67a4
-  - org: kubernetes-sigs
+          - name: 9.34.0-1.29-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+  - org: harbor
     projects:
-      - name: metrics-server
-        repository: metrics-server/charts/metrics-server
+      - name: harbor
+        repository: harbor/harbor-helm
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.6.2-eks-1-24-13-da99883b9791fb9e8a6e135513f49b636583e40a
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: metallb
+    projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/eks-anywhere
+        versions:
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/prod_artifact_move-regional.yaml
+++ b/generatebundlefile/data/prod_artifact_move-regional.yaml
@@ -10,38 +10,38 @@ packages:
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.0.0-latest  # This is only used to move images for scanning, keep as 0.0.0-latest
-            - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: credential-provider-package
         copyimages: true
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.3.13-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 0.3.13-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.1.2-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.1.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.25.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -49,66 +49,66 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.21.0-1.24-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 9.21.0-1.25-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 9.21.0-1.26-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 9.21.0-1.27-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 9.21.0-1.28-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 9.34.0-1.25-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.34.0-1.26-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.34.0-1.27-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.34.0-1.28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.34.0-1.29-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.7-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.6.4-eks-1-24-29-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 0.6.4-eks-1-25-25-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 0.6.4-eks-1-26-21-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 0.6.4-eks-1-27-15-93dbb0e58f98edc2cf246127109c680c0d7fec5c
-            - name: 0.6.4-eks-1-28-8-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.6.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.43.0-93dbb0e58f98edc2cf246127109c680c0d7fec5c
+            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325

--- a/generatebundlefile/data/prod_artifact_move.yaml
+++ b/generatebundlefile/data/prod_artifact_move.yaml
@@ -5,42 +5,39 @@ packages:
   - org: aws
     projects:
       - name: eks-anywhere-packages
-        copyimages: true
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
-        copyimages: true
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
-        copyimages: true
         repository: credential-provider-package
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-f13ac7d95b585105a84ab407eee13a0324d16a11
+          - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
         repository: hello-eks-anywhere
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.1.2-c014c0e09013bc7dcea65cc982712946d50ce582
+          - name: 0.1.2-latest-helm
   - org: aws-observability
     projects:
       - name: adot
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.25.0-ec883752f028661cbb3bda6083a77263226dca5a
+          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -48,68 +45,66 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 1.11.0-62f15756a0e14958d3ca963e6541dbda0a76e364
+          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 9.21.0-1.23-f9017a890ac64959308c86f341b72cdc2c3a67a4
-          - name: 9.21.0-1.24-f9017a890ac64959308c86f341b72cdc2c3a67a4
-          - name: 9.21.0-1.25-f9017a890ac64959308c86f341b72cdc2c3a67a4
-          - name: 9.21.0-1.26-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
-          - name: 9.21.0-1.27-f9017a890ac64959308c86f341b72cdc2c3a67a4-release-0.16-helm
-          - name: 9.21.0-1.28-f70bcf2d1cd0d76011744ac3bf6e757c0fe8fe37
+          - name: 9.34.0-1.25-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+          - name: 9.34.0-1.26-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.34.0-1.27-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.34.0-1.28-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.34.0-1.29-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.9.1-b42d4365dd463719ae87d661100a24a2456f7ebe
+          - name: 2.9.1-latest-helm
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.13.7-21c206156e2f173a9471a992637eb43bf5147170
+          - name: 0.13.12-latest-helm
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.6.2-eks-1-23-18-da99883b9791fb9e8a6e135513f49b636583e40a
-          - name: 0.6.2-eks-1-24-13-da99883b9791fb9e8a6e135513f49b636583e40a
-          - name: 0.6.2-eks-1-25-9-da99883b9791fb9e8a6e135513f49b636583e40a
-          - name: 0.6.2-eks-1-26-5-da99883b9791fb9e8a6e135513f49b636583e40a
-          - name: 0.6.3-eks-1-27-4-21c206156e2f173a9471a992637eb43bf5147170
-          - name: 0.6.4-eks-1-28-5-f2dc3c9bf04f185c4d14d443688c88418aa33dfc
+          - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9-latest-helm
+          - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
+          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 3.6.0-5fcc28fee80347ff96ab4d4f9fcf1c88b71b7f0a
+          - name: 3.9.1-latest-helm
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.43.0-0dfd662881d5a3a14830a9ca527908990cfb26f6
+          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -6,22 +6,22 @@ packages:
     projects:
       - name: eks-anywhere-packages
         repository: eks-anywhere-packages
-        registry: public.ecr.aws/w9m0f3l5
+        registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
-        registry: public.ecr.aws/w9m0f3l5
+        registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 0.3.13-latest-helm
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
-        registry: public.ecr.aws/w9m0f3l5
+        registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
       - name: credential-provider-package
         repository: credential-provider-package
-        registry: public.ecr.aws/w9m0f3l5
+        registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 0.0.0-e378a9d19cb5916261966156287d6fc747ec26a4-latest-helm
   - org: aws-containers

--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -32,6 +32,7 @@ function orasLogin () {
     regional_build_mode=${REGIONAL_BUILD_MODE:-}
     if [[ "$regional_build_mode" == "true" ]]; then
         profile=default
+        export AWS_PROFILE=$profile
     else
         profile=${PROFILE:-}
     fi

--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -98,12 +98,12 @@ fi
 # Generate Bundles from Public ECR
 export AWS_PROFILE=prod
 export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/prodconfigfile
-for version in 1-24 1-25 1-26 1-27 1-28; do
+for version in 1-25 1-26 1-27 1-28 1-29; do
     generate ${version} "prod"
 done
 
 # Push Bundles to Public ECR
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
-for version in 1-24 1-25 1-26 1-27 1-28; do
+for version in 1-25 1-26 1-27 1-28 1-29; do
     push ${version}
 done


### PR DESCRIPTION
Add Kubernetes 1.29 prod packages input files, deprecate 1.24 prod packages


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
