### PR TITLE
Fix staging bundle image tags after manually running pipelines

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -88,7 +88,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -88,7 +88,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -53,7 +53,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -53,7 +53,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -88,7 +88,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -88,7 +88,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -53,7 +53,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -88,7 +88,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/w9m0f3l5

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
       - name: credential-provider-package
         repository: credential-provider-package
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.4.3-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere

--- a/generatebundlefile/data/promote/metallb/promote.yaml
+++ b/generatebundlefile/data/promote/metallb/promote.yaml
@@ -8,11 +8,11 @@ packages:
         repository: metallb/crds
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-latest
+            - name: 0.14.5-latest
   - org: metallb 
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 857151390494.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.13.12-latest
+            - name: 0.14.5-latest

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -9,12 +9,12 @@ packages:
         repository: eks-anywhere-packages
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
       - name: eks-anywhere-packages-migrations
         copyimages: true
         repository: eks-anywhere-packages-migrations
@@ -26,7 +26,7 @@ packages:
         repository: credential-provider-package
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 0.4.3-1b3abb9bb2f39a317a8efd688a3ac8977d36e355
+          - name: 0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -56,9 +56,9 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 9.37.0-1.26-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
-          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
-          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
-          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 9.37.0-1.27-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
+          - name: 9.37.0-1.28-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
+          - name: 9.37.0-1.29-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e-latest-helm
           - name: 9.37.0-1.30-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
   - org: harbor
     projects:

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -98,7 +98,7 @@ packages:
         repository: emissary-ingress/emissary
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 3.9.1-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 3.9.1-latest-helm
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: public.ecr.aws/l0g8r8j6


### PR DESCRIPTION
*Description of changes:*
Some of the tags updated in the staging bundle weren't present in the Build Account `857151390494` Public ECR from which the staging pipeline copies over to the Packages staging account. This lead to staging pipeline failing for Packages. Additionally, metallb images were still getting promoted for the older tag as we hadn't updated the tag on promote file. This change updates the image tags on staging bundles to the images that have been verified to be present in the above account's public ECR and fixes the tag for metallb to promote the latest version bump. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
