### PR TITLE
fix: Update metrics-server to eksbuild.11 in dev bundles

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-29.yaml
+++ b/generatebundlefile/data/bundles_dev/1-29.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-32.yaml
+++ b/generatebundlefile/data/bundles_dev/1-32.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-34.yaml
+++ b/generatebundlefile/data/bundles_dev/1-34.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-35.yaml
+++ b/generatebundlefile/data/bundles_dev/1-35.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb

--- a/generatebundlefile/data/bundles_dev/1-36.yaml
+++ b/generatebundlefile/data/bundles_dev/1-36.yaml
@@ -67,7 +67,7 @@ packages:
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-latest
+            - name: 0.8.1-eksbuild.11-latest
   - org: metallb
     projects:
       - name: metallb


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Update metrics-server from eksbuild.2 to eksbuild.11 in dev bundle configs (1-29 through 1-36). eksbuild.11 includes fixes for CVE-2026-33186 (grpc v1.79.3), CVE-2026-39821 (x/net v0.55.0), and x/crypto CVEs. The build-tooling EKS_ADDON_IMAGE_TAG was updated in aws/eks-anywhere-build-tooling#5502 but the dev bundle yaml was missed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.