### PR TITLE
Provide admission webhook decoder when instantiating CRD validators

### DIFF
--- a/pkg/packages/manager_test.go
+++ b/pkg/packages/manager_test.go
@@ -31,14 +31,14 @@ models:
   cj2a:
     year: "45"
 `
-)
-const newConfiguration = `
+	newConfiguration = `
 make: willys
 models:
   mc: "49"
   cj3a:
     year: "49"
 `
+)
 
 type PackageOCISource = api.PackageOCISource
 

--- a/pkg/webhook/package_webhook.go
+++ b/pkg/webhook/package_webhook.go
@@ -46,6 +46,7 @@ func InitPackageValidator(mgr ctrl.Manager) error {
 			&webhook.Admission{Handler: &packageValidator{
 				Client:       mgr.GetClient(),
 				BundleClient: bundle.NewManagerClient(mgr.GetClient()),
+				decoder:      admission.NewDecoder(mgr.GetScheme()),
 			}})
 	return nil
 }
@@ -156,10 +157,4 @@ func validatePackage(p *v1alpha1.Package, jsonSchema []byte) (*gojsonschema.Resu
 	configToValidate := gojsonschema.NewStringLoader(packageConfigString)
 
 	return schema.Validate(configToValidate)
-}
-
-// InjectDecoder injects the decoder.
-func (v *packageValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
 }

--- a/pkg/webhook/packagebundle_webhook.go
+++ b/pkg/webhook/packagebundle_webhook.go
@@ -51,6 +51,7 @@ func NewPackageBundleValidator(mgr ctrl.Manager) packageBundleValidator {
 		Client:       client,
 		BundleClient: bundle.NewManagerClient(client),
 		log:          mgr.GetLogger().WithName("webhook"),
+		decoder:      admission.NewDecoder(mgr.GetScheme()),
 	}
 }
 
@@ -108,11 +109,5 @@ func (v *packageBundleValidator) isPackageBundleValid(pb *v1alpha1.PackageBundle
 		v.log.Info("Invalid signature", "Error", err, "Digest", base64.StdEncoding.EncodeToString(digest[:]), "Manifest", string(yml))
 		return fmt.Errorf("The signature is invalid for the configured public key: " + domain.Pubkey)
 	}
-	return nil
-}
-
-// InjectDecoder injects the decoder.
-func (v *packageBundleValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
 	return nil
 }

--- a/pkg/webhook/packagebundle_webhook_test.go
+++ b/pkg/webhook/packagebundle_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere-packages/controllers/mocks"
@@ -19,6 +20,7 @@ func TestBundleValidate(t *testing.T) {
 	mockManager := mocks.NewMockManager(gomock.NewController(t))
 	mockManager.EXPECT().GetClient().Return(nil)
 	mockManager.EXPECT().GetLogger().Return(logr.Discard())
+	mockManager.EXPECT().GetScheme().Return(runtime.NewScheme())
 	sut := NewPackageBundleValidator(mockManager)
 
 	t.Run("missing signature", func(t *testing.T) {

--- a/pkg/webhook/packagebundlecontroller_webhook.go
+++ b/pkg/webhook/packagebundlecontroller_webhook.go
@@ -43,9 +43,10 @@ func InitPackageBundleControllerValidator(mgr ctrl.Manager) error {
 	mgr.GetWebhookServer().
 		Register("/validate-packages-eks-amazonaws-com-v1alpha1-packagebundlecontroller",
 			&webhook.Admission{Handler: &activeBundleValidator{
-				Client: mgr.GetClient(),
-				Config: mgr.GetConfig(),
-				tcc:    tcc,
+				Client:  mgr.GetClient(),
+				Config:  mgr.GetConfig(),
+				tcc:     tcc,
+				decoder: admission.NewDecoder(mgr.GetScheme()),
 			}})
 	return nil
 }
@@ -142,10 +143,4 @@ func (v *activeBundleValidator) handleInner(ctx context.Context, pbc *v1alpha1.P
 		},
 	}
 	return resp, nil
-}
-
-// InjectDecoder injects the decoder.
-func (v *activeBundleValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
 }


### PR DESCRIPTION
Recently we bumped controller-runtime (CR) from v0.14.4 to v0.16.5. In CR v0.15.0, they added a [change](https://github.com/kubernetes-sigs/controller-runtime/commit/927c09e54313d6476b5780b7f029f381d777c149) which removes logic for the injection of decoders. Hence we need to explicitly initialize the decoders when registering the validating webhook handlers for the packages CRDs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
