### PR TITLE
feat: Update ADOT/Emissary/Prometheus in dev bundles for v0.26.0

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-32.yaml
+++ b/generatebundlefile/data/bundles_dev/1-32.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-34.yaml
+++ b/generatebundlefile/data/bundles_dev/1-34.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest

--- a/generatebundlefile/data/bundles_dev/1-35.yaml
+++ b/generatebundlefile/data/bundles_dev/1-35.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -86,16 +86,16 @@ packages:
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest


### PR DESCRIPTION
Issue #, if available:

Part of v0.26.0 curated packages release

Description of changes:

Update dev bundle versions (1-29 through 1-35) for v0.26.0 package upgrades:
- ADOT: 0.45.1-latest -> 0.48.0-latest
- Emissary: 3.10.0-latest -> 4.1.0-latest (+ emissary-crds)
- Prometheus: 3.8.0-latest -> 3.12.0-latest

MetalLB will be updated separately (pending BFD testing confirmation).
1-36.yaml will be updated after #1295 merges.

Related build-tooling PRs (merged):
- ADOT v0.48.0: https://github.com/aws/eks-anywhere-build-tooling/pull/5450
- Emissary v4.1.0: https://github.com/aws/eks-anywhere-build-tooling/pull/5461
- Prometheus v3.12.0: https://github.com/aws/eks-anywhere-build-tooling/pull/5465