### PR TITLE
Packages staging release

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-26.yaml
+++ b/generatebundlefile/data/bundles_staging/1-26.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.54.0-f4526c69059ebaf6fff5cbddb6c3087aa651f879
+            - name: 2.54.0-bc09267cc490825ef74e1191bcb41d0170a9b60c
 

--- a/generatebundlefile/data/bundles_staging/1-27.yaml
+++ b/generatebundlefile/data/bundles_staging/1-27.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.54.0-f4526c69059ebaf6fff5cbddb6c3087aa651f879
+            - name: 2.54.0-bc09267cc490825ef74e1191bcb41d0170a9b60c
 

--- a/generatebundlefile/data/bundles_staging/1-28.yaml
+++ b/generatebundlefile/data/bundles_staging/1-28.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.54.0-f4526c69059ebaf6fff5cbddb6c3087aa651f879
+            - name: 2.54.0-bc09267cc490825ef74e1191bcb41d0170a9b60c
 

--- a/generatebundlefile/data/bundles_staging/1-29.yaml
+++ b/generatebundlefile/data/bundles_staging/1-29.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.54.0-f4526c69059ebaf6fff5cbddb6c3087aa651f879
+            - name: 2.54.0-bc09267cc490825ef74e1191bcb41d0170a9b60c
 

--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -98,5 +98,5 @@ packages:
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.54.0-f4526c69059ebaf6fff5cbddb6c3087aa651f879
+            - name: 2.54.0-bc09267cc490825ef74e1191bcb41d0170a9b60c
 


### PR DESCRIPTION
*Description of changes:*

This PR updates Prometheus version in staging bundle.

Node exporter image tag was missing corresponding to Prometheus chart git SHA, did the pipeline rebuild for both and updated the tag in staging bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
