### PR TITLE
fix: Remove redundant upgradeRelease call in Install()

### DIFF
--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -150,11 +150,6 @@ func (d *helmDriver) Install(ctx context.Context,
 		d.log.Info("failed to Update Secret in all namespaces", "error", err)
 	}
 
-	err = d.upgradeRelease(ctx, name, helmChart, values)
-	if err != nil {
-		return fmt.Errorf("upgrading helm chart %s: %w", name, err)
-	}
-
 	if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
 		d.log.Info("failed to Update Secret in all namespaces", "error", err)
 	}

--- a/pkg/driver/helmdriver.go
+++ b/pkg/driver/helmdriver.go
@@ -150,10 +150,6 @@ func (d *helmDriver) Install(ctx context.Context,
 		d.log.Info("failed to Update Secret in all namespaces", "error", err)
 	}
 
-	if err := d.secretAuth.AddSecretToAllNamespace(ctx); err != nil {
-		d.log.Info("failed to Update Secret in all namespaces", "error", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3902

*Description of changes:*
Remove the second `upgradeRelease` call in `helmdriver.go:Install()`.

The second call (introduced in commit 3827a3d / PR #521) passes identical
values to the first, producing a redundant helm upgrade on every reconcile
when a release already exists. For non-idempotent charts like Harbor
(`core-secret.yaml` calls `genCA` on every render, regenerating the TLS CA),
this triggers unnecessary pod rollouts on each reconcile cycle. If a rollout
interrupts an in-progress DB migration, Harbor's schema state becomes dirty
(`schema_migrations.dirty=true`) and Harbor fails to start permanently.

Also removed the duplicate `AddSecretToAllNamespace` call after removing the second upgradeRelease, both calls ran consecutively with no operation  between them, making the second one redundant.

*Testing:*
Cluster-tested on a vSphere EKS-A cluster (Kubernetes 1.33):
- Built a custom controller image from this branch and deployed it to the
  test cluster (`eksa-packages/eks-anywhere-packages` deployment)
- Installed Harbor as a Package CR (packageName: harbor,
  version 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4)
- After STATE=installed, triggered reconcile cycles via annotation update
- Observed helm release revisions in `eksa-packages` namespace:
  - Each reconcile produced exactly +1 revision (not +2)
  - Release revision stayed stable with no config changes
- `make test` passed (all packages ok, no new generated-file changes)

By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.
<img width="1693" height="780" alt="Screenshot 2026-06-04 at 3 18 03 PM" src="https://github.com/user-attachments/assets/9c6fc638-7c51-4e6f-9ad9-b63a4bae1033" />
