### PR TITLE
Add support to update both legacy and default path for kubelet-extra-args for ubuntu

### DIFF
--- a/credentialproviderpackage/charts/credential-provider-package/templates/_helpers.tpl
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/_helpers.tpl
@@ -81,6 +81,8 @@ Function to figure out os name
 {{- printf "bottlerocket" -}}
 {{- else if contains "Amazon Linux" .status.nodeInfo.osImage -}}
 {{- printf "default" -}}
+{{- else if contains "Ubuntu" .status.nodeInfo.osImage -}}
+{{- printf "ubuntu" -}}
 {{- else -}}
 {{- printf "sysconfig" -}}
 {{- end }}

--- a/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
@@ -43,8 +43,8 @@ spec:
             {{- else if eq $os "ubuntu" }}
             - mountPath: /node-files/kubelet-extra-args
               name: kubelet-extra-args
-            - mountPath: /node-files/kubelet-extra-args-legacy
-              name: kubelet-extra-args-legacy
+            - mountPath: /node-files/ubuntu-legacy-kubelet-extra-args
+              name: ubuntu-legacy-kubelet-extra-args
             - name: package-mounts
               mountPath: /eksa-packages
             {{- else}}
@@ -84,7 +84,7 @@ spec:
           hostPath:
             path: /etc/default/kubelet
             type: FileOrCreate
-        - name: kubelet-extra-args-legacy
+        - name: ubuntu-legacy-kubelet-extra-args
           hostPath:
             path: /etc/sysconfig/kubelet
             type: FileOrCreate

--- a/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
@@ -40,6 +40,13 @@ spec:
             {{- if eq $os "bottlerocket" }}
             - mountPath: /run/api.sock
               name: socket
+            {{- else if eq $os "ubuntu" }}
+            - mountPath: /node-files/kubelet-extra-args
+              name: kubelet-extra-args
+            - mountPath: /node-files/kubelet-extra-args-legacy
+              name: kubelet-extra-args-legacy
+            - name: package-mounts
+              mountPath: /eksa-packages
             {{- else}}
             - mountPath: /node-files/kubelet-extra-args
               name: kubelet-extra-args
@@ -71,6 +78,15 @@ spec:
         - name: kubelet-extra-args
           hostPath:
             path: /etc/default/kubelet
+            type: FileOrCreate
+        {{- else if eq $os "ubuntu"}}
+        - name: kubelet-extra-args
+          hostPath:
+            path: /etc/default/kubelet
+            type: FileOrCreate
+        - name: kubelet-extra-args-legacy
+          hostPath:
+            path: /etc/sysconfig/kubelet
             type: FileOrCreate
         {{- else}}
         - name: kubelet-extra-args

--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"syscall"
@@ -26,7 +25,7 @@ const (
 	basePath              = "/eksa-packages/"
 	credOutFile           = "aws-creds"
 	mountedExtraArgs      = "/node-files/kubelet-extra-args"
-	ubuntuLegacyExtraArgs = "/node-files/kubelet-extra-args-legacy"
+	ubuntuLegacyExtraArgs = "/node-files/ubuntu-legacy-kubelet-extra-args"
 	credProviderFile      = "credential-provider-config.yaml"
 
 	// Binaries
@@ -226,7 +225,7 @@ func (c *linuxOS) createConfig() (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	err = ioutil.WriteFile(dstPath, bytes, 0o600)
+	err = os.WriteFile(dstPath, bytes, 0o600)
 	if err != nil {
 		return "", err
 	}

--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -22,11 +22,12 @@ import (
 var credProviderTemplate string
 
 const (
-	binPath          = "/eksa-binaries/"
-	basePath         = "/eksa-packages/"
-	credOutFile      = "aws-creds"
-	mountedExtraArgs = "/node-files/kubelet-extra-args"
-	credProviderFile = "credential-provider-config.yaml"
+	binPath               = "/eksa-binaries/"
+	basePath              = "/eksa-packages/"
+	credOutFile           = "aws-creds"
+	mountedExtraArgs      = "/node-files/kubelet-extra-args"
+	ubuntuLegacyExtraArgs = "/node-files/kubelet-extra-args-legacy"
+	credProviderFile      = "credential-provider-config.yaml"
 
 	// Binaries
 	ecrCredProviderBinary = "ecr-credential-provider"
@@ -34,19 +35,21 @@ const (
 )
 
 type linuxOS struct {
-	profile       string
-	extraArgsPath string
-	basePath      string
-	config        constants.CredentialProviderConfigOptions
+	profile             string
+	extraArgsPath       string
+	legacyExtraArgsPath string
+	basePath            string
+	config              constants.CredentialProviderConfigOptions
 }
 
 var _ configurator.Configurator = (*linuxOS)(nil)
 
 func NewLinuxConfigurator() *linuxOS {
 	return &linuxOS{
-		profile:       "",
-		extraArgsPath: mountedExtraArgs,
-		basePath:      basePath,
+		profile:             "",
+		extraArgsPath:       mountedExtraArgs,
+		legacyExtraArgsPath: ubuntuLegacyExtraArgs,
+		basePath:            basePath,
 	}
 }
 
@@ -62,9 +65,8 @@ func (c *linuxOS) UpdateAWSCredentials(sourcePath, profile string) error {
 	return err
 }
 
-func (c *linuxOS) UpdateCredentialProvider(_ string) error {
-	// Adding to KUBELET_EXTRA_ARGS in place
-	file, err := ioutil.ReadFile(c.extraArgsPath)
+func (c *linuxOS) updateConfigFile(configPath string) error {
+	file, err := os.ReadFile(configPath)
 	if err != nil {
 		return err
 	}
@@ -91,8 +93,24 @@ func (c *linuxOS) UpdateCredentialProvider(_ string) error {
 	}
 
 	out := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(c.extraArgsPath, []byte(out), 0o644)
+	err = os.WriteFile(configPath, []byte(out), 0o644)
 	return err
+}
+
+func (c *linuxOS) UpdateCredentialProvider(_ string) error {
+	// Adding to KUBELET_EXTRA_ARGS in place
+	if err := c.updateConfigFile(mountedExtraArgs); err != nil {
+		return fmt.Errorf("failed to update kubelet args: %v", err)
+	}
+
+	// Adding KUBELET_EXTRA_ARGS to legacy path for ubuntu
+	if _, err := os.Stat(ubuntuLegacyExtraArgs); err == nil {
+		if err := c.updateConfigFile(ubuntuLegacyExtraArgs); err != nil {
+			return fmt.Errorf("failed to update legacy kubelet args for ubuntu: %v", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *linuxOS) CommitChanges() error {

--- a/credentialproviderpackage/pkg/configurator/linux/linux_test.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux_test.go
@@ -2,7 +2,6 @@ package linux
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,10 +15,11 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 	testDir, _ := test.NewWriter(t)
 	dir := testDir + "/"
 	type fields struct {
-		profile       string
-		extraArgsPath string
-		basePath      string
-		config        constants.CredentialProviderConfigOptions
+		profile             string
+		extraArgsPath       string
+		legacyExtraArgsPath string
+		basePath            string
+		config              constants.CredentialProviderConfigOptions
 	}
 	type args struct {
 		line string
@@ -36,9 +36,10 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 		{
 			name: "test empty string",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns:        []string{constants.DefaultImagePattern},
 					DefaultCacheDuration: constants.DefaultCacheDuration,
@@ -52,9 +53,10 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 		{
 			name: "test multiple match patterns",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns: []string{
 						"1234567.dkr.ecr.us-east-1.amazonaws.com",
@@ -71,9 +73,10 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 		{
 			name: "skip credential provider if already provided",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns:        []string{constants.DefaultImagePattern},
 					DefaultCacheDuration: constants.DefaultCacheDuration,
@@ -87,9 +90,10 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 		{
 			name: "test alpha api",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns:        []string{constants.DefaultImagePattern},
 					DefaultCacheDuration: constants.DefaultCacheDuration,
@@ -104,9 +108,10 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 		{
 			name: "test v1 api 1.27",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns:        []string{constants.DefaultImagePattern},
 					DefaultCacheDuration: constants.DefaultCacheDuration,
@@ -122,10 +127,11 @@ func Test_linuxOS_updateKubeletArguments(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &linuxOS{
-				profile:       tt.fields.profile,
-				extraArgsPath: tt.fields.extraArgsPath,
-				basePath:      tt.fields.basePath,
-				config:        tt.fields.config,
+				profile:             tt.fields.profile,
+				extraArgsPath:       tt.fields.extraArgsPath,
+				legacyExtraArgsPath: tt.fields.legacyExtraArgsPath,
+				basePath:            tt.fields.basePath,
+				config:              tt.fields.config,
 			}
 			t.Setenv("K8S_VERSION", tt.k8sVersion)
 
@@ -143,10 +149,11 @@ func Test_linuxOS_UpdateAWSCredentials(t *testing.T) {
 	testDir, _ := test.NewWriter(t)
 	dir := testDir + "/"
 	type fields struct {
-		profile       string
-		extraArgsPath string
-		basePath      string
-		config        constants.CredentialProviderConfigOptions
+		profile             string
+		extraArgsPath       string
+		legacyExtraArgsPath string
+		basePath            string
+		config              constants.CredentialProviderConfigOptions
 	}
 	type args struct {
 		sourcePath string
@@ -161,9 +168,10 @@ func Test_linuxOS_UpdateAWSCredentials(t *testing.T) {
 		{
 			name: "simple credential move",
 			fields: fields{
-				profile:       "eksa-packages",
-				extraArgsPath: dir,
-				basePath:      dir,
+				profile:             "eksa-packages",
+				extraArgsPath:       dir,
+				legacyExtraArgsPath: dir,
+				basePath:            dir,
 				config: constants.CredentialProviderConfigOptions{
 					ImagePatterns:        []string{constants.DefaultImagePattern},
 					DefaultCacheDuration: constants.DefaultCacheDuration,
@@ -180,10 +188,11 @@ func Test_linuxOS_UpdateAWSCredentials(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dstFile := tt.fields.basePath + credOutFile
 			c := &linuxOS{
-				profile:       tt.fields.profile,
-				extraArgsPath: tt.fields.extraArgsPath,
-				basePath:      tt.fields.basePath,
-				config:        tt.fields.config,
+				profile:             tt.fields.profile,
+				extraArgsPath:       tt.fields.extraArgsPath,
+				legacyExtraArgsPath: tt.fields.legacyExtraArgsPath,
+				basePath:            tt.fields.basePath,
+				config:              tt.fields.config,
 			}
 			if err := c.UpdateAWSCredentials(tt.args.sourcePath, tt.args.profile); (err != nil) != tt.wantErr {
 				t.Errorf("UpdateAWSCredentials() error = %v, wantErr %v", err, tt.wantErr)
@@ -199,12 +208,12 @@ func Test_linuxOS_UpdateAWSCredentials(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to set file back to readable")
 			}
-			expectedCreds, err := ioutil.ReadFile(tt.args.sourcePath)
+			expectedCreds, err := os.ReadFile(tt.args.sourcePath)
 			if err != nil {
 				t.Errorf("Failed to read source credential file")
 			}
 
-			actualCreds, err := ioutil.ReadFile(dstFile)
+			actualCreds, err := os.ReadFile(dstFile)
 			if err != nil {
 				t.Errorf("Failed to read created credential file")
 			}
@@ -215,10 +224,11 @@ func Test_linuxOS_UpdateAWSCredentials(t *testing.T) {
 
 func Test_linuxOS_Initialize(t *testing.T) {
 	type fields struct {
-		profile       string
-		extraArgsPath string
-		basePath      string
-		config        constants.CredentialProviderConfigOptions
+		profile             string
+		extraArgsPath       string
+		legacyExtraArgsPath string
+		basePath            string
+		config              constants.CredentialProviderConfigOptions
 	}
 	type args struct {
 		config constants.CredentialProviderConfigOptions


### PR DESCRIPTION
**What did we have before?**

- We used `/etc/sysconfig/kubelet` to update kubelet extra args with credential provider arguments.
- An upstream image-builder update added a new EnvironmentFile (/etc/default/kubelet).
- For Ubuntu, this new file took precedence, causing credential provider arguments to be updated in the wrong place.
- We reverted this change with a [patch](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch).

**Changes Made:**
Updated the path KUBELET_EXTRA_ARGS file path for Ubuntu to `/etc/default/kubelet` so that credential provider arguments are updated in the right file for Ubuntu, also added KUBELET_EXTRA_ARGS_LEGACY to support older image templates which would still read from `/etc/sysconfig/kubelet`

Once we do packages release, we will also revert the image-builder [patch](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch) to make it consistent with upstream.

**Testing**
- Created a cluster with Ubuntu image template
- Installed credential provider package using helm 
  - `helm install credential-provider-package oci://public.ecr.aws/personalregistry/credential-provider-package --version 0.4.4-9b0192e048c510b9e3ce36087e992b6d0558a6d4 --set sourceRegistry=public.ecr.aws/personalregistry -n eksa-packages `
- Verified if KUBELET_EXTRA_ARGS are updated in correct path
- Tested for cluster upgrade scenario(k8s version 1.29–1.30)

**Kubelet args in both files before package installation:**
```
root@mgmt-ubuntu-md-0-kczw7-mc289:/home/ec2-user# cat /etc/default/kubelet
KUBELET_EXTRA_ARGS=--pod-infra-container-image=public.ecr.aws/eks-distro/kubernetes/pause:v1.29.8-eks-1-29-22root@mgmt-ubuntu-md-0-kczw7-mc289:/home/ec2-user#

root@mgmt-ubuntu-md-0-kczw7-mc289:/home/ec2-user# cat /etc/sysconfig/kubelet
cat: /etc/sysconfig/kubelet: No such file or directory
```
**Kubelet args in both files after credential provider package was installed:**
```
root@mgmt-ubuntu-md-0-kczw7-mc289:/home/ec2-user# cat /etc/default/kubelet
KUBELET_EXTRA_ARGS=--pod-infra-container-image=public.ecr.aws/eks-distro/kubernetes/pause:v1.29.8-eks-1-29-22 --image-credential-provider-config=/eksa-packages/credential-provider-config.yaml --image-credential-provider-bin-dir=/eksa-packages/

root@mgmt-ubuntu-md-0-kczw7-mc289:/home/ec2-user# cat /etc/sysconfig/kubelet
KUBELET_EXTRA_ARGS= --image-credential-provider-config=/eksa-packages/credential-provider-config.yaml --image-credential-provider-bin-dir=/eksa-packages/
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
