### PR TITLE
Conditionally install registry mirror secret with Helm chart

### DIFF
--- a/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
+++ b/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
@@ -1,14 +1,16 @@
 {{- $render := include "eks-anywhere-packages.rendertype" . }}
-{{- if or (eq $render "controller") (eq $render "workload") }}
+{{- $workloadNamespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
+{{- if (eq $render "controller") }}
+# We are creating the Secret only if it is not found or if endpoint is not empty.
+# This condition ensures the secret is not accidentally set to empty values.
+{{- if or (not (lookup "v1" "Secret" "eksa-packages" "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
   name: registry-mirror-secret
-  {{- if eq $render "controller" }}
   namespace: {{ .Values.namespace }}
-  {{- else if eq $render "workload" }}
-  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
-  {{- end }}
 data:
   {{- with .Values.registryMirrorSecret }}
   ENDPOINT: "{{ .endpoint }}"
@@ -18,4 +20,26 @@ data:
   INSECURE: "{{ .insecure }}"
   {{- end }}
 type: Opaque
+{{- end }}
+{{- end }}
+# Similar condition when installing on a workload cluster.
+{{- if (eq $render "workload") }}
+{{- if or (not (lookup "v1" "Secret" $workloadNamespace "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: registry-mirror-secret
+  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
+data:
+  {{- with .Values.registryMirrorSecret }}
+  ENDPOINT: "{{ .endpoint }}"
+  USERNAME: "{{ .username }}"
+  PASSWORD: "{{ .password }}"
+  CACERTCONTENT: "{{ .cacertcontent }}"
+  INSECURE: "{{ .insecure }}"
+  {{- end }}
+type: Opaque
+{{- end }}
 {{- end }}


### PR DESCRIPTION
*Issues:*
https://github.com/aws/eks-anywhere/issues/7114
https://github.com/aws/eks-anywhere-internal/issues/2268

*Description of changes:*
The changes to the helm chart conditionally create the registry mirror secret. The values for the secret are inputted from EKS-A when helm installing `eks-anywhere-packages` on a cluster with registry mirror configuration.

But whenever the `eks-anywhere-packages` package was updated; when we have a new active bundle on the PBC we run into a scenario where the values are not found and the secret got empty (as described on the issues above).

The changes now ensure that the helm chart secret is only recreated either 
1. The secret is not found on the cluster
2. There are values to be updated with for the secret

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
