### PR TITLE
add helm.sh/hook annotation to resolve race condition

### DIFF
--- a/charts/eks-anywhere-packages/templates/cleanup-hook.yaml
+++ b/charts/eks-anywhere-packages/templates/cleanup-hook.yaml
@@ -1,0 +1,50 @@
+{{- $render := include "eks-anywhere-packages.rendertype" . }}
+{{- $namespace := printf "%s-%s" "eksa-packages" .Values.clusterName -}}
+{{- if or (eq $render "controller") (eq $render "workload") }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "eks-anywhere-packages.fullname" . }}-cleanup
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+  labels:
+    {{- include "eks-anywhere-packages.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      serviceAccountName: {{ include "eks-anywhere-packages.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+      - name: cleanup
+        image: {{.Values.sourceRegistry}}{{ template "template.image" .Values.controller }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          APISERVER=https://kubernetes.default.svc
+          CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+          delete_resource() {
+            local url="$1"
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" --cacert "$CACERT" \
+              -H "Authorization: Bearer $TOKEN" \
+              -X DELETE "$url")
+            if [ "$code" = "200" ] || [ "$code" = "404" ]; then
+              echo "OK ($code): $url"
+            else
+              echo "WARN ($code): $url"
+            fi
+          }
+
+          delete_resource "$APISERVER/apis/packages.eks.amazonaws.com/v1alpha1/namespaces/{{ $namespace }}/packages/eks-anywhere-packages"
+          delete_resource "$APISERVER/apis/packages.eks.amazonaws.com/v1alpha1/namespaces/{{ $namespace }}/packages/ecr-credential-provider-package"
+          delete_resource "$APISERVER/apis/packages.eks.amazonaws.com/v1alpha1/namespaces/eksa-packages/packagebundlecontrollers/{{ .Values.clusterName }}"
+          echo "Cleanup complete"
+{{- end }}

--- a/charts/eks-anywhere-packages/templates/credentialpackage.yaml
+++ b/charts/eks-anywhere-packages/templates/credentialpackage.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: eksa-packages-{{.Values.clusterName}}
   annotations:
     "helm.sh/resource-policy": keep
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/resource-policy": keep
     "anywhere.eks.aws.com/internal": "true"
 spec:
   packageName: credential-provider-package

--- a/charts/eks-anywhere-packages/templates/package.yaml
+++ b/charts/eks-anywhere-packages/templates/package.yaml
@@ -7,6 +7,8 @@ apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: Package
 metadata:
   annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
     "helm.sh/resource-policy": keep
     "anywhere.eks.aws.com/internal": "true"
   name: eks-anywhere-packages
@@ -27,6 +29,8 @@ apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: Package
 metadata:
   annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
     "helm.sh/resource-policy": keep
     "anywhere.eks.aws.com/internal": "true"
   name: eks-anywhere-packages-{{ .Values.clusterName }}

--- a/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
+++ b/charts/eks-anywhere-packages/templates/packagebundlecontroller.yaml
@@ -5,6 +5,9 @@
 apiVersion: packages.eks.amazonaws.com/v1alpha1
 kind: PackageBundleController
 metadata:
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
   name: {{.Values.clusterName}}
   namespace: eksa-packages
 spec:


### PR DESCRIPTION
*Problem Statement:*
After bumping to helm version v4+, the package workflow with registry mirror pull-through-cache configuration and pure helm install will encounter issues.

Helm v4.1.0
```
helm version
version.BuildInfo{Version:"v4.1.0", GitCommit:"4553a0a96e5205595079b6757236cc6f969ed1b9", GitTreeState:"clean", GoVersion:"go1.25.6", KubeClientVersion:"v1.35"}

helm upgrade --install eks-anywhere-packages oci://975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5/eks-anywhere-packages --version 0.4.15-eks-a-118 --set sourceRegistry=975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5 --set defaultRegistry=public.ecr.aws/w9m0f3l5 --set defaultImageRegistry=067575901363.dkr.ecr.us-west-2.amazonaws.com --set clusterName=pull-through-cache --kubeconfig pull-through-cache/pull-through-cache-eks-a-cluster.kubeconfig --create-namespace --namespace eksa-packages -f pull-through-cache/generated/values.yaml --insecure-skip-tls-verify
Release "eks-anywhere-packages" does not exist. Installing it now.
Pulled: 975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5/eks-anywhere-packages:0.4.15-eks-a-118
Digest: sha256:86c30115075655ca1d2c909317528b21a72f7e33bfc870afdde1dc5848592ecb
Error: Internal error occurred: failed calling webhook "vpackage.kb.io": failed to call webhook: Post "[https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc:443/validate-packages-eks-amazonaws-com-v1alpha1-package?timeout=10s](https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc/validate-packages-eks-amazonaws-com-v1alpha1-package?timeout=10s)": dial tcp 10.105.47.116:443: connect: connection refused
Internal error occurred: failed calling webhook "vpackagebundlecontroller.kb.io": failed to call webhook: Post "[https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc:443/validate-packages-eks-amazonaws-com-v1alpha1-packagebundlecontroller?timeout=10s](https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc/validate-packages-eks-amazonaws-com-v1alpha1-packagebundlecontroller?timeout=10s)": dial tcp 10.105.47.116:443: connect: connection refused
```

Helm v3
```
helm upgrade --install eks-anywhere-packages oci://975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5/eks-anywhere-packages --version 0.4.15-eks-a-118 --set sourceRegistry=975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5 --set defaultRegistry=public.ecr.aws/w9m0f3l5 --set defaultImageRegistry=067575901363.dkr.ecr.us-west-2.amazonaws.com --set clusterName=pull-through-cache --kubeconfig pull-through-cache/pull-through-cache-eks-a-cluster.kubeconfig --create-namespace --namespace eksa-packages -f pull-through-cache/generated/values.yaml --insecure-skip-tls-verify
Release "eks-anywhere-packages" does not exist. Installing it now.
Pulled: 975050071200.dkr.ecr.us-west-2.amazonaws.com:443/ecr-public/w9m0f3l5/eks-anywhere-packages:0.4.15-eks-a-118
Digest: sha256:86c30115075655ca1d2c909317528b21a72f7e33bfc870afdde1dc5848592ecb
NAME: eks-anywhere-packages
LAST DEPLOYED: Thu Apr  2 19:08:11 2026
NAMESPACE: eksa-packages
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thanks for installing, for any bugs or issues please file them at https://github.com/aws/eks-anywhere-packages/issues

For more information on running eks-anywhere-packages, visit:
https://github.com/aws/eks-anywhere-packages
```
*Description of changes:*
- Add "helm.sh/hook" to make sure package and packagebundlecontroller install after crds 


*Testing:*
1. Install helm version v4.1.0
2. Create a tag `v0.4.17` on my own branch containing the fix and upload the eks-anywhere-packages image to my public ecr
3. Helm install `eks-anywhere-packages`
```
helm upgrade --install eks-anywhere-packages oci://public.ecr.aws/p2x5x2t2/eks-anywhere-packages \
--version 0.4.17-1ce58938ecd21ce10f38dffc0f014f2c3bd9f149 --set sourceRegistry=public.ecr.aws/p2x5x2t2 \
--set defaultRegistry=public.ecr.aws/p2x5x2t2 --set defaultImageRegistry=public.ecr.aws/p2x5x2t2 \
--set clusterName=redhat-134-ptc --kubeconfig redhat-134-ptc/redhat-134-ptc-eks-a-cluster.kubeconfig \
--create-namespace --namespace eksa-packages -f values.yaml --insecure-skip-tls-verify --wait --timeout 5m
Release "eks-anywhere-packages" does not exist. Installing it now.
Pulled: public.ecr.aws/p2x5x2t2/eks-anywhere-packages:0.4.17-1ce58938ecd21ce10f38dffc0f014f2c3bd9f149
Digest: sha256:2ac91b9faa475599ad67c194c0c8f40fc0d78fa52b9f0f0717be0f3ab5d56513
NAME: eks-anywhere-packages
LAST DEPLOYED: Wed Apr  8 11:55:26 2026
NAMESPACE: eksa-packages
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:
Thanks for installing, for any bugs or issues please file them at https://github.com/aws/eks-anywhere-packages/issues
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
