### PR TITLE
Update ADOT to 0.49.0-latest in dev bundles

### DIFF
--- a/generatebundlefile/data/bundles_dev/1-30.yaml
+++ b/generatebundlefile/data/bundles_dev/1-30.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-31.yaml
+++ b/generatebundlefile/data/bundles_dev/1-31.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-32.yaml
+++ b/generatebundlefile/data/bundles_dev/1-32.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-33.yaml
+++ b/generatebundlefile/data/bundles_dev/1-33.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-34.yaml
+++ b/generatebundlefile/data/bundles_dev/1-34.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-35.yaml
+++ b/generatebundlefile/data/bundles_dev/1-35.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager

--- a/generatebundlefile/data/bundles_dev/1-36.yaml
+++ b/generatebundlefile/data/bundles_dev/1-36.yaml
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.48.0-latest
+            - name: 0.49.0-latest
   - org: cert-manager
     projects:
       - name: cert-manager


### PR DESCRIPTION
*Issue #, if available:*
N/A (CVE remediation for v0.26.0 -- see aws/eks-anywhere-internal#3906; dev bundle tracking aws/eks-anywhere-internal#3907)

*Description of changes:*
Update ADOT from 0.48.0-latest to 0.49.0-latest in dev bundle configs
(1-30 through 1-36).

ADOT v0.49.0 (based on OpenTelemetry Collector v0.156.0) bumps golang.org/x/crypto
to >= v0.52 and golang.org/x/net to >= v0.55, remediating the 8 critical CVEs
flagged in the beta bundle scan:
- CVE-2026-39821 (golang.org/x/net)
- CVE-2026-39830, CVE-2026-39831, CVE-2026-39832, CVE-2026-39833, CVE-2026-39834,
  CVE-2026-42508, CVE-2026-46595 (golang.org/x/crypto)

The v0.49.0 collector image and helm chart are already in beta ECR via
build-tooling aws/eks-anywhere-build-tooling#5597 (merged; Codebuild + Bundle-Creation
green). This PR points the dev bundles at the new version so the regenerated
bundle references the v0.49.0 image (digest sha256:d2bdfff2...) instead of the
old 0.48.0 image (sha256:9b28046...).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.