### PR TITLE
Adding reg mirror sec creation on flag workloadPackageOnly

### DIFF
--- a/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
+++ b/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
@@ -23,7 +23,7 @@ data:
 type: Opaque
 {{- end }}
 {{- end }}
-{{- if (eq $render "workload") }}
+{{- if or (eq $render "workload") (eq $render "package") }}
 {{- if or (not (lookup "v1" "Secret" $workloadNamespace "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2268*

*Description of changes:*
When creating workload clusters from an EKS-A management cluster using the eks-a controller workflow, we have set a flag `workloadPackageOnly` which creates a `eks-anywhere-packages` package object on the cluster. 

This then reconciles and creates the necessary PBC and dependent packages for a workload cluster.

But the `registry-mirror-secret` values are inputted from EKS-A; thereby they were always empty for a workload cluster with registry mirror configured. This fix enables creating the secret for workload cluster during install from EKS-A controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
