### PR TITLE
Use helm charts only from main branch when finding latest image tag

### DIFF
--- a/generatebundlefile/README.md
+++ b/generatebundlefile/README.md
@@ -80,7 +80,7 @@ packages:
 
 #### Latest Version
 
-The "latest" tag will tell the program to use a timestamp lookup, and find the most recently pushed helm chart for information, even if that helm chart doesn't have the latest tag.
+The "latest" tag will tell the program to use a timestamp lookup, and find the most recently pushed helm chart for information only if that helm chart has the latest tag.
 
 ```yaml
 name: "v1-22-1001"

--- a/generatebundlefile/bundle_test.go
+++ b/generatebundlefile/bundle_test.go
@@ -65,7 +65,7 @@ func TestNewBundleGenerate(t *testing.T) {
 }
 
 var (
-	testTagBundle      string = "0.1.0_c4e25cb42e9bb88d2b8c2abfbde9f10ade39b214"
+	testTagBundle      string = "0.1.0_latest_c4e25cb42e9bb88d2b8c2abfbde9f10ade39b214"
 	testShaBundle      string = "sha256:d5467083c4d175e7e9bba823e95570d28fff86a2fbccb03f5ec3093db6f039be"
 	testImageMediaType string = "application/vnd.oci.image.manifest.v1+json"
 	testRegistryId     string = "067575901363.dkr.ecr.us-west-2.amazonaws.com"

--- a/generatebundlefile/ecr.go
+++ b/generatebundlefile/ecr.go
@@ -85,7 +85,7 @@ func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error
 				}
 			}
 		}
-		//
+
 		if tag.Name == "latest" {
 			ImageDetails, err := c.Describe(&ecr.DescribeImagesInput{
 				RepositoryName: aws.String(project.Repository),
@@ -94,14 +94,15 @@ func (c *ecrClient) GetShaForInputs(project Project) ([]api.SourceVersion, error
 				return nil, fmt.Errorf("unable to complete DescribeImagesRequest to ECR: %s", err)
 			}
 
-			sha, err := getLatestImageSha(ImageDetails)
+			filteredImageDetails := ImageTagFilter(ImageDetails, "")
+			sha, err := getLatestImageSha(filteredImageDetails)
 			if err != nil {
 				return nil, err
 			}
 			sourceVersion = append(sourceVersion, *sha)
 			continue
 		}
-		//
+
 		if strings.HasSuffix(tag.Name, "-latest") {
 			regex := regexp.MustCompile(`-latest`)
 			splitVersion := regex.Split(tag.Name, -1) // extract out the version without the latest

--- a/generatebundlefile/ecr_helper.go
+++ b/generatebundlefile/ecr_helper.go
@@ -81,7 +81,7 @@ func ImageTagFilter(details []ecrtypes.ImageDetail, version string) []ecrtypes.I
 	return filteredDetails
 }
 
-// getLatestImageSha Iterates list of Helm Charts, to find latest pushed image and return tag/sha  of the latest pushed image
+// getLatestImageSha Iterates list of Helm Charts, to find latest pushed image and return tag/sha of the latest pushed image
 func getLatestImageSha(details []ecrtypes.ImageDetail) (*api.SourceVersion, error) {
 	var latest ecrtypes.ImageDetail
 	latest.ImagePushedAt = &time.Time{}


### PR DESCRIPTION
*Description of changes:*
Currently, the dev packages bundles are generated based on the dev bundle input files defined [here](https://github.com/aws/eks-anywhere-packages/tree/main/generatebundlefile/data/bundles_dev) for each kubernetes version. Except for the package controller helm charts, all other packages helm charts have the "latest" version tag in the input file which tells the program to use a timestamp lookup and find the most recently pushed helm chart for information, even if that helm chart doesn't have the latest tag. This causes an issue when a certain package gets built from the release branch as that tag will be used in the dev packages bundle instead of the latest tag. Even if the packages helm chart have the same version/tag on the main and release branch, it could still cause an issue when certain bug fixes from main aren't backported to the release branch in the [eks-anywhere-build-tooling](https://github.com/aws/eks-anywhere-build-tooling) repository. For example, the cert-manager tests started failing recently when the cert-manager helm chart built from the release-0.20 branch was used in the generated packages dev bundle due to a bug fix merged in [#3403](https://github.com/aws/eks-anywhere-build-tooling/pull/3403) not being backported to the release-0.20 branch. This PR updates the logic in the generatebundlefile CLI to find the most recently pushed helm chart which also contains the "latest" tag so that it doesn't use the helm charts from the release branches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
