### PR TITLE
Add creation timestamp to package bundles

### DIFF
--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -45,9 +46,10 @@ func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *api.Packag
 			APIVersion: api.SchemeBuilder.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        bundleName,
-			Namespace:   api.PackageNamespace,
-			Annotations: DefaultExcludesAnnotation,
+			Name:              bundleName,
+			Namespace:         api.PackageNamespace,
+			Annotations:       DefaultExcludesAnnotation,
+			CreationTimestamp: metav1.Time{Time: time.Time{}},
 		},
 		Spec: api.PackageBundleSpec{
 			Packages: []api.BundlePackage{
@@ -109,9 +111,10 @@ func AddMetadata(s api.PackageBundleSpec, name string) *api.PackageBundle {
 			APIVersion: api.SchemeBuilder.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   api.PackageNamespace,
-			Annotations: DefaultExcludesAnnotation,
+			Name:              name,
+			Namespace:         api.PackageNamespace,
+			Annotations:       DefaultExcludesAnnotation,
+			CreationTimestamp: metav1.Time{Time: time.Now()},
 		},
 		Spec: s,
 	}


### PR DESCRIPTION
Adding creation timestamp to package bundles so that we can identify the latest created bundle by chronological order.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
