### PR TITLE
Moving helm chart comment block

### DIFF
--- a/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
+++ b/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
@@ -1,9 +1,10 @@
 {{- $render := include "eks-anywhere-packages.rendertype" . }}
 {{- $workloadNamespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
 {{- if (eq $render "controller") }}
-# We are creating the Secret only if it is not found or if endpoint is not empty.
-# This condition ensures the secret is not accidentally set to empty values.
 {{- if or (not (lookup "v1" "Secret" "eksa-packages" "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
+# We are creating the Secret only if it is not found or if endpoint is not empty
+# This condition ensures the secret is not accidentally set to empty values
+# Similar condition when installing on a workload cluster
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,7 +23,6 @@ data:
 type: Opaque
 {{- end }}
 {{- end }}
-# Similar condition when installing on a workload cluster.
 {{- if (eq $render "workload") }}
 {{- if or (not (lookup "v1" "Secret" $workloadNamespace "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
 apiVersion: v1


### PR DESCRIPTION
*Description of changes:*
Helm has an issue where its not parsing the comment block properly. Similar issues mentioned on this [post](https://stackoverflow.com/a/63383447/13156793). Helm template gives

```yaml
# This condition ensures the secret is not accidentally set to empty values.apiVersion: v1
kind: Secret
metadata:
  annotations:
```
The `apiVersion: v1` should have been parsed as part of the yaml but its being added to comment.

Moved the comments and ran template to check issue was resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
