### PR TITLE
Fix metrics server image tags for all Kubernetes versions

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -81,7 +81,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -81,7 +81,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -81,7 +81,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -81,7 +81,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -88,10 +88,10 @@ packages:
         registry: public.ecr.aws/l0g8r8j6
         versions:
           - name: 0.7.1-eks-1-26-38-fe14b98f98132123f478eaf6e65bba4a29bf488b
-          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b
-          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b
-          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b
-          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b
+          - name: 0.7.1-eks-1-27-32-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
+          - name: 0.7.1-eks-1-28-25-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
+          - name: 0.7.1-eks-1-29-14-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
+          - name: 0.7.1-eks-1-30-7-fe14b98f98132123f478eaf6e65bba4a29bf488b-latest-helm
   - org: emissary
     projects:
       - name: emissary


### PR DESCRIPTION
*Description of changes:*
The metric server images in build account for Kubernetes version 1.27 and above are tagged with suffix `-latest-helm`. Add the suffix to fix build failures on packages staging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
