### PR TITLE
Remove regional build mode option from generatebundlefile CLI

### DIFF
--- a/generatebundlefile/options.go
+++ b/generatebundlefile/options.go
@@ -24,7 +24,6 @@ type Options struct {
 	privateProfile    string
 	bundleFile        string
 	regionCheck       bool
-	regionalBuildMode bool
 }
 
 func (o *Options) SetupLogger() {

--- a/pkg/signature/manifest.go
+++ b/pkg/signature/manifest.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"os"
 	"path"
 	"strings"
 	"text/template"
@@ -30,11 +29,7 @@ var (
 )
 
 func init() {
-	if os.Getenv("REGIONAL_BUILD_MODE") == "true" {
-		PublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELSnBPQf4H/GFb6yl6smKB9wwuKnD4goGHQYwg9+yQ1YusQNqZPn/QkVZnWCzJbZ/pksmpkno6dSzb/Hq+dBAMA=="
-	} else {
-		PublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP0Yo+ZxzPUEfohcG3bbJ8987UT4f0tj+XVBjS/s35wkfjrxTKrVZQpz3ta3zi5ZlgXzd7a20B1U1Py/TtPsxw=="
-	}
+	PublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELSnBPQf4H/GFb6yl6smKB9wwuKnD4goGHQYwg9+yQ1YusQNqZPn/QkVZnWCzJbZ/pksmpkno6dSzb/Hq+dBAMA=="
 	EksaDomain = Domain{Name: DomainName, Pubkey: PublicKey}
 }
 

--- a/pkg/webhook/packagebundle_webhook_test.go
+++ b/pkg/webhook/packagebundle_webhook_test.go
@@ -56,7 +56,7 @@ func TestBundleValidate(t *testing.T) {
 
 		err = sut.isPackageBundleValid(myBundle)
 
-		assert.EqualError(t, err, "The signature is invalid for the configured public key: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP0Yo+ZxzPUEfohcG3bbJ8987UT4f0tj+XVBjS/s35wkfjrxTKrVZQpz3ta3zi5ZlgXzd7a20B1U1Py/TtPsxw==")
+		assert.EqualError(t, err, "The signature is invalid for the configured public key: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELSnBPQf4H/GFb6yl6smKB9wwuKnD4goGHQYwg9+yQ1YusQNqZPn/QkVZnWCzJbZ/pksmpkno6dSzb/Hq+dBAMA==")
 	})
 
 	t.Run("env override", func(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
[#2389](https://github.com/aws/eks-anywhere-internal/issues/2389)

*Description of changes:*
Removing the `regionalBuildMode` option from the generatebundlefile CLI as we only run regional pipelines for generating and releasing packages bundles, helm charts and images. [#1137](https://github.com/aws/eks-anywhere-packages/pull/1137) removes all the non-regional bundle input files making the regional build mode env variable redundant as we always build in regional mode going forward.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
