### PR TITLE
Fixing log message when secret not found

### DIFF
--- a/pkg/registry/certinjector.go
+++ b/pkg/registry/certinjector.go
@@ -76,7 +76,7 @@ func (ci *CertInjector) fetchCertContent(ctx context.Context, clusterName string
 
 	if err := ci.k8sClient.Get(ctx, nn, registryMirrorSecret); err != nil {
 		if apierrors.IsNotFound(err) {
-			ci.log.Info("Registry mirror secret not found: %v", err)
+			ci.log.Info("Registry mirror secret not found", "error", err)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("getting secret %s: %s", nn.String(), err)


### PR DESCRIPTION
*Description of changes:*
Logger panics because error key was not specified.

```bash
2024-04-29T17:11:34.682Z	PackageBundleController	odd number of arguments passed as key-value pairs for logging	{"ignored key": "Secret \"registry-mirror-secret\" not found"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
