### PR TITLE
Unset AWS_PROFILE env var in prod release script

### DIFF
--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -40,7 +40,6 @@ fi
 
 # Generate bundles from beta account private ECR registry and
 # push them to prod account private ECR registry (same as beta account in this case)
-export AWS_PROFILE=prod
 for version in 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "prod"
     push ${version} "prod"


### PR DESCRIPTION
We don't need to set the `AWS_PROFILE` env var since we're pushing to the same account. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
