### PR TITLE
Tag package bundles differently for regional staging/prod

### DIFF
--- a/generatebundlefile/hack/generate_bundle.sh
+++ b/generatebundlefile/hack/generate_bundle.sh
@@ -42,5 +42,5 @@ chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin
 
 for version in 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "dev"
-    push ${version}
+    push ${version} "dev"
 done

--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -105,5 +105,5 @@ done
 # Push Bundles to Public ECR
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
 for version in 1-26 1-27 1-28 1-29 1-30; do
-    push ${version}
+    push ${version} "prod"
 done

--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -104,7 +104,7 @@ done
 # Push Bundles to Public ECR
 aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
 for version in 1-26 1-27 1-28 1-29 1-30; do
-    push ${version}
+    push ${version} "staging"
 done
 
 # Check images from Bundle in Private ECR


### PR DESCRIPTION
Tag package bundles differently for regional staging/prod so that they don't override one another.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
