### PR TITLE
Add prod bundle for Kubernetes version 1.31

### DIFF
--- a/generatebundlefile/data/bundles_prod/1-31.yaml
+++ b/generatebundlefile/data/bundles_prod/1-31.yaml
@@ -1,0 +1,103 @@
+# This info is hardcoded and comes from https://github.com/aws/eks-anywhere-build-tooling
+name: "v1-31-1001"
+kubernetesVersion: "1.31"
+minControllerVersion: "v0.4.4"
+packages:
+  - org: aws
+    projects:
+      - name: eks-anywhere-packages
+        repository: eks-anywhere-packages
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.4.4-8523de417336843618bd1f9e4c56eec7fab2d955
+      - name: eks-anywhere-packages-crds
+        repository: eks-anywhere-packages-crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.4.4-8523de417336843618bd1f9e4c56eec7fab2d955
+      - name: eks-anywhere-packages-migrations
+        repository: eks-anywhere-packages-migrations
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.4.4-8523de417336843618bd1f9e4c56eec7fab2d955
+      - name: credential-provider-package
+        repository: credential-provider-package
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 0.4.4-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: aws-containers
+    projects:
+      - name: hello-eks-anywhere
+        repository: hello-eks-anywhere
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.1.2-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: aws-observability
+    projects:
+      - name: adot
+        repository: adot/charts/aws-otel-collector
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.40.1-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: cert-manager
+    projects:
+      - name: cert-manager
+        workloadonly: true
+        repository: cert-manager/cert-manager
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+          - name: 1.15.3-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: kubernetes
+    projects:
+      - name: cluster-autoscaler
+        repository: cluster-autoscaler/charts/cluster-autoscaler
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 9.40.0-1.31-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: harbor
+    projects:
+      - name: harbor
+        repository: harbor/harbor-helm
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 2.11.1-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: metallb
+    projects:
+      - name: metallb
+        repository: metallb/metallb
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.14.8-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: metallb
+    projects:
+      - name: metallb-crds
+        repository: metallb/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.14.8-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: kubernetes-sigs
+    projects:
+      - name: metrics-server
+        repository: metrics-server/charts/metrics-server
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 0.7.1-eks-1-31-4-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: emissary
+    projects:
+      - name: emissary
+        repository: emissary-ingress/emissary
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-8523de417336843618bd1f9e4c56eec7fab2d955
+      - name: emissary-crds
+        repository: emissary-ingress/crds
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 3.9.1-8523de417336843618bd1f9e4c56eec7fab2d955
+  - org: prometheus
+    projects:
+      - name: prometheus
+        repository: prometheus/charts/prometheus
+        registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
+        versions:
+            - name: 2.54.0-8523de417336843618bd1f9e4c56eec7fab2d955

--- a/generatebundlefile/hack/release_prod.sh
+++ b/generatebundlefile/hack/release_prod.sh
@@ -40,7 +40,7 @@ fi
 
 # Generate bundles from beta account private ECR registry and
 # push them to prod account private ECR registry (same as beta account in this case)
-for version in 1-26 1-27 1-28 1-29 1-30; do
+for version in 1-26 1-27 1-28 1-29 1-30 1-31; do
     generate ${version} "prod"
     push ${version} "prod"
 done


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
Add prod bundle for Kubernetes version 1.31

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
