### PR TITLE
Use only artifacts built from main branch in package bundle

### DIFF
--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -79,7 +79,7 @@ func ImageTagFilter(details []ImageDetailsBothECR, version string) []ImageDetail
 	var filteredDetails []ImageDetailsBothECR
 	for _, detail := range details {
 		for _, tag := range detail.ImageTags {
-			if strings.HasPrefix(tag, version) {
+			if strings.HasPrefix(tag, version) && strings.Contains(tag, "latest") {
 				filteredDetails = append(filteredDetails, detail)
 			}
 		}


### PR DESCRIPTION
When generating the packages bundle, we only want to use artifacts built from main branch since we don't update and build packages from release branches. All artifacts built from main are tagged with `latest` so that makes it a useful filter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
