### PR TITLE
Tag package bundles with epoch time and date of creation

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -66,19 +66,19 @@ function push () {
     removeBundleMetadata bundle.yaml
 
     latest_tag="v${version}-latest"
-    versioned_tag="v${version}-${CODEBUILD_BUILD_NUMBER}"
+    versioned_tag=$(yq ".metadata.name" bundle.yaml)
     case $stage in
     dev)
-        latest_tag="v${version}-latest"
-        versioned_tag="v${version}-${CODEBUILD_BUILD_NUMBER}"
+        latest_tag="${latest_tag}"
+        versioned_tag="${versioned_tag}"
         ;;
     staging)
-        latest_tag="v${version}-latest-staging"
-        versioned_tag="v${version}-${CODEBUILD_BUILD_NUMBER}-staging"
+        latest_tag="${latest_tag}-staging"
+        versioned_tag="${versioned_tag}-staging"
         ;;
     prod)
-        latest_tag="v${version}-latest-prod"
-        versioned_tag="v${version}-${CODEBUILD_BUILD_NUMBER}-prod"
+        latest_tag="${latest_tag}-prod"
+        versioned_tag="${versioned_tag}-prod"
         ;;
     *)
         echo "Invalid stage: $stage"

--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -22,7 +22,6 @@ export LANG=C.UTF-8
 
 BASE_AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
-export CODEBUILD_BUILD_NUMBER=$(($CODEBUILD_BUILD_NUMBER+110))
 
 . "${BASE_DIRECTORY}/generatebundlefile/hack/common.sh"
 ORAS_BIN=${BASE_DIRECTORY}/bin/oras

--- a/generatebundlefile/input.go
+++ b/generatebundlefile/input.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	YamlSeparator = "\n---\n"
+	YamlSeparator  = "\n---\n"
+	YYYYMMDDFormat = "2006-01-02"
 )
 
 func ValidateInputConfig(fileName string) (*Input, error) {
@@ -142,14 +143,13 @@ func (c *SDKClients) NewBundleFromInput(Input *Input) (api.PackageBundleSpec, st
 	if Input.Name == "" || Input.KubernetesVersion == "" {
 		return packageBundleSpec, "", nil, fmt.Errorf("error: Empty input field from `Name` or `KubernetesVersion`.")
 	}
-	var name string
-	name, ok := os.LookupEnv("CODEBUILD_BUILD_NUMBER")
-	if !ok {
-		name = Input.Name
-	} else {
-		version := strings.Split(Input.KubernetesVersion, ".")
-		name = fmt.Sprintf("v1-%s-%s", version[1], name)
-	}
+
+	currentTime := time.Now()
+	currentEpochTime := currentTime.Unix()
+	date := currentTime.Format(YYYYMMDDFormat)
+
+	version := strings.Split(Input.KubernetesVersion, ".")
+	name := fmt.Sprintf("v1-%s-%s-%d", version[1], date, currentEpochTime)
 	if Input.MinVersion != "" {
 		packageBundleSpec.MinVersion = Input.MinVersion
 	}


### PR DESCRIPTION
We are changing the logic of packages bundles tagging to use the date and epoch time of the bundle creation instead of an arbitrary value like the CodeBuild build number.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
