### PR TITLE
Fix prometheus image tags in staging

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26-regional.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0
 

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/bundles_staging/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27-regional.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0
 

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/bundles_staging/1-28-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28-regional.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0
 

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/bundles_staging/1-29-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29-regional.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0
 

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/bundles_staging/1-30-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30-regional.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0
 

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -100,4 +100,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/staging_artifact_move-regional.yaml
+++ b/generatebundlefile/data/staging_artifact_move-regional.yaml
@@ -111,4 +111,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+            - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -110,4 +110,4 @@ packages:
         repository: prometheus/charts/prometheus
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 2.52.0-ef38252d0be5762249b5cbf82006b2726779c5a8
+          - name: 2.52.0-451cb0d2fd416176540b65be9e46b4cfc0db99f0


### PR DESCRIPTION
*Description of changes:*
Packages staging bundle release failed as there was a mismatch in commits during the build between the Prometheus images built after this [commit](https://github.com/aws/eks-anywhere-build-tooling/pull/3292) vs the helm charts built later after this [fix](https://github.com/aws/eks-anywhere-build-tooling/pull/3330). Since we only reference the tags for helm charts in our staging bundles, the builds implicitly expect the same tag for the images. Due to the mistmatch on commits the bundle build wasn't able to fetch an appropriate image for that tag. Kicked off a fresh build of Prometheus images and charts, then updated the tags on bundle to reflect the latest image tag.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
