### PR TITLE
Ensure all versions specified in input file are promoted

### DIFF
--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -127,7 +127,9 @@ func cmdPromote(opts *Options) error {
 			delete(promoteCharts, opts.promote) // Clear the promote map to pull values only from file
 			for _, p := range Inputs.Packages {
 				for _, project := range p.Projects {
-					promoteCharts[project.Repository] = append(promoteCharts[project.Repository], project.Versions[0].Name)
+					for _, version := range project.Versions {
+						promoteCharts[project.Repository] = append(promoteCharts[project.Repository], version.Name)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The packages promotion code only supported promoting one version for each package in the input file. This PR fixes that to allow more than one version to be promoted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
