### PR TITLE
Updating registry mirror CA cert in PBC controller reconcile

### DIFF
--- a/api/v1alpha1/packagebundlecontroller.go
+++ b/api/v1alpha1/packagebundlecontroller.go
@@ -37,3 +37,8 @@ func (config *PackageBundleController) GetBundleURI() (uri string) {
 func (config *PackageBundleController) GetActiveBundleURI() (uri string) {
 	return config.GetBundleURI() + ":" + config.Spec.ActiveBundle
 }
+
+// IsDefaultRegistryDefault checks if the PBC DefaultRegistry is public.ecr.aws/eks-anywhere
+func (config *PackageBundleController) IsDefaultRegistryDefault() bool {
+	return config.GetDefaultRegistry() == defaultRegistry
+}

--- a/api/v1alpha1/packagebundlecontroller_test.go
+++ b/api/v1alpha1/packagebundlecontroller_test.go
@@ -53,3 +53,10 @@ func TestPackageBundleController_GetActiveBundleURI(t *testing.T) {
 	sut := GivenPackageBundleController()
 	assert.Equal(t, "public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles:v1-21-1003", sut.GetActiveBundleURI())
 }
+
+func TestPackageBundleController_IsDefaultRegistryDefault(t *testing.T) {
+	sut := GivenPackageBundleController()
+	assert.Equal(t, false, sut.IsDefaultRegistryDefault())
+	sut.Spec.DefaultRegistry = "public.ecr.aws/eks-anywhere"
+	assert.Equal(t, true, sut.IsDefaultRegistryDefault())
+}

--- a/pkg/bundle/client.go
+++ b/pkg/bundle/client.go
@@ -135,7 +135,7 @@ func (bc *managerClient) GetSecret(ctx context.Context, name string) (secret *v1
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("aws-secret error:%v", err)
+		return nil, fmt.Errorf("getting secret %s error:%v", nn.String(), err)
 	}
 
 	return secret, nil

--- a/pkg/registry/certinjector.go
+++ b/pkg/registry/certinjector.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+)
+
+const (
+	registryMirrorCredName   = "registry-mirror-cred"
+	registryMirrorSecretName = "registry-mirror-secret"
+)
+
+type CertInjector struct {
+	k8sClient client.Client
+	log       logr.Logger
+}
+
+// NewCertInjector creates a new CertInjector.
+func NewCertInjector(k8sClient client.Client, log logr.Logger) *CertInjector {
+	return &CertInjector{
+		k8sClient: k8sClient,
+		log:       log,
+	}
+}
+
+// UpdateIfNeeded is responsible for verifying the registry CA cert is available on the mounted `registry-mirror-cred` secret.
+func (ci *CertInjector) UpdateIfNeeded(ctx context.Context, clusterName string) error {
+	certContent, err := ci.fetchCertContent(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("fetching CA cert content: %v", err)
+	}
+	if certContent == nil {
+		ci.log.Info("No CA cert content found", "cluster", clusterName)
+		return nil
+	}
+
+	registryMirrorCred := &corev1.Secret{}
+	credSecretName := types.NamespacedName{Name: registryMirrorCredName, Namespace: api.PackageNamespace}
+	if err := ci.k8sClient.Get(ctx, credSecretName, registryMirrorCred); err != nil {
+		return fmt.Errorf("getting secret %s: %s", credSecretName.String(), err)
+	}
+
+	credCertKey := fmt.Sprintf("%s_ca.crt", clusterName)
+	if _, ok := registryMirrorCred.Data[credCertKey]; !ok {
+		ci.log.Info("Updating registry CA cert", "cluster", clusterName, "secret", registryMirrorCredName)
+		registryMirrorCred.Data[credCertKey] = certContent
+		if err := ci.k8sClient.Update(ctx, registryMirrorCred, &client.UpdateOptions{}); err != nil {
+			return fmt.Errorf("updating secret %s: %s", credSecretName.String(), err)
+		}
+	} else {
+		ci.log.Info("CA Cert already updated", "cluster", clusterName)
+	}
+
+	return nil
+}
+
+// fetchCertContent fetches the CA cert content from `registry-mirror-secret` in the cluster namespace.
+// If CACERTCONTENT is empty; we return nil.
+// Else we return the contents.
+func (ci *CertInjector) fetchCertContent(ctx context.Context, clusterName string) ([]byte, error) {
+	managementClusterName := os.Getenv("CLUSTER_NAME")
+	registryMirrorSecret := &corev1.Secret{}
+	nn := types.NamespacedName{Name: registryMirrorSecretName, Namespace: api.PackageNamespace}
+	if clusterName != managementClusterName {
+		nn = types.NamespacedName{Name: registryMirrorSecretName, Namespace: fmt.Sprintf("%s-%s", api.PackageNamespace, clusterName)}
+	}
+
+	if err := ci.k8sClient.Get(ctx, nn, registryMirrorSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			ci.log.Info("Registry mirror secret not found: %v", err)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting secret %s: %s", nn.String(), err)
+	}
+
+	if len(registryMirrorSecret.Data["CACERTCONTENT"]) > 0 {
+		return registryMirrorSecret.Data["CACERTCONTENT"], nil
+	}
+
+	return nil, nil
+}

--- a/pkg/registry/certinjector_test.go
+++ b/pkg/registry/certinjector_test.go
@@ -1,0 +1,156 @@
+package registry_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	"github.com/aws/eks-anywhere-packages/controllers/mocks"
+	"github.com/aws/eks-anywhere-packages/pkg/registry"
+)
+
+func TestUpdateIfNeededSuccess(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(gomock.NewController(t))
+	regSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-mirror-secret",
+			Namespace: "eksa-packages-test-cluster",
+		},
+		Data: map[string][]byte{
+			"CACERTCONTENT": bytes.NewBufferString("AAA").Bytes(),
+		},
+	}
+	regCredSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-mirror-cred",
+			Namespace: api.PackageNamespace,
+		},
+		Data: make(map[string][]byte),
+	}
+	mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regSecret.Name, Namespace: regSecret.Namespace}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+			regSecret.DeepCopyInto(s)
+			return nil
+		})
+	mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regCredSecret.Name, Namespace: regCredSecret.Namespace}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+			regCredSecret.DeepCopyInto(s)
+			return nil
+		})
+	mockClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Return(nil)
+
+	ci := registry.NewCertInjector(mockClient, logr.Discard())
+	err := ci.UpdateIfNeeded(ctx, "test-cluster")
+	assert.ErrorIs(t, err, nil)
+}
+
+func TestUpdateIfNeededSuccessCertUpdated(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(gomock.NewController(t))
+	regSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-mirror-secret",
+			Namespace: "eksa-packages-test-cluster",
+		},
+		Data: map[string][]byte{
+			"CACERTCONTENT": bytes.NewBufferString("AAA").Bytes(),
+		},
+	}
+	regCredSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-mirror-cred",
+			Namespace: api.PackageNamespace,
+		},
+		Data: map[string][]byte{
+			"test-cluster_ca.crt": bytes.NewBufferString("AAA").Bytes(),
+		},
+	}
+	mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regSecret.Name, Namespace: regSecret.Namespace}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+			regSecret.DeepCopyInto(s)
+			return nil
+		})
+	mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regCredSecret.Name, Namespace: regCredSecret.Namespace}, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+			regCredSecret.DeepCopyInto(s)
+			return nil
+		})
+
+	ci := registry.NewCertInjector(mockClient, logr.Discard())
+	err := ci.UpdateIfNeeded(ctx, "test-cluster")
+	assert.ErrorIs(t, err, nil)
+}
+
+func TestUpdateIfNeededError(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks.NewMockClient(gomock.NewController(t))
+	t.Run("registry mirror secret not found", func(t *testing.T) {
+		mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: "registry-mirror-secret", Namespace: "eksa-packages-test-cluster"}, gomock.Any()).
+			Return(apierrors.NewNotFound(corev1.Resource("secret"), "registry-mirror-secret"))
+		ci := registry.NewCertInjector(mockClient, logr.Discard())
+		err := ci.UpdateIfNeeded(ctx, "test-cluster")
+		assert.ErrorIs(t, err, nil)
+	})
+
+	t.Run("registry mirror secret get error", func(t *testing.T) {
+		mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: "registry-mirror-secret", Namespace: "eksa-packages-test-cluster"}, gomock.Any()).
+			Return(errors.New("get error"))
+		ci := registry.NewCertInjector(mockClient, logr.Discard())
+		err := ci.UpdateIfNeeded(ctx, "test-cluster")
+		assert.ErrorContains(t, err, "fetching CA cert content: getting secret")
+	})
+
+	t.Run("registry mirror secret CA content not found", func(t *testing.T) {
+		regSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "registry-mirror-secret",
+				Namespace: "eksa-packages-test-cluster",
+			},
+			Data: map[string][]byte{
+				"CACERTCONTENT": make([]byte, 0),
+			},
+		}
+		mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regSecret.Name, Namespace: regSecret.Namespace}, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+				regSecret.DeepCopyInto(s)
+				return nil
+			})
+		ci := registry.NewCertInjector(mockClient, logr.Discard())
+		err := ci.UpdateIfNeeded(ctx, "test-cluster")
+		assert.ErrorIs(t, err, nil)
+	})
+
+	t.Run("registry mirror cred secret get error", func(t *testing.T) {
+		regSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "registry-mirror-secret",
+				Namespace: "eksa-packages-test-cluster",
+			},
+			Data: map[string][]byte{
+				"CACERTCONTENT": bytes.NewBufferString("AAA").Bytes(),
+			},
+		}
+		mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: regSecret.Name, Namespace: regSecret.Namespace}, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, name types.NamespacedName, s *corev1.Secret, _ ...client.GetOption) error {
+				regSecret.DeepCopyInto(s)
+				return nil
+			})
+		mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: "registry-mirror-cred", Namespace: "eksa-packages"}, gomock.Any()).
+			Return(errors.New("get error"))
+		ci := registry.NewCertInjector(mockClient, logr.Discard())
+		err := ci.UpdateIfNeeded(ctx, "test-cluster")
+		assert.ErrorContains(t, err, "getting secret")
+	})
+}


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2269:*

*Description of changes:*
Packages controller pod has a mounted secret `registry-mirror-cred`. This secret creates the CA cert on the pod with the name `<cluster-name>_ca.crt`.

When dealing with multiple clusters; specifically when workload clusters are created from EKS-A. The packages controller pod fails with an 
```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```
As the new cluster's CA cert is not updated on the mounted secret.

These changes add a step in the PBC controller workflow that checks the mounted secret and updates the registry CA cert if the field is missing in the data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
