### PR TITLE
Use 1.32 for autoscaler until 1.33 upstream support is released

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.46.6-1.33-latest
+            - name: 9.46.6-1.32-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-33.yaml
+++ b/generatebundlefile/data/bundles_prod/1-33.yaml
@@ -53,7 +53,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.46.6-1.33-ca00cfb299ea8e546e7dbe9bc7bf7a7f154b7a28
+            - name: 9.46.6-1.32-ca00cfb299ea8e546e7dbe9bc7bf7a7f154b7a28
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_staging/1-33.yaml
+++ b/generatebundlefile/data/bundles_staging/1-33.yaml
@@ -72,7 +72,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.46.6-1.33-ca00cfb299ea8e546e7dbe9bc7bf7a7f154b7a28
+            - name: 9.46.6-1.32-ca00cfb299ea8e546e7dbe9bc7bf7a7f154b7a28
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Autoscaler upstream does not have support for 1.33 yet. Use 1.32 for autoscaler until 1.33 upstream support is released

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


