### PR TITLE
Update prod bundle for package release

### DIFF
--- a/generatebundlefile/data/bundles_prod/1-28.yaml
+++ b/generatebundlefile/data/bundles_prod/1-28.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-28.yaml
+++ b/generatebundlefile/data/bundles_prod/1-28.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-29.yaml
+++ b/generatebundlefile/data/bundles_prod/1-29.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-29.yaml
+++ b/generatebundlefile/data/bundles_prod/1-29.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-30.yaml
+++ b/generatebundlefile/data/bundles_prod/1-30.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-30.yaml
+++ b/generatebundlefile/data/bundles_prod/1-30.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-31.yaml
+++ b/generatebundlefile/data/bundles_prod/1-31.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-31.yaml
+++ b/generatebundlefile/data/bundles_prod/1-31.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-32.yaml
+++ b/generatebundlefile/data/bundles_prod/1-32.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-32.yaml
+++ b/generatebundlefile/data/bundles_prod/1-32.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-33.yaml
+++ b/generatebundlefile/data/bundles_prod/1-33.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.6-219cdb017cc53620296dbbe96bc9d39c8aef8481
+          - name: 0.4.8-2b14f5510b18747819672e570828a4fd7260e5f6
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -53,7 +53,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.46.6-1.32-ca00cfb299ea8e546e7dbe9bc7bf7a7f154b7a28
+            - name: 9.47.0-1.33-f79bc2e104800e0bbc10b5aa383056e32fdf87e7
   - org: harbor
     projects:
       - name: harbor
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.14.9-86ed88d61f9bf11dd0cdef4390a9c23d0712015b
+            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
   - org: kubernetes-sigs
     projects:
       - name: metrics-server

--- a/generatebundlefile/data/bundles_prod/1-33.yaml
+++ b/generatebundlefile/data/bundles_prod/1-33.yaml
@@ -67,12 +67,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-c43fb9ffd35cab575d99e4cb3665317eb0ca7137
+            - name: 0.14.9-56a5f4c53e98fe1035904a127728781b46b00af2
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
*Description of changes:*
- Update package prod bundle to latest version
  -  eks-anywhere-packages
  - metallb
  - cluster-autoscaler for kubernetes version 1.33 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
