### PR TITLE
Update staging bundles to latest package versions

### DIFF
--- a/generatebundlefile/data/bundles_staging/1-30.yaml
+++ b/generatebundlefile/data/bundles_staging/1-30.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.30-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.30-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-31.yaml
+++ b/generatebundlefile/data/bundles_staging/1-31.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.31-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.31-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-32.yaml
+++ b/generatebundlefile/data/bundles_staging/1-32.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.32-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.32-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-33.yaml
+++ b/generatebundlefile/data/bundles_staging/1-33.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.33-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.33-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-34.yaml
+++ b/generatebundlefile/data/bundles_staging/1-34.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.34-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.34-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-35.yaml
+++ b/generatebundlefile/data/bundles_staging/1-35.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.35-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.35-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc

--- a/generatebundlefile/data/bundles_staging/1-36.yaml
+++ b/generatebundlefile/data/bundles_staging/1-36.yaml
@@ -9,22 +9,22 @@ packages:
         repository: eks-anywhere-packages
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-crds
         repository: eks-anywhere-packages-crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: eks-anywhere-packages-migrations
         repository: eks-anywhere-packages-migrations
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
       - name: credential-provider-package
         repository: credential-provider-package
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 0.4.15-bfa37afbe8fd2c9471b138b2729c35b737ad52cf
+          - name: 0.4.17-97cea5a35f6077a7b93cbb1db3d82944cdff594b
   - org: aws-containers
     projects:
       - name: hello-eks-anywhere
@@ -38,7 +38,7 @@ packages:
         repository: adot/charts/aws-otel-collector
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.45.1-0a79bb66343a3e7440c195598f1575f2ea89d42f
+            - name: 0.49.0-ede5c0211ada6ad0fa2254dbba74d6691675bee3
   - org: cert-manager
     projects:
       - name: cert-manager
@@ -46,56 +46,56 @@ packages:
         repository: cert-manager/cert-manager
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-          - name: 1.19.3-dcb73486cb037dbae13d92d891af6847d221e966
+          - name: 1.20.2-eksbuild.3-0fd1e3113a8ab92fc8d3a41402d727ab7d73e95c
   - org: emissary
     projects:
       - name: emissary
         repository: emissary-ingress/emissary
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
       - name: emissary-crds
         repository: emissary-ingress/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.10.0-0e206e65fb1eb8d82a30a9ea6c6ae6a451d6c324
+            - name: 4.1.0-71c9f9f01cce0e11231cb101e00676e307ce70cd
   - org: harbor
     projects:
       - name: harbor
         repository: harbor/harbor-helm
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 2.14.2-05508806c712ec4e11ccdcd55f2ddecf6ca238f4
+            - name: 2.14.2-c35aff37c5c9ddc956d11950535fd2ed19366038
   - org: kubernetes
     projects:
       - name: cluster-autoscaler
         repository: cluster-autoscaler/charts/cluster-autoscaler
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 9.55.0-1.35-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 9.55.0-1.36-ed83e8b4e147f0ac2edf9e1a1a996205bbed1fc5
   - org: kubernetes-sigs
     projects:
       - name: metrics-server
         repository: metrics-server/charts/metrics-server
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.8.1-eksbuild.2-a3a46f7739e846a516d7ecfa9c1c28e29c89b548
+            - name: 0.8.1-eksbuild.11-2d3ae292608127ed5b22b1f327192a0e69d49d51
   - org: metallb
     projects:
       - name: metallb
         repository: metallb/metallb
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
       - name: metallb-crds
         repository: metallb/crds
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 0.15.2-9348057197ed07e06cb125b2c6cb9511ffd3ed62
+            - name: 0.16.1-53ccfa3e6cffccca29e0b82d29ef9db7f1a4940e
   - org: prometheus
     projects:
       - name: prometheus
         repository: prometheus/charts/prometheus
         registry: 067575901363.dkr.ecr.us-west-2.amazonaws.com
         versions:
-            - name: 3.8.0-3726eca575d05fdd2b9cdcb1fd32f4e0cc3441ba
+            - name: 3.12.0-6b01831749bcc5fb184480d1527e2dc5898c06fc


### PR DESCRIPTION
Bump bundles_staging 1-30~1-36 to new 067 image tags: controller 0.4.17 (mainline), ADOT 0.49.0, cert-manager 1.20.2-eksbuild.3, Emissary 4.1.0, Harbor CVE rebuild, cluster-autoscaler 1.36, metrics-server eksbuild.11, MetalLB 0.16.1, Prometheus 3.12.0. Also fix 1-36 autoscaler version (1.35 -> 1.36).

*Issue #, if available:* N/A

*Description of changes:*

Cut the staging bundles for the latest curated packages release. Updates
`generatebundlefile/data/bundles_staging/1-30.yaml` through `1-36.yaml` to point
at the newly-built images in the packages beta account (067575901363):

| Package | Old | New |
|---|---|---|
| controller (eks-anywhere-packages / -crds / -migrations / credential-provider-package) | 0.4.15 | 0.4.17 (mainline) |
| ADOT (adot/charts/aws-otel-collector) | 0.45.1 | 0.49.0 |
| cert-manager | 1.19.3 | 1.20.2-eksbuild.3 |
| Emissary (+ crds) | 3.10.0 | 4.1.0 |
| Harbor (harbor/harbor-helm) | 2.14.2 (old sha) | 2.14.2 (CVE-rebuild sha) |
| cluster-autoscaler | 9.55.0-1.XX (old sha) | 9.55.0-1.XX (new sha) |
| metrics-server | 0.8.1-eksbuild.2 | 0.8.1-eksbuild.11 |
| MetalLB (+ crds) | 0.15.2 | 0.16.1 |
| Prometheus | 3.8.0 | 3.12.0 |

Notes:
- Each tag is a pinned `<version>-<sha>` matching the mainline `-latest-helm`
  build in 067; every tag was verified present in 067 ECR via `describe-images`.
- Harbor's version is unchanged (2.14.2) but the sha is bumped to pick up the
  CVE-remediation rebuild.
- cluster-autoscaler keeps its per-k8s-version segment (1.30..1.36); the 1-36
  file's autoscaler was previously copied from 1-35 as `9.55.0-1.35-...` and is
  corrected to `9.55.0-1.36-...`.
- No changes to `name:` / `minControllerVersion:` (consistent with prior
  staging bumps, e.g. #1263 / #1273).

*Testing:* Values verified against 067 ECR. Post-merge, the packages staging
pipeline runs; the Release + ECRImageReplication stages copy the images into the
staging account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.