### PR TITLE
fix: remove reference for undefined method removeBundleMetadata

### DIFF
--- a/generatebundlefile/hack/common.sh
+++ b/generatebundlefile/hack/common.sh
@@ -63,7 +63,6 @@ function push () {
     local stage=${2?:no version specified}
     cd "${BASE_DIRECTORY}/generatebundlefile/output-${version}"
     orasLogin "$REPO"
-    removeBundleMetadata bundle.yaml
 
     latest_tag="v${version}-latest"
     versioned_tag=$(yq ".metadata.name" bundle.yaml)


### PR DESCRIPTION
### Description of changes:
Removed reference of undefined method `removeBundleMetadata`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
