### PR TITLE
Fix packages migration chart tag to latest

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-25.yaml
+++ b/generatebundlefile/data/bundles_staging/1-25.yaml
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -19,7 +19,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -20,7 +20,7 @@ packages:
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.0.0-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
+          - name: 0.4.2-latest-helm
       - name: credential-provider-package
         copyimages: true
         repository: credential-provider-package

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -14,13 +14,13 @@ packages:
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-latest-helm
+          - name: 0.4.2-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.3.13-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 0.0.0-237fd9658c4c5d4a6093c4c89881e9cccd0448bb
       - name: credential-provider-package
         copyimages: true
         repository: credential-provider-package


### PR DESCRIPTION
*Issue #, if available:*
The current tag for `eks-anywhere-packages-migrations` is unavailable on public ecr. Update it to the latest tag that's present in our build account 
  
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
