### PR TITLE
Removing unwanted feature gate(KubeletCredentialProviders) option

### DIFF
--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -217,12 +217,6 @@ func (c *linuxOS) createConfig() (string, error) {
 
 func (c *linuxOS) updateKubeletArguments(line string) string {
 	args := ""
-	k8sVersion := os.Getenv("K8S_VERSION")
-	if semver.Compare(k8sVersion, "v1.26") < 0 {
-		if !strings.Contains(line, "KubeletCredentialProviders") {
-			args += " --feature-gates=KubeletCredentialProviders=true"
-		}
-	}
 
 	val, err := c.createConfig()
 	if err != nil {

--- a/credentialproviderpackage/pkg/configurator/linux/linux_test.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux_test.go
@@ -47,8 +47,7 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 			args:             args{line: ""},
 			outputConfigPath: dir + "/" + credProviderFile,
 			configWantPath:   "testdata/expected-config.yaml",
-			want: fmt.Sprintf(" --feature-gates=KubeletCredentialProviders=true "+
-				"--image-credential-provider-config=%s%s", dir, credProviderFile),
+			want:             fmt.Sprintf(" --image-credential-provider-config=%s%s", dir, credProviderFile),
 		},
 		{
 			name: "test multiple match patterns",
@@ -67,8 +66,7 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 			args:             args{line: ""},
 			outputConfigPath: dir + "/" + credProviderFile,
 			configWantPath:   "testdata/expected-config-multiple-patterns.yaml",
-			want: fmt.Sprintf(" --feature-gates=KubeletCredentialProviders=true "+
-				"--image-credential-provider-config=%s%s", dir, credProviderFile),
+			want:             fmt.Sprintf(" --image-credential-provider-config=%s%s", dir, credProviderFile),
 		},
 		{
 			name: "skip credential provider if already provided",
@@ -81,23 +79,7 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 					DefaultCacheDuration: constants.DefaultCacheDuration,
 				},
 			},
-			args:             args{line: " --feature-gates=KubeletCredentialProviders=true"},
-			outputConfigPath: dir + "/" + credProviderFile,
-			configWantPath:   "testdata/expected-config.yaml",
-			want:             fmt.Sprintf(" --image-credential-provider-config=%s%s", dir, credProviderFile),
-		},
-		{
-			name: "skip both cred provider and feature gate if provided",
-			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
-				config: constants.CredentialProviderConfigOptions{
-					ImagePatterns:        []string{constants.DefaultImagePattern},
-					DefaultCacheDuration: constants.DefaultCacheDuration,
-				},
-			},
-			args:             args{line: " --feature-gates=KubeletCredentialProviders=false --image-credential-provider-config=blah"},
+			args:             args{line: " --image-credential-provider-config=blah"},
 			outputConfigPath: dir + "/" + credProviderFile,
 			configWantPath:   "",
 			want:             "",
@@ -117,8 +99,7 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 			outputConfigPath: dir + "/" + credProviderFile,
 			configWantPath:   "testdata/expected-config-alpha.yaml",
 			k8sVersion:       "v1.25",
-			want: fmt.Sprintf(" --feature-gates=KubeletCredentialProviders=true "+
-				"--image-credential-provider-config=%s%s", dir, credProviderFile),
+			want:             fmt.Sprintf(" --image-credential-provider-config=%s%s", dir, credProviderFile),
 		},
 		{
 			name: "test v1 api 1.27",
@@ -135,8 +116,7 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 			outputConfigPath: dir + "/" + credProviderFile,
 			configWantPath:   "testdata/expected-config.yaml",
 			k8sVersion:       "v1.27",
-			want: fmt.Sprintf(" --feature-gates=KubeletCredentialProviders=true "+
-				"--image-credential-provider-config=%s%s", dir, credProviderFile),
+			want:             fmt.Sprintf(" --image-credential-provider-config=%s%s", dir, credProviderFile),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
*Description of changes:*
- Removing unwanted feature gate option `KubeletCredentialProviders`. `KubeletCredentialProviders` feature gate was  GA'ed in `1.26` and was removed from `1.28`. For current supported release versions for EKS-A we don't need to add feature-gate option in kubelet-extra-args since the default option is `true` until 1.28 and is not available in later release versions 
Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/
- Updated the unit test

*Testing*
- make test
- Functional testing was done along with this[ PR](https://github.com/aws/eks-anywhere-packages/pull/1177).
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
