### PR TITLE
Add Kubernetes 1.30 staging packages bundle and deprecate 1.25

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26-regional.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26-regional.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,57 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.26-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.26-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-26-38-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
 

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,58 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.34.0-1.26-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.37.0-1.26-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.1-eks-1-26-38-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/bundles_staging/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27-regional.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,57 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.27-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
 

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,58 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.34.0-1.27-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/bundles_staging/1-28-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28-regional.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,57 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
 

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,58 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.34.0-1.28-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
+          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/bundles_staging/1-29-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29-regional.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,57 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.29-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
 

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,58 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.34.0-1.29-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/bundles_staging/1-30-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30-regional.yaml
@@ -1,7 +1,7 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
-minControllerVersion: "v0.3.2"
+name: "v1-30-1001"
+kubernetesVersion: "1.30"
+minControllerVersion: "v0.4.3"
 packages:
   - org: aws
     projects:
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,57 +46,57 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.25-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.30-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
 

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -1,7 +1,7 @@
 # This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
-name: "v1-25-1001"
-kubernetesVersion: "1.25"
-minControllerVersion: "v0.3.2"
+name: "v1-30-1001"
+kubernetesVersion: "1.30"
+minControllerVersion: "v0.4.3"
 packages:
   - org: aws
     projects:
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,58 +46,58 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.34.0-1.25-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+          - name: 9.37.0-1.30-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9-latest-helm
+          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/staging_artifact_move-regional.yaml
+++ b/generatebundlefile/data/staging_artifact_move-regional.yaml
@@ -10,24 +10,24 @@ packages:
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
             - name: 0.0.0-latest  # This is only used to move images for scanning, keep as 0.0.0-latest
-            - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+            - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         copyimages: true
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -41,7 +41,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.36.0-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -49,66 +49,66 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.13.2-828e7d186ded23e54f6bd95a5ce1319150f7e325
+          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.34.0-1.25-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 9.34.0-1.26-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 9.34.0-1.27-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 9.34.0-1.28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 9.34.0-1.29-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 9.37.0-1.26-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+            - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+            - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+            - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+            - name: 9.37.0-1.30-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-            - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+            - name: 0.7.1-eks-1-26-38-fe14b98f98132123f478eaf6e65bba4a29bf488b
+            - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
+            - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
+            - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
+            - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.49.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
+            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -9,24 +9,24 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         copyimages: true
         repository: credential-provider-package
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-a8009c93800d27ff66e09116ae9d78e90afd56c2
+          - name: v0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -40,7 +40,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.36.0-3e8e1251371da02c4b0259d9cbc6bd3ffaf9a581
+          - name: 0.39.0-1ce89733ecc3f0160b6b90e7c00cc3885918e1a5
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -48,66 +48,66 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 1.13.2-e378a9d19cb5916261966156287d6fc747ec26a4
+          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 9.34.0-1.25-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
-          - name: 9.34.0-1.26-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
-          - name: 9.34.0-1.27-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
-          - name: 9.34.0-1.28-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281-latest-helm
-          - name: 9.34.0-1.29-c6d1bdac61d1f705f9c5a28409d7a1f5223f6281
+          - name: 9.37.0-1.26-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.30-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.9.1-latest-helm
+          - name: 2.10.2-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: metallb
     projects:
       - name: metallb-crds
         repository: metallb/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.13.12-latest-helm
+          - name: 0.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.7.0-eks-1-25-32-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9-latest-helm
-          - name: 0.7.0-eks-1-26-28-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-          - name: 0.7.0-eks-1-27-22-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-          - name: 0.7.0-eks-1-28-15-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
-          - name: 0.7.0-eks-1-29-4-8f055c3376c2e26dcc3d79ac765fbf3a33249ce9
+          - name: 0.7.1-eks-1-26-38-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 3.9.1-2d41a83e380c5fcc8c3ae5edc7aea4b88ccf5cde
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 3.9.1-latest-helm
+          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.49.1-5565f1afed717ab164013be68ee283c0e9563076
+          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8

--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -97,13 +97,13 @@ fi
 # Generate Bundles from Public ECR
 export AWS_PROFILE=staging
 export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/stagingconfigfile
-for version in 1-25 1-26 1-27 1-28 1-29; do
+for version in 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "staging"
 done
 
 # Push Bundles to Public ECR
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
-for version in 1-25 1-26 1-27 1-28 1-29; do
+for version in 1-26 1-27 1-28 1-29 1-30; do
     push ${version}
 done
 
@@ -111,7 +111,7 @@ done
 if [[ "$regional_build_mode" != "true" ]]; then
     export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/configfile
     export AWS_PROFILE=packages
-    for version in 1-25 1-26 1-27 1-28 1-29; do
+    for version in 1-26 1-27 1-28 1-29 1-30; do
         regionCheck ${version}
     done
 fi


### PR DESCRIPTION
*Description of changes:*
Bump curated packages to their latest build versions and add Kubernetes version 1.30 to staging bundles. Deprecate Kubernetes version 1.25 bundles. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
