### PR TITLE
Fix Registry Secrets

### DIFF
--- a/pkg/artifacts/registry.go
+++ b/pkg/artifacts/registry.go
@@ -42,7 +42,8 @@ func (p *RegistryPuller) Pull(ctx context.Context, ref string, clusterName strin
 		store = registry.NewDockerCredentialStore(configFile)
 	}
 
-	sc := registry.NewStorageContext(art.Registry, store, certificates, false)
+	insecure := registry.GetRegistryInsecure(clusterName)
+	sc := registry.NewStorageContext(art.Registry, store, certificates, insecure)
 	remoteRegistry, err := remote.NewRegistry(art.Registry)
 	if err != nil {
 		return nil, err

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -25,7 +25,8 @@ const (
 	retryLong      = time.Duration(60) * time.Second
 	retryVeryLong  = time.Duration(180) * time.Second
 	sourceRegistry = "sourceRegistry"
-	secretName     = "registryMirrorSecret"
+	registrySecret = "registryMirrorSecret"
+	secretName     = "registry-mirror-secret"
 )
 
 type ManagerContext struct {
@@ -150,13 +151,15 @@ func processInstalling(mc *ManagerContext) bool {
 		return true
 	}
 	values[sourceRegistry] = mc.getImageRegistry(values)
-	registryMirrorSecret, err := mc.ManagerClient.GetSecret(mc.Ctx, "registry-mirror-secret")
+	registryMirrorSecret, err := mc.ManagerClient.GetSecret(mc.Ctx, secretName)
 	if err != nil {
 		mc.Package.Status.Detail = err.Error()
 		mc.Log.Error(err, "Install failed")
 		return true
 	}
-	values[secretName] = registryMirrorSecret.Data
+	if registryMirrorSecret != nil {
+		values[registrySecret] = registryMirrorSecret.Data
+	}
 	if mc.Source.Registry == "" {
 		mc.Source.Registry = mc.PBC.GetDefaultRegistry()
 	}

--- a/pkg/packages/manager.go
+++ b/pkg/packages/manager.go
@@ -25,6 +25,7 @@ const (
 	retryLong      = time.Duration(60) * time.Second
 	retryVeryLong  = time.Duration(180) * time.Second
 	sourceRegistry = "sourceRegistry"
+	secretName     = "registryMirrorSecret"
 )
 
 type ManagerContext struct {
@@ -149,6 +150,13 @@ func processInstalling(mc *ManagerContext) bool {
 		return true
 	}
 	values[sourceRegistry] = mc.getImageRegistry(values)
+	registryMirrorSecret, err := mc.ManagerClient.GetSecret(mc.Ctx, "registry-mirror-secret")
+	if err != nil {
+		mc.Package.Status.Detail = err.Error()
+		mc.Log.Error(err, "Install failed")
+		return true
+	}
+	values[secretName] = registryMirrorSecret.Data
 	if mc.Source.Registry == "" {
 		mc.Source.Registry = mc.PBC.GetDefaultRegistry()
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After the initial install of eks-anywhere-packages by eks-anywhere, packages will pull down the packagebundle (PB) and update itself using the version in the PB. This PR adds the registry mirror secret data to the overriden values, so that packages can still use registry mirror after the upgrade. 

We should also use the insecure field when pulling from the registry instead of hardcoding it to false.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
