### PR TITLE
Fix AWS profile arg for ECR login

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -29,15 +29,13 @@ function orasLogin () {
         region="--region=us-east-1"
     fi
 
-    regional_build_mode=${REGIONAL_BUILD_MODE:-}
-    if [[ "$regional_build_mode" == "true" ]]; then
-        profile=default
-        export AWS_PROFILE=$profile
-    else
-        profile=${PROFILE:-}
+    profile=${PROFILE:-}
+    profile_arg=""
+    if [ -n "$profile" ]; then
+        profile_arg="--profile=$profile"
     fi
 
-    aws "$awsCmd" "$region" --profile=$profile get-login-password | "$ORAS_BIN" login "$repo" --username AWS --password-stdin
+    aws "$awsCmd" "$region" $profile_arg get-login-password | "$ORAS_BIN" login "$repo" --username AWS --password-stdin
 }
 
 function generate () {


### PR DESCRIPTION
Fixes the error
```console
The config profile (default) could not be found
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
