### PR TITLE
Adding secret defaulting and always look up reg secret

### DIFF
--- a/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
+++ b/charts/eks-anywhere-packages/templates/registrymirrorsecret.yaml
@@ -1,45 +1,41 @@
 {{- $render := include "eks-anywhere-packages.rendertype" . }}
-{{- $workloadNamespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
-{{- if (eq $render "controller") }}
-{{- if or (not (lookup "v1" "Secret" "eksa-packages" "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
-# We are creating the Secret only if it is not found or if endpoint is not empty
-# This condition ensures the secret is not accidentally set to empty values
-# Similar condition when installing on a workload cluster
+{{- $namespace := .Values.namespace }}
+{{- $regSecret := (lookup "v1" "Secret" $namespace "registry-mirror-secret") }}
+{{- if (ne $render "controller") }}
+{{- $namespace = printf "%s-%s" $namespace .Values.clusterName -}}
+{{- $regSecret = (lookup "v1" "Secret" $namespace "registry-mirror-secret") }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
   name: registry-mirror-secret
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
 data:
-  {{- with .Values.registryMirrorSecret }}
-  ENDPOINT: "{{ .endpoint }}"
-  USERNAME: "{{ .username }}"
-  PASSWORD: "{{ .password }}"
-  CACERTCONTENT: "{{ .cacertcontent }}"
-  INSECURE: "{{ .insecure }}"
+  {{- $endpoint := .Values.registryMirrorSecret.endpoint }}
+  {{- $username := .Values.registryMirrorSecret.username }}
+  {{- $password := .Values.registryMirrorSecret.password }}
+  {{- $cacertcontent := .Values.registryMirrorSecret.cacertcontent }}
+  {{- $insecure := .Values.registryMirrorSecret.insecure }}
+  {{- if $regSecret }}
+  {{- if (eq $endpoint "") }}
+  {{- $endpoint = get $regSecret.data "ENDPOINT" }}
   {{- end }}
-type: Opaque
-{{- end }}
-{{- end }}
-{{- if or (eq $render "workload") (eq $render "package") }}
-{{- if or (not (lookup "v1" "Secret" $workloadNamespace "registry-mirror-secret")) (ne .Values.registryMirrorSecret.endpoint "") -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
-  name: registry-mirror-secret
-  namespace: {{ .Values.namespace }}-{{ .Values.clusterName }}
-data:
-  {{- with .Values.registryMirrorSecret }}
-  ENDPOINT: "{{ .endpoint }}"
-  USERNAME: "{{ .username }}"
-  PASSWORD: "{{ .password }}"
-  CACERTCONTENT: "{{ .cacertcontent }}"
-  INSECURE: "{{ .insecure }}"
+  {{- if (eq $username "") }}
+  {{- $username = get $regSecret.data "USERNAME" }}
   {{- end }}
+  {{- if (eq $password "") }}
+  {{- $password = get $regSecret.data "PASSWORD" }}
+  {{- end }}
+  {{- if (eq $cacertcontent "") }}
+  {{- $cacertcontent = get $regSecret.data "CACERTCONTENT" }}
+  {{- end }}
+  {{- if (eq $insecure "") }}
+  {{- $insecure = get $regSecret.data "INSECURE" }}
+  {{- end }}
+  {{- end }}
+  ENDPOINT: "{{ $endpoint }}"
+  USERNAME: "{{ $username }}"
+  PASSWORD: "{{ $password }}"
+  CACERTCONTENT: "{{ $cacertcontent }}"
+  INSECURE: "{{ $insecure }}"
 type: Opaque
-{{- end }}
-{{- end }}

--- a/ecrtokenrefresher/pkg/secrets/common/common.go
+++ b/ecrtokenrefresher/pkg/secrets/common/common.go
@@ -113,11 +113,20 @@ func CreateDockerAuthConfig(creds []*secrets.Credential) *dockerConfig {
 	config := dockerConfig{Auths: make(map[string]*dockerAuth)}
 
 	for _, cred := range creds {
+		username := cred.Username
+		password := cred.Password
+		if username == "" {
+			username = "username"
+		}
+		if password == "" {
+			password = "password"
+		}
+
 		config.Auths[cred.Registry] = &dockerAuth{
-			Username: cred.Username,
-			Password: cred.Password,
+			Username: username,
+			Password: password,
 			Email:    defaultEmail,
-			Auth:     base64.StdEncoding.EncodeToString([]byte(cred.Username + ":" + cred.Password)),
+			Auth:     base64.StdEncoding.EncodeToString([]byte(username + ":" + password)),
 		}
 	}
 


### PR DESCRIPTION
*Description of changes:*
Modified the reg secret logic to always do a lookup on the cluster to ensure backward compatibility since helm keep was not existing in older clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
