### PR TITLE
Update dev bundles: add MetalLB v0.16.1 + update 1-36 with ADOT/Emiss…

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-32.yaml
+++ b/generatebundlefile/data/bundles_dev/1-32.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-32.yaml
+++ b/generatebundlefile/data/bundles_dev/1-32.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-34.yaml
+++ b/generatebundlefile/data/bundles_dev/1-34.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-34.yaml
+++ b/generatebundlefile/data/bundles_dev/1-34.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-35.yaml
+++ b/generatebundlefile/data/bundles_dev/1-35.yaml
@@ -74,12 +74,12 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary

--- a/generatebundlefile/data/bundles_dev/1-35.yaml
+++ b/generatebundlefile/data/bundles_dev/1-35.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-36.yaml
+++ b/generatebundlefile/data/bundles_dev/1-36.yaml
@@ -46,7 +46,7 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.20.2-eksbuild.2-latest
+          - name: 1.20.2-eksbuild.3-latest
   - org: harbor
     projects:
       - name: harbor

--- a/generatebundlefile/data/bundles_dev/1-36.yaml
+++ b/generatebundlefile/data/bundles_dev/1-36.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-latest
+            - name: 0.48.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -74,28 +74,28 @@ packages:
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-latest
+            - name: 0.16.1-latest
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-latest
+            - name: 4.1.0-latest
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-latest
+            - name: 3.12.0-latest


### PR DESCRIPTION
*Issue #, if available:*

Follow-up to #1301

*Description of changes:*

Update dev bundles for v0.26.0:
- MetalLB 0.15.2 → 0.16.1 across all bundles (1-29 through 1-36)
- 1-36.yaml: ADOT 0.48.0, Emissary 4.1.0, Prometheus 3.12.0 (matching 1-29~1-35, added after #1295 merged)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.