### PR TITLE
Remove helm chart promotion to public ECR in staging and prod release

### DIFF
--- a/generatebundlefile/hack/release_staging.sh
+++ b/generatebundlefile/hack/release_staging.sh
@@ -29,47 +29,18 @@ ORAS_BIN=${BASE_DIRECTORY}/bin/oras
 make build
 chmod +x ${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile
 
-# Release Helm Chart, and bundle to Staging account
-cat << EOF > stagingconfigfile
-[default]
-region=us-west-2
-account=$BASE_AWS_ACCOUNT_ID
-output=json
-
-[profile staging]
-role_arn=$ARTIFACT_DEPLOYMENT_ROLE
-region=us-east-1
-credential_source=EcsContainer
-EOF
-
-export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/stagingconfigfile
-export PROFILE=staging
 . "${BASE_DIRECTORY}/generatebundlefile/hack/common.sh"
 
-aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
-
-file_name=staging_artifact_move.yaml
 REGISTRY=${BASE_AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
 REPO=${REGISTRY}/eks-anywhere-packages-bundles
-
-# Move Helm charts within the bundle to Public ECR
-${BASE_DIRECTORY}/generatebundlefile/bin/generatebundlefile  \
-    --input ${BASE_DIRECTORY}/generatebundlefile/data/${file_name} \
-    --public-profile ${PROFILE}
 
 if [ ! -x "${ORAS_BIN}" ]; then
     make oras-install
 fi
 
-# Generate Bundles from Public ECR
-export AWS_PROFILE=staging
-export AWS_CONFIG_FILE=${BASE_DIRECTORY}/generatebundlefile/stagingconfigfile
+# Generate bundles from beta account private ECR registry and
+# push them to prod account private ECR registry (same as beta account in this case)
 for version in 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "staging"
-done
-
-# Push Bundles to Public ECR
-aws ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login --username AWS --password-stdin public.ecr.aws
-for version in 1-26 1-27 1-28 1-29 1-30; do
     push ${version} "staging"
 done


### PR DESCRIPTION
*Description of changes:*
This PR remove unnecessary helm charts promotion to public ECR registry in staging and prod release jobs as we now handle that in the ECR replication job. It also refactors the script to call the `generate` and `push` bundle functions in a single loop over kubernetes versions and update the comments to reflect what the job actually does.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
