### PR TITLE
Remove AWS_PROFILE env variable from prod release job

### DIFF
--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -40,7 +40,6 @@ fi
 
 # Generate bundles from beta account private ECR registry and
 # push them to prod account private ECR registry (same as beta account in this case)
-export AWS_PROFILE=prod
 for version in 1-26 1-27 1-28 1-29 1-30; do
     generate ${version} "prod"
     push ${version} "prod"


### PR DESCRIPTION
*Description of changes:*
Packages prod release job is failing with following error:
```
/codebuild/output/src2082008850/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages/bin/oras login 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages-bundles --username AWS --password-stdin 
aws ecr --region=us-west-2 get-login-password
The config profile (prod) could not be found
Error: Get "https://067575901363.dkr.ecr.us-west-2.amazonaws.com/v2/": no basic auth credentials
```
This PR fixes this by removing the exported AWS_PROFILE env variables from the prod release script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
