### PR TITLE
Filter out proper image tags based on tag format

### DIFF
--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -186,7 +186,16 @@ func getLatestHelmTagandSha(details []ImageDetailsBothECR) (string, string, erro
 	if reflect.DeepEqual(latest, ImageDetailsBothECR{}) {
 		return "", "", fmt.Errorf("error no images found")
 	}
-	return latest.ImageTags[0], *latest.ImageDigest, nil
+
+	var imageTag string
+	imageTagRegex := regexp.MustCompile(`^\d+\.\d+\.\d+.*[0-9a-f]{40}$`)
+	for _, tag := range latest.ImageTags {
+		if imageTagRegex.MatchString(tag) {
+			imageTag = tag
+			break
+		}
+	}
+	return imageTag, *latest.ImageDigest, nil
 }
 
 // getLatestImageSha Iterates list of ECR Public Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image


### PR DESCRIPTION
We want the promoted image tags to be of the format `X.Y.Z-<commit hash>`, for example, `0.4.3-451cb0d2fd416176540b65be9e46b4cfc0db99f0` but sometimes if the same digest has multiple tags, it could pick up an image which does not follow the structure, such as `0.4.3-latest-helm`, as it's just getting the first element from the list without checking its format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
