### PR TITLE
Use oras binary from builder-base image

### DIFF
--- a/generatebundlefile/Makefile
+++ b/generatebundlefile/Makefile
@@ -60,28 +60,3 @@ test:
 
 .PHONY: presubmit
 presubmit: build test # lint is run via github action
-
-## ORAS Make commands
-ORAS_VERSION := "0.12.0"
-ifeq ($(OS),Windows_NT)
-        # no op
-else
-	UNAME_S := $(shell uname -s)
-	UNAME_M := $(shell uname -m)
-	ifeq ($(UNAME_S),Linux)
-		ifeq ($(UNAME_M),x86_64)
-			ORAS_OSARCH := "linux_amd64"
-		endif
-	endif
-	ifeq ($(UNAME_S),Darwin)
-		ifeq ($(UNAME_M),x86_64)
-			ORAS_OSARCH := "darwin_amd64"
-		endif
-	endif
-endif
-
-.PHONY: oras-install
-oras-install:
-	mkdir -p $(REPO_ROOT)/bin
-	curl -L -s https://github.com/oras-project/oras/releases/download/v$(ORAS_VERSION)/oras_$(ORAS_VERSION)_$(ORAS_OSARCH).tar.gz \
-		| tar zx -C $(REPO_ROOT)/bin oras

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -31,11 +31,6 @@ else
     REGISTRY=$(aws ecr-public --region us-east-1 describe-registries --query 'registries[*].registryUri' --output text)
 fi
 REPO=${REGISTRY}/eks-anywhere-packages-bundles
-ORAS_BIN=${BASE_DIRECTORY}/bin/oras
-
-if [ ! -x "${ORAS_BIN}" ]; then
-    make oras-install
-fi
 
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin

--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -25,7 +25,6 @@ BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 export CODEBUILD_BUILD_NUMBER=$(($CODEBUILD_BUILD_NUMBER+110))
 
 . "${BASE_DIRECTORY}/generatebundlefile/hack/common.sh"
-ORAS_BIN=${BASE_DIRECTORY}/bin/oras
 
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile
@@ -90,10 +89,6 @@ REPO=${REGISTRY}/eks-anywhere-packages-bundles
 ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
     --input ${BASE_DIRECTORY}/generatebundlefile/data/${file_name} \
     --public-profile ${PROFILE}
-
-if [ ! -x "${ORAS_BIN}" ]; then
-    make oras-install
-fi
 
 # Generate Bundles from Public ECR
 export AWS_PROFILE=prod

--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -24,7 +24,6 @@ BASE_AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 
 . "${BASE_DIRECTORY}/generatebundlefile/hack/common.sh"
-ORAS_BIN=${BASE_DIRECTORY}/bin/oras
 
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile
@@ -89,10 +88,6 @@ REPO=${REGISTRY}/eks-anywhere-packages-bundles
 ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
     --input ${BASE_DIRECTORY}/generatebundlefile/data/${file_name} \
     --public-profile ${PROFILE}
-
-if [ ! -x "${ORAS_BIN}" ]; then
-    make oras-install
-fi
 
 # Generate Bundles from Public ECR
 export AWS_PROFILE=staging


### PR DESCRIPTION
This PR changes the build scripts to use `oras` from the builder-base image instead of installing it ourselves.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
