### PR TITLE
Update 1-36 dev bundle cluster-autoscaler to 1.36

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-36.yaml
+++ b/generatebundlefile/data/bundles_dev/1-36.yaml
@@ -60,7 +60,7 @@ packages:
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.35-latest
+            - name: 9.55.0-1.36-latest
   - org: kubernetes-sigs
     projects:
       - name: metrics-server


### PR DESCRIPTION
Issue: https://github.com/aws/eks-anywhere-internal/issues/3907

The 1-36 dev bundle (`generatebundlefile/data/bundles_dev/1-36.yaml`) still pointed cluster-autoscaler at `9.55.0-1.35-latest` , it was copied from the 1-35 file when the 1-36 bundle was first created and never bumped to its own minor. Every other bundles_dev file points at its own minor (`9.55.0-1.33-latest`, `9.55.0-1.34-latest`, `9.55.0-1.35-latest`), so 1-36 should be `9.55.0-1.36-latest`.

The kubernetes-autoscaler build for cluster-autoscaler 1.36.0 is now green (build-tooling #5595 + CHECKSUMS revert #5596) and the `9.55.0-1.36-latest` chart is published to the beta ECR, so the dev bundle can point at it. This unblocks TestTinkerbellKubernetes136UbuntuCuratedPackagesClusterAutoscalerSimpleFlow using the 1.36 chart.