### PR TITLE
Add dev bundles for K8s version 1.30

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-30-regional.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30-regional.yaml
@@ -1,0 +1,101 @@
+# This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
+name: "v1-30-1001"
+kubernetesVersion: "1.30"
+minControllerVersion: "v0.3.2"
+packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.0.0-latest
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.0.0-latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+  - org: aws-observability
+    projects:
+      - name: adot
+        repository: adot/charts/aws-otel-collector
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: latest
+  - org: harbor
+    projects:
+      - name: harbor
+        repository: harbor/harbor-helm
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+  - org: kubernetes
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 9.34.0-1.29-latest
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.0-eks-1-29-latest
+  - org: metallb
+    projects:
+      - name: metallb
+        repository: metallb/metallb
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+      - name: metallb-crds
+        repository: metallb/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest
+  - org: prometheus
+    projects:
+      - name: prometheus
+        repository: prometheus/charts/prometheus
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: latest

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -1,0 +1,101 @@
+# This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
+name: "v1-30-1001"
+kubernetesVersion: "1.30"
+minControllerVersion: "v0.3.2"
+packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: 0.0.0-latest
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: aws-observability
+    projects:
+      - name: adot
+        repository: adot/charts/aws-otel-collector
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+          - name: latest
+  - org: harbor
+    projects:
+      - name: harbor
+        repository: harbor/harbor-helm
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: kubernetes
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: 9.34.0-1.29-latest
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: 0.7.0-eks-1-29-latest
+  - org: metallb
+    projects:
+      - name: metallb
+        repository: metallb/metallb
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+      - name: metallb-crds
+        repository: metallb/crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest
+  - org: prometheus
+    projects:
+      - name: prometheus
+        repository: prometheus/charts/prometheus
+        registry: public.ecr.aws/l0g8r8j6
+        versions:
+            - name: latest

--- a/generatebundlefile/data/promote/autoscaler/promote.yaml
+++ b/generatebundlefile/data/promote/autoscaler/promote.yaml
@@ -8,32 +8,39 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.29-latest
+            - name: 9.37.0-1.30-latest
   - org: cluster-autoscaler
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.28-latest
+            - name: 9.37.0-1.29-latest
   - org: cluster-autoscaler
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.27-latest
+            - name: 9.37.0-1.28-latest
   - org: cluster-autoscaler
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.26-latest
+            - name: 9.37.0-1.27-latest
   - org: cluster-autoscaler
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.25-latest
+            - name: 9.37.0-1.26-latest
+  - org: cluster-autoscaler
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 9.37.0-1.25-latest

--- a/generatebundlefile/data/promote/metrics-server/promote.yaml
+++ b/generatebundlefile/data/promote/metrics-server/promote.yaml
@@ -8,6 +8,13 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
+            - name: 0.7.0-eks-1-30-latest
+  - org: metrics-server
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
+        versions:
             - name: 0.7.0-eks-1-29-latest
   - org: metrics-server
     projects:

--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -40,7 +40,7 @@ fi
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin
 
-for version in 1-25 1-26 1-27 1-28 1-29; do
+for version in 1-25 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "dev"
     push ${version}
 done


### PR DESCRIPTION
*Issue #, if available:*
Add dev bundles for K8s version 1.30. Update autoscaler and metrics to latest tags on the dev bundle. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
