### PR TITLE
Update autoscaler and metrics-server version in the 1.31 dev bundle

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -60,14 +60,14 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.30-latest
+            - name: 9.37.0-1.31-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.7.1-eks-1-30-latest
+            - name: 0.7.1-eks-1-31-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
*Description of changes:*
This PR updates the autoscaler and metrics-server version in the 1.31 dev bundle to start packages testing with Kubernetes v1.31.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
