### PR TITLE
Use session token for ecr aws authentication

### DIFF
--- a/charts/eks-anywhere-packages/templates/awssecret.yaml
+++ b/charts/eks-anywhere-packages/templates/awssecret.yaml
@@ -13,6 +13,9 @@ data:
   AWS_ACCESS_KEY_ID: "{{ .id }}"
   AWS_SECRET_ACCESS_KEY: "{{ .secret }}"
   REGION: "{{ .region }}"
+  {{- if .sessionToken }}
+  AWS_SESSION_TOKEN: "{{ .sessionToken }}"
+  {{- end }}
   {{- if .config }}
   config: "{{ .config }}"
   {{- end }}

--- a/charts/eks-anywhere-packages/templates/cronjob.yaml
+++ b/charts/eks-anywhere-packages/templates/cronjob.yaml
@@ -44,6 +44,12 @@ spec:
                     secretKeyRef:
                       name: aws-secret
                       key: AWS_SECRET_ACCESS_KEY
+                - name: AWS_SESSION_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aws-secret
+                      key: AWS_SESSION_TOKEN
+                      optional: true
                 - name: AWS_REGION
                   valueFrom:
                     secretKeyRef:

--- a/charts/eks-anywhere-packages/templates/deployment.yaml
+++ b/charts/eks-anywhere-packages/templates/deployment.yaml
@@ -120,6 +120,12 @@ spec:
               secretKeyRef:
                 name: aws-secret
                 key: AWS_SECRET_ACCESS_KEY
+          - name: AWS_SESSION_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: aws-secret
+                key: AWS_SESSION_TOKEN
+                optional: true
           - name: AWS_REGION
             valueFrom:
               secretKeyRef:

--- a/charts/eks-anywhere-packages/values.yaml
+++ b/charts/eks-anywhere-packages/values.yaml
@@ -122,6 +122,7 @@ registryMirrorSecret:
 awsSecret:
   id: ""
   secret: ""
+  sessionToken: ""
   region: ""
   # -- Config overrides other awsSecret fields
   config: ""

--- a/credentialproviderpackage/pkg/awscred/awscred.go
+++ b/credentialproviderpackage/pkg/awscred/awscred.go
@@ -3,7 +3,6 @@ package awscred
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -12,44 +11,62 @@ const (
 	configSecretPath          = "/secrets/aws-creds/config"
 	accessKeySecretPath       = "/secrets/aws-creds/AWS_ACCESS_KEY_ID"
 	secretAccessKeySecretPath = "/secrets/aws-creds/AWS_SECRET_ACCESS_KEY"
+	sessionTokenSecretPath    = "/secrets/aws-creds/AWS_SESSION_TOKEN"
 	regionSecretPath          = "/secrets/aws-creds/REGION"
 	createConfigPath          = "/config"
 )
 
-func generateAwsConfigSecret(accessKeyPath, secretAccessKeyPath, regionPath string) (string, error) {
-	accessKeyByte, err := ioutil.ReadFile(accessKeyPath)
+func generateAwsConfigSecret(accessKeyPath, secretAccessKeyPath, sessionTokenPath, regionPath string) (string, error) {
+	accessKeyByte, err := os.ReadFile(accessKeyPath)
 	if err != nil {
 		return "", err
 	}
 	accessKey := strings.Trim(string(accessKeyByte), "'")
-	secretAccessKeyByte, err := ioutil.ReadFile(secretAccessKeyPath)
+	secretAccessKeyByte, err := os.ReadFile(secretAccessKeyPath)
 	if err != nil {
 		return "", err
 	}
 	secretAccessKey := strings.Trim(string(secretAccessKeyByte), "'")
-	regionByte, err := ioutil.ReadFile(regionPath)
+	regionByte, err := os.ReadFile(regionPath)
 	if err != nil {
 		return "", err
 	}
 	region := strings.Trim(string(regionByte), "'")
 
-	awsConfig := fmt.Sprintf(
+	// check if sessionToken exists and read it
+	if _, err := os.Stat(sessionTokenPath); !os.IsNotExist(err) {
+		sessionTokenByte, err := os.ReadFile(sessionTokenPath)
+		if err != nil {
+			return "", err
+		}
+		sessionToken := strings.Trim(string(sessionTokenByte), "'")
+
+		return fmt.Sprintf(
+			`
+[default]
+aws_access_key_id=%s
+aws_secret_access_key=%s
+aws_session_token=%s
+region=%s
+`, accessKey, secretAccessKey, sessionToken, region), nil
+
+	}
+
+	return fmt.Sprintf(
 		`
 [default]
 aws_access_key_id=%s
 aws_secret_access_key=%s
 region=%s
-`, accessKey, secretAccessKey, region)
-
-	return awsConfig, err
+`, accessKey, secretAccessKey, region), nil
 }
 
 func GetAwsConfigPath() (string, error) {
 	_, err := os.Stat(configSecretPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			awsConfig, err := generateAwsConfigSecret(accessKeySecretPath, secretAccessKeySecretPath, regionSecretPath)
-			err = ioutil.WriteFile(createConfigPath, []byte(awsConfig), 0o400)
+			awsConfig, err := generateAwsConfigSecret(accessKeySecretPath, secretAccessKeySecretPath, sessionTokenSecretPath, regionSecretPath)
+			err = os.WriteFile(createConfigPath, []byte(awsConfig), 0o400)
 			return createConfigPath, err
 		}
 	}

--- a/tilt/deployment.yaml
+++ b/tilt/deployment.yaml
@@ -113,6 +113,12 @@ spec:
             secretKeyRef:
               key: AWS_SECRET_ACCESS_KEY
               name: aws-secret
+        - name: AWS_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: aws-secret
+              key: AWS_SESSION_TOKEN
+              optional: true
         - name: AWS_REGION
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2650
https://github.com/aws/eks-anywhere-packages/issues/1182
https://github.com/aws/eks-anywhere-packages/issues/1181

*Description of changes:*
Add session token in secret if available and use it in credential-package

*Testing*
Tested the changes by creating a cluster. verified that aws-secrets has session token and able to install curated package successfully. Tested current use case i.e. without session token and verified installation of packages succesful.

![Screenshot 2025-03-13 at 10 50 14 AM](https://github.com/user-attachments/assets/5933d327-5288-449a-8d27-f091c9d6f2ea)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


