### PR TITLE
Pass proxy env vars to ecr credential provider

### DIFF
--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -14,6 +14,8 @@ spec:
   packageName: credential-provider-package
   targetNamespace: eksa-packages
   config: |-
+    proxy:
+    {{- toYaml .Values.proxy | nindent 6 }}
     tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/templates/daemonset.yaml
@@ -64,6 +64,12 @@ spec:
               value: {{(index .Values.credential 0).defaultCacheDuration}}
             - name: K8S_VERSION
               value: "v{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}"
+            - name: HTTP_PROXY
+              value: {{ .Values.proxy.HTTP_PROXY | quote}}
+            - name: HTTPS_PROXY
+              value: {{ .Values.proxy.HTTPS_PROXY | quote}}
+            - name: NO_PROXY
+              value: {{ .Values.proxy.NO_PROXY | quote}}
       volumes:
         # Currently only one secret (aws-secret) is supported at this time
         - name: aws-creds

--- a/credentialproviderpackage/charts/credential-provider-package/values.yaml
+++ b/credentialproviderpackage/charts/credential-provider-package/values.yaml
@@ -22,6 +22,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+proxy:
+  HTTP_PROXY: ""
+  HTTPS_PROXY: ""
+  NO_PROXY: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
+++ b/credentialproviderpackage/pkg/configurator/bottlerocket/bottlerocket.go
@@ -38,9 +38,10 @@ type brKubernetes struct {
 	Kubernetes kubernetes `json:"kubernetes"`
 }
 type ecrCredentialProvider struct {
-	CacheDuration string   `json:"cache-duration"`
-	Enabled       bool     `json:"enabled"`
-	ImagePatterns []string `json:"image-patterns"`
+	CacheDuration string            `json:"cache-duration"`
+	Enabled       bool              `json:"enabled"`
+	ImagePatterns []string          `json:"image-patterns"`
+	Environment   map[string]string `json:"environment,omitempty"`
 }
 type credentialProviders struct {
 	EcrCredentialProvider ecrCredentialProvider `json:"ecr-credential-provider"`
@@ -190,6 +191,7 @@ func createCredentialProviderPayload(config constants.CredentialProviderConfigOp
 					Enabled:       true,
 					ImagePatterns: config.ImagePatterns,
 					CacheDuration: config.DefaultCacheDuration,
+					Environment:   configurator.GetProxyEnvironment(),
 				},
 			},
 		},

--- a/credentialproviderpackage/pkg/configurator/linux/linux.go
+++ b/credentialproviderpackage/pkg/configurator/linux/linux.go
@@ -217,13 +217,14 @@ func (c *linuxOS) createConfig() (string, error) {
 		"apiVersion":    getApiVersion(),
 		"imagePattern":  c.config.ImagePatterns,
 		"cacheDuration": c.config.DefaultCacheDuration,
+		"proxy":         configurator.GetProxyEnvironment(),
 	}
 
 	dstPath := c.basePath + credProviderFile
 
 	bytes, err := templater.Execute(credProviderTemplate, values)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	err = os.WriteFile(dstPath, bytes, 0o600)
 	if err != nil {

--- a/credentialproviderpackage/pkg/configurator/linux/templates/credential-provider-config.yaml
+++ b/credentialproviderpackage/pkg/configurator/linux/templates/credential-provider-config.yaml
@@ -15,3 +15,9 @@ providers:
         value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/eksa-packages
       - name: HOME
         value: {{.home}}
+{{- if .proxy }}
+{{- range $key, $value := .proxy }}
+      - name: {{ $key }}
+        value: "{{ $value }}"
+{{- end }}
+{{- end }}

--- a/credentialproviderpackage/pkg/configurator/proxy.go
+++ b/credentialproviderpackage/pkg/configurator/proxy.go
@@ -1,0 +1,18 @@
+package configurator
+
+import "os"
+
+// GetProxyEnvironment returns a map of proxy environment variables if HTTP_PROXY is set
+func GetProxyEnvironment() map[string]string {
+	proxy := make(map[string]string)
+	if httpProxy := os.Getenv("HTTP_PROXY"); httpProxy != "" {
+		proxy["HTTP_PROXY"] = httpProxy
+	}
+	if httpsProxy := os.Getenv("HTTPS_PROXY"); httpsProxy != "" {
+		proxy["HTTPS_PROXY"] = httpsProxy
+	}
+	if noProxy := os.Getenv("NO_PROXY"); noProxy != "" {
+		proxy["NO_PROXY"] = noProxy
+	}
+	return proxy
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3528

*Description of changes:*
When using curated packages with proxy configured in an airgapped environment, ecr-credential-provider kubelet plugin will fail to retrieve ecr credentials. The request times out as it's not configured to use proxy. Following error is observed from kubelet service logs
```
Aug 13 20:47:12 ub130pkgproxy-md-0-tkzgw-gjcgl kubelet[4170]: E0813 20:47:12.329512    4170 plugin.go:235] Failed getting credential from external registry credential provider: error execing credential provider plugin ecr-credential-provider for image 067575901363.dkr.ecr.us-west-2.amazonaws.com/hello-eks-anywhere: context deadline exceeded: I0813 20:46:12.343864    5769 main.go:124] Getting creds for private image 067575901363.dkr.ecr.us-west-2.amazonaws.com/hello-eks-anywhere
```

*Testing*
Fixed the failing cluster by manually editing /eksa-packages/credential-provider-config.yaml to include proxy environment variables. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
