### PR TITLE
Creating namespace for workload cluster packages

### DIFF
--- a/charts/eks-anywhere-packages/templates/namespace.yaml
+++ b/charts/eks-anywhere-packages/templates/namespace.yaml
@@ -28,7 +28,6 @@ metadata:
 {{- end }}
 {{- end }}
 
-{{- if not (eq $render "package") }}
 {{ $pkgnamespace := (printf "%s-%s" "eksa-packages" .Values.clusterName) }}
 {{- if not (lookup "v1" "Namespace" "" $pkgnamespace ) -}}
 apiVersion: v1
@@ -37,5 +36,4 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   name: {{ $pkgnamespace }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
*Description of changes:*
We need the `eksa-package-<clustername>` namespace to exist to create the registry-mirror-secret for workload clusters from EKS-A.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
