### PR TITLE
Bump cert-manager to fixed chart

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-26-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26-regional.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/bundles_staging/1-27-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27-regional.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/bundles_staging/1-28-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28-regional.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/bundles_staging/1-29-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29-regional.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/bundles_staging/1-30-regional.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30-regional.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/w9m0f3l5
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/staging_artifact_move-regional.yaml
+++ b/generatebundlefile/data/staging_artifact_move-regional.yaml
@@ -49,7 +49,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.14.5-d18f9e2def8e8e24b3ce0e0c543cc4d1d7d6512e
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler

--- a/generatebundlefile/data/staging_artifact_move.yaml
+++ b/generatebundlefile/data/staging_artifact_move.yaml
@@ -48,7 +48,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: public.ecr.aws/l0g8r8j6
         versions:
-          - name: 1.14.5-b3aebd18d7ccfee138e40d8e037a684a8f135e6f
+          - name: 1.14.5-e88962cabe4c34a5e332e490bd7d2c1c263ce9fb
   - org: kubernetes
     projects:
       - name: cluster-autoscaler


### PR DESCRIPTION
*Description of changes:*
The current cert-manager helm-chart is borked in prod as the chart size is too big to be stored as K8s secret by helm. Update the chart after the size issue has been fixed.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
