### PR TITLE
fix prometheus version sha conflict

### DIFF
--- a/generatebundlefile/data/bundles_prod/1-25.yaml
+++ b/generatebundlefile/data/bundles_prod/1-25.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_prod/1-26.yaml
+++ b/generatebundlefile/data/bundles_prod/1-26.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_prod/1-27.yaml
+++ b/generatebundlefile/data/bundles_prod/1-27.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_prod/1-28.yaml
+++ b/generatebundlefile/data/bundles_prod/1-28.yaml
@@ -104,4 +104,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_prod/1-29.yaml
+++ b/generatebundlefile/data/bundles_prod/1-29.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/eks-anywhere
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_staging/1-25.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/prod_artifact_move.yaml
+++ b/generatebundlefile/data/prod_artifact_move.yaml
@@ -110,4 +110,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -110,4 +110,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.49.1-19c7d1677a0b24e84a80647449d1324a6445b2d7
+          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076


### PR DESCRIPTION
*Description of changes:*
Fix prometheus version sha conflict. The helm points to the wrong sha digest for the given tag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
