### PR TITLE
Update autoscaler helm chart version to latest 9.40.0 in dev bundle

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-27.yaml
+++ b/generatebundlefile/data/bundles_dev/1-27.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.27-latest
+            - name: 9.40.0-1.27-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_dev/1-28.yaml
+++ b/generatebundlefile/data/bundles_dev/1-28.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.28-latest
+            - name: 9.40.0-1.28-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.29-latest
+            - name: 9.40.0-1.29-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.30-latest
+            - name: 9.40.0-1.30-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.37.0-1.31-latest
+            - name: 9.40.0-1.31-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
*Description of changes:*
Autoscaler was recently bumped to the latest version in [#3841](https://github.com/aws/eks-anywhere-build-tooling/pull/3841). This PR updates the autoscaler helm chart version to latest 9.40.0 in dev bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
