### PR TITLE
Revert autoscaler and metrics-server to 1.30 kubernetes version

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -60,14 +60,14 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.31-latest
+            - name: 9.37.0-1.30-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.1-eks-1-31-latest
+            - name: 0.7.1-eks-1-30-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
This PR reverts version update for autoscaler and metrics-server. Currently, there is no autoscaler chart for 1.31 Kubernetes version, which is causing the build pipeline for packages to fail at `Bundle Generation` stage.

Cluster-Autoscaler 1.31 still refers to 1.30 GIT_TAG as placeholder once we have updated the curated package, will update the dev-bundle to reflect correct version.